### PR TITLE
핵심 백엔드 메서드 설명 주석을 보강

### DIFF
--- a/src/main/java/com/bikeprojectminji/bikeback/auth/service/AuthService.java
+++ b/src/main/java/com/bikeprojectminji/bikeback/auth/service/AuthService.java
@@ -49,6 +49,8 @@ public class AuthService {
     }
 
     public LoginResponse register(RegisterRequest request) {
+        // 회원가입은 이메일 중복을 먼저 막고,
+        // 정상 사용자면 저장 직후 바로 access token까지 발급해 앱이 추가 로그인 없이 진입하도록 한다.
         if (userRepository.existsByEmail(request.email())) {
             throw new BadRequestException("이미 사용 중인 이메일입니다.");
         }
@@ -59,6 +61,8 @@ public class AuthService {
     }
 
     public LoginResponse login(LoginRequest request) {
+        // 로그인은 이메일로 사용자를 찾고, 저장된 passwordHash와 현재 입력 비밀번호를 비교한다.
+        // 한쪽이라도 맞지 않으면 같은 예외 메시지로 응답해 계정 존재 여부를 노출하지 않는다.
         UserEntity user = userRepository.findByEmail(request.email())
                 .orElseThrow(() -> new UnauthorizedException("이메일 또는 비밀번호가 올바르지 않습니다."));
 
@@ -71,11 +75,15 @@ public class AuthService {
     }
 
     public AuthMeResponse getCurrentUser(String subject) {
+        // 이미 인증된 subject를 현재 사용자 aggregate로 해석하고,
+        // 앱에서 바로 쓸 수 있는 최소 프로필 정보로 축약해 반환한다.
         UserEntity user = findUserBySubject(subject);
         return new AuthMeResponse(user.getId(), user.getEmail(), user.getDisplayName(), true, "USER");
     }
 
     public UserEntity findUserBySubject(String subject) {
+        // 현재 토큰 subject는 숫자 userId일 수도 있고, 레거시 externalId일 수도 있다.
+        // 두 경로를 모두 허용해 이전 토큰과 새 토큰의 연속성을 유지한다.
         try {
             Long userId = Long.valueOf(subject);
             return userRepository.findById(userId)
@@ -87,6 +95,8 @@ public class AuthService {
     }
 
     private String issueToken(UserEntity user) {
+        // 토큰은 현재 userId를 subject로 고정하고,
+        // 앱이 자주 쓰는 email/displayName만 claim으로 최소 포함한다.
         Instant issuedAt = clock.instant();
         Instant expiresAt = issuedAt.plusSeconds(tokenValiditySec);
 
@@ -107,6 +117,8 @@ public class AuthService {
     }
 
     private UserEntity resolveRegisterUser(RegisterRequest request) {
+        // legacyExternalId가 없으면 완전 신규 계정 생성이고,
+        // 있으면 과거 레거시 계정을 실제 로컬 계정으로 승격(claim)하는 흐름이다.
         String passwordHash = passwordEncoder.encode(request.password());
         if (request.legacyExternalId() == null || request.legacyExternalId().isBlank()) {
             return new UserEntity(null, request.email(), passwordHash, request.displayName(), request.profileImageUrl());

--- a/src/main/java/com/bikeprojectminji/bikeback/course/service/CourseService.java
+++ b/src/main/java/com/bikeprojectminji/bikeback/course/service/CourseService.java
@@ -67,6 +67,8 @@ public class CourseService {
     }
 
     public CourseListResponse getCourses(Long cursor, Integer limit) {
+        // 전체 코스 목록은 public 코스만 대상으로 cursor pagination을 적용하고,
+        // 응답에서는 화면 목록에 필요한 최소 필드만 남긴다.
         int pageSize = resolveLimit(limit);
         List<CourseEntity> queriedCourses = courseRepository.findPublicPageAfter(cursor, pageSize + 1);
 
@@ -90,6 +92,7 @@ public class CourseService {
     }
 
     public CourseDetailResponse getCourseDetail(Long courseId, String subject, String shareToken) {
+        // 코스 상세는 visibility / owner / shareToken 규칙을 통과한 코스만 읽을 수 있다.
         CourseEntity course = findReadableCourse(courseId, subject, shareToken);
 
         return new CourseDetailResponse(
@@ -101,6 +104,7 @@ public class CourseService {
     }
 
     public CourseRoutePointsResponse getCourseRoutePoints(Long courseId, String subject, String shareToken) {
+        // 경로 포인트 조회도 상세 조회와 같은 읽기 권한 규칙을 그대로 따른다.
         CourseEntity course = findReadableCourse(courseId, subject, shareToken);
 
         List<CourseRoutePointResponse> points = courseRoutePointRepository.findByCourseIdOrderByPointOrderAsc(course.getId()).stream()
@@ -115,6 +119,8 @@ public class CourseService {
     }
 
     public FeaturedCourseResponse getFeaturedCourses(BigDecimal lat, BigDecimal lon) {
+        // 추천 코스는 curated 후보를 먼저 읽고,
+        // 위치가 있으면 거리 기준 정렬, 없으면 fallback 순서로 제한된 개수만 노출한다.
         List<CourseEntity> featuredCourses = courseRepository.findFeaturedCourses();
         if (featuredCourses.isEmpty()) {
             log.info("featured courses fallback: no curated courses available");
@@ -161,6 +167,8 @@ public class CourseService {
 
     @Transactional
     public CourseWriteResponse createCourseFromRideRecord(String subject, CreateCourseFromRideRecordRequest request) {
+        // 코스 생성은 사용자가 소유한 ride record를 읽어 route point를 course route point로 복제하는 방식이다.
+        // 즉 ride 기록과 course는 source of truth를 공유하지 않고, 생성 시점에 복사본을 만든다.
         validateCreateRequest(request);
         UserEntity user = authService.findUserBySubject(subject);
         RideRecordEntity rideRecord = rideRecordRepository.findByIdAndOwnerUserId(request.sourceRideRecordId(), user.getId())
@@ -196,6 +204,8 @@ public class CourseService {
 
     @Transactional
     public CourseWriteResponse updateCourse(String subject, Long courseId, UpdateCourseRequest request) {
+        // 코스 수정은 metadata 수정과 route point 교체를 한 트랜잭션으로 처리해
+        // 제목/설명/visibility와 경로 포인트가 어긋난 상태를 남기지 않게 한다.
         validateUpdateRequest(request);
         UserEntity user = authService.findUserBySubject(subject);
         CourseEntity course = findOwnedCourse(courseId, user.getId());
@@ -227,6 +237,8 @@ public class CourseService {
 
     @Transactional
     public CourseShareResponse getCourseShareInfo(String subject, Long courseId) {
+        // 공유 정보 조회는 PRIVATE 코스를 먼저 차단하고,
+        // 공개 가능한 코스에 대해서만 shareToken을 생성 또는 재사용한다.
         UserEntity user = authService.findUserBySubject(subject);
         CourseEntity course = findOwnedCourse(courseId, user.getId());
 

--- a/src/main/java/com/bikeprojectminji/bikeback/location/controller/LocationController.java
+++ b/src/main/java/com/bikeprojectminji/bikeback/location/controller/LocationController.java
@@ -23,6 +23,7 @@ public class LocationController {
     @GetMapping("/me/recent")
     public ApiResponse<RecentLocationResponse> getMyRecentLocation(@AuthenticationPrincipal Jwt jwt) {
         // recent cache는 선택적 상태이므로, 값이 없으면 404로 명시적으로 응답한다.
+        // 즉, source of truth 부재를 숨기지 않고 "현재 캐시가 없다"는 사실을 그대로 표현한다.
         return recentLocationCacheService.find(jwt.getSubject())
                 .map(snapshot -> ApiResponse.success(new RecentLocationResponse(
                         snapshot.rideRecordId(),

--- a/src/main/java/com/bikeprojectminji/bikeback/location/service/RecentLocationCacheService.java
+++ b/src/main/java/com/bikeprojectminji/bikeback/location/service/RecentLocationCacheService.java
@@ -18,6 +18,7 @@ public class RecentLocationCacheService {
     }
 
     public Optional<RecentLocationSnapshot> find(String subject) {
+        // subject 기준 최근 위치는 현재 단계에서 1건만 유지하므로, 그대로 Optional로 조회한다.
         return recentLocationCacheStore.find(subject);
     }
 
@@ -29,6 +30,8 @@ public class RecentLocationCacheService {
             BigDecimal longitude,
             OffsetDateTime capturedAt
     ) {
+        // 지금은 ACTIVE 세션 전체를 저장하지 않고,
+        // 주행 저장이 완료된 시점의 마지막 위치만 COMPLETE 상태로 캐시에 남긴다.
         recentLocationCacheStore.save(subject, new RecentLocationSnapshot(
                 rideRecordId,
                 latitude,

--- a/src/main/java/com/bikeprojectminji/bikeback/profile/service/ProfileService.java
+++ b/src/main/java/com/bikeprojectminji/bikeback/profile/service/ProfileService.java
@@ -22,11 +22,15 @@ public class ProfileService {
     }
 
     public ProfileMeResponse getMyProfile(String subject) {
+        // profile 조회는 profile 도메인이 직접 사용자를 식별하지 않고,
+        // auth 도메인을 통해 현재 사용자 aggregate를 받아 응답용 DTO로 변환한다.
         UserEntity user = authService.findUserBySubject(subject);
         return toResponse(user);
     }
 
     public ProfileMeResponse updateMyProfile(String subject, UpdateProfileRequest request) {
+        // profile 수정은 displayName / profileImageUrl만 다루고,
+        // 사용자 계정 aggregate 저장 책임은 auth가 소유한 UserRepository를 그대로 사용한다.
         UserEntity user = authService.findUserBySubject(subject);
         user.updateProfile(request.displayName(), request.profileImageUrl());
         UserEntity savedUser = userRepository.save(user);
@@ -34,6 +38,7 @@ public class ProfileService {
     }
 
     private ProfileMeResponse toResponse(UserEntity user) {
+        // 앱에서 필요한 최소 프로필 형태로만 잘라 응답해 도메인 entity가 직접 외부로 새지 않게 한다.
         return new ProfileMeResponse(user.getId(), user.getEmail(), user.getDisplayName(), user.getProfileImageUrl());
     }
 }

--- a/src/main/java/com/bikeprojectminji/bikeback/ride/controller/RidePolicyController.java
+++ b/src/main/java/com/bikeprojectminji/bikeback/ride/controller/RidePolicyController.java
@@ -26,6 +26,8 @@ public class RidePolicyController {
             @PathVariable Long courseId,
             @RequestBody RidePolicyEvaluationRequest request
     ) {
+        // 외부 API는 기존 course path를 그대로 유지해 앱 계약을 깨지 않고,
+        // 내부 계산 책임만 ride.policy 서비스로 위임한다.
         return ApiResponse.success(ridePolicyService.evaluate(courseId, request));
     }
 }

--- a/src/main/java/com/bikeprojectminji/bikeback/ride/service/RideRecordService.java
+++ b/src/main/java/com/bikeprojectminji/bikeback/ride/service/RideRecordService.java
@@ -41,6 +41,8 @@ public class RideRecordService {
 
     @Transactional
     public RideRecordResponse saveRideRecord(String subject, CreateRideRecordRequest request) {
+        // 자유 주행 저장은 입력 검증 -> 현재 사용자 식별 -> ride record 저장 -> route point 저장 순서로 진행한다.
+        // point와 summary는 항상 DB가 원본이고, 캐시는 후속 조회 최적화 용도로만 갱신한다.
         validateCreateRequest(request);
         UserEntity user = authService.findUserBySubject(subject);
 
@@ -83,6 +85,8 @@ public class RideRecordService {
     }
 
     private void validateCreateRequest(CreateRideRecordRequest request) {
+        // 저장 요청은 startedAt/endedAt/summary/routePoints가 모두 있어야 하고,
+        // 음수 거리/시간이나 비정상 pointOrder는 여기서 조기에 차단한다.
         if (request == null) {
             throw new BadRequestException("자유 주행 기록 요청 본문이 필요합니다.");
         }
@@ -102,6 +106,8 @@ public class RideRecordService {
     }
 
     private List<RideRecordPointRequest> normalizeRoutePoints(List<RideRecordPointRequest> routePoints) {
+        // route point는 입력 순서가 어떻든 pointOrder 기준으로 다시 정렬하고,
+        // 중복 pointOrder와 누락 좌표를 여기서 한 번에 검증한다.
         if (routePoints == null || routePoints.isEmpty()) {
             throw new BadRequestException("routePoints는 비어 있을 수 없습니다.");
         }

--- a/src/main/java/com/bikeprojectminji/bikeback/weather/service/WeatherService.java
+++ b/src/main/java/com/bikeprojectminji/bikeback/weather/service/WeatherService.java
@@ -34,6 +34,8 @@ public class WeatherService {
     }
 
     public CurrentWeatherResponse getCurrent(BigDecimal lat, BigDecimal lon) {
+        // 현재 날씨 조회는 provider 성공을 우선 사용하고,
+        // 실패 시에는 last-success 캐시를 60분 범위 안에서만 fallback으로 허용한다.
         WeatherLocationKey locationKey = WeatherLocationKey.from(lat, lon);
         WeatherProviderResult providerResult = weatherProviderPort.getCurrent(locationKey);
 
@@ -55,11 +57,14 @@ public class WeatherService {
     }
 
     private boolean isWithinLastSuccessTtl(WeatherSnapshot snapshot) {
+        // weather fallback은 마지막 성공 시각이 60분을 넘지 않아야만 유효하다.
         OffsetDateTime now = OffsetDateTime.ofInstant(clock.instant(), ZoneOffset.UTC);
         return Duration.between(snapshot.lastSucceededAt(), now).compareTo(LAST_SUCCESS_TTL) <= 0;
     }
 
     private CurrentWeatherResponse toResponse(WeatherSnapshot snapshot, boolean stale) {
+        // 외부 응답에서는 snapshot 내부 구조를 그대로 노출하지 않고,
+        // stale 여부와 forecast fallback 사용 여부만 함께 풀어서 전달한다.
         return new CurrentWeatherResponse(
                 snapshot.weather(),
                 snapshot.wind(),


### PR DESCRIPTION
## 요약
- auth, profile, weather, location, ride, course 핵심 서비스/컨트롤러 메서드에 한글 설명 주석을 보강했습니다.
- 클래스 소개 수준이 아니라 입력 해석, 책임 경계, source of truth / cache 관계를 메서드 기준으로 설명하도록 맞췄습니다.
- 코드 동작은 바꾸지 않고 학습/유지보수 가독성만 높이는 범위로 제한했습니다.

## 검증
- `./gradlew.bat test --tests "com.bikeprojectminji.bikeback.auth.service.AuthServiceTest" --tests "com.bikeprojectminji.bikeback.profile.service.ProfileServiceTest" --tests "com.bikeprojectminji.bikeback.weather.service.WeatherServiceTest" --tests "com.bikeprojectminji.bikeback.location.controller.LocationControllerTest" --tests "com.bikeprojectminji.bikeback.location.service.RecentLocationCacheServiceTest" --tests "com.bikeprojectminji.bikeback.ride.service.RideRecordServiceTest" --tests "com.bikeprojectminji.bikeback.ride.controller.RidePolicyControllerTest" --tests "com.bikeprojectminji.bikeback.course.service.CourseServiceTest"`
- `./gradlew.bat build`

## 리뷰 포인트
- 메서드 주석이 구현 의도/경계 설명에 집중하고 있는지
- 과주석 없이 실제로 공부에 도움이 되는 수준인지
- 도메인 ownership, cache 역할, 외부 계약 유지 이유가 충분히 드러나는지