### PR TITLE
서울대입구 테스트 코스와 health endpoint 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@
   - `POST /api/v1/ride-records`
 - 날씨
   - `GET /api/v1/weather/current`
+- 운영
+  - `GET /health`
 
 ## 패키지 구조
 

--- a/src/main/java/com/bikeprojectminji/bikeback/global/health/HealthController.java
+++ b/src/main/java/com/bikeprojectminji/bikeback/global/health/HealthController.java
@@ -1,0 +1,21 @@
+package com.bikeprojectminji.bikeback.global.health;
+
+import com.bikeprojectminji.bikeback.global.response.ApiResponse;
+import java.util.Map;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class HealthController {
+
+    /**
+     * Railway healthcheck와 운영 smoke가 동일한 기준으로 앱 생존 여부를 확인하도록 최소 health 응답을 제공한다.
+     */
+    @GetMapping("/health")
+    public ApiResponse<Map<String, String>> health() {
+        return ApiResponse.success(Map.of(
+                "status", "ok",
+                "service", "bike-back"
+        ));
+    }
+}

--- a/src/main/resources/db/migration/V10__seed_snu_station_test_course.sql
+++ b/src/main/resources/db/migration/V10__seed_snu_station_test_course.sql
@@ -1,0 +1,71 @@
+WITH next_orders AS (
+    SELECT
+        COALESCE(MAX(display_order), 0) + 1 AS next_display_order,
+        COALESCE(MAX(featured_rank), 0) + 1 AS next_featured_rank
+    FROM courses
+), inserted_course AS (
+    INSERT INTO courses (
+        title,
+        description,
+        distance_km,
+        estimated_duration_min,
+        display_order,
+        curated,
+        featured_rank,
+        start_latitude,
+        start_longitude,
+        visibility
+    )
+    SELECT
+        '서울대입구 테스트 루프',
+        '서울대입구역 3번 출구 인근에서 출발해 샤로수길 입구와 관악구청 방향을 가볍게 확인하는 실사용 테스트용 코스입니다.',
+        3.2,
+        18,
+        next_display_order,
+        TRUE,
+        next_featured_rank,
+        37.4813850,
+        126.9527790,
+        'PUBLIC'
+    FROM next_orders
+    WHERE NOT EXISTS (
+        SELECT 1
+        FROM courses
+        WHERE title = '서울대입구 테스트 루프'
+    )
+    RETURNING id
+), target_course AS (
+    SELECT id FROM inserted_course
+    UNION ALL
+    SELECT id
+    FROM courses
+    WHERE title = '서울대입구 테스트 루프'
+    LIMIT 1
+)
+INSERT INTO course_route_points (course_id, point_order, latitude, longitude)
+SELECT
+    target_course.id,
+    route_points.point_order,
+    route_points.latitude,
+    route_points.longitude
+FROM target_course
+CROSS JOIN (
+    VALUES
+        (1, 37.4813850::NUMERIC(10,7), 126.9527790::NUMERIC(10,7)),
+        (2, 37.4819100::NUMERIC(10,7), 126.9533200::NUMERIC(10,7)),
+        (3, 37.4824200::NUMERIC(10,7), 126.9540300::NUMERIC(10,7)),
+        (4, 37.4828600::NUMERIC(10,7), 126.9549200::NUMERIC(10,7)),
+        (5, 37.4831400::NUMERIC(10,7), 126.9557400::NUMERIC(10,7)),
+        (6, 37.4825500::NUMERIC(10,7), 126.9561200::NUMERIC(10,7)),
+        (7, 37.4818700::NUMERIC(10,7), 126.9559100::NUMERIC(10,7)),
+        (8, 37.4812000::NUMERIC(10,7), 126.9553400::NUMERIC(10,7)),
+        (9, 37.4808300::NUMERIC(10,7), 126.9545000::NUMERIC(10,7)),
+        (10, 37.4809100::NUMERIC(10,7), 126.9534800::NUMERIC(10,7)),
+        (11, 37.4811200::NUMERIC(10,7), 126.9529400::NUMERIC(10,7)),
+        (12, 37.4813850::NUMERIC(10,7), 126.9527790::NUMERIC(10,7))
+) AS route_points(point_order, latitude, longitude)
+WHERE NOT EXISTS (
+    SELECT 1
+    FROM course_route_points existing
+    WHERE existing.course_id = target_course.id
+);

--- a/src/test/java/com/bikeprojectminji/bikeback/global/health/HealthControllerTest.java
+++ b/src/test/java/com/bikeprojectminji/bikeback/global/health/HealthControllerTest.java
@@ -1,0 +1,38 @@
+package com.bikeprojectminji.bikeback.global.health;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.bikeprojectminji.bikeback.global.config.SecurityConfig;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(HealthController.class)
+@Import(SecurityConfig.class)
+@TestPropertySource(properties = {
+        "auth.jwt.secret=01234567890123456789012345678901",
+        "auth.jwt.issuer=bike-back-test",
+        "auth.jwt.token-validity-sec=3600"
+})
+class HealthControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    @DisplayName("health endpoint는 200과 최소 상태 필드를 반환한다")
+    void healthReturnsOkResponse() throws Exception {
+        mockMvc.perform(get("/health"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(200))
+                .andExpect(jsonPath("$.message").value("success"))
+                .andExpect(jsonPath("$.data.status").value("ok"))
+                .andExpect(jsonPath("$.data.service").value("bike-back"));
+    }
+}


### PR DESCRIPTION
## 작업 목적
- 서울대입구 근처 follow 테스트용 코스를 운영에 반영합니다.
- Railway healthcheck와 smoke 기준을 /health로 고정합니다.

## 변경 내용
- /health endpoint 및 controller test 추가
- 서울대입구 테스트 루프 seed migration 추가
- README 운영 endpoint 반영

## 확인 방법
- cmd.exe /c gradlew.bat test build --console=plain
- curl https://bike-back-production.up.railway.app/health
- curl https://bike-back-production.up.railway.app/api/v1/courses
- curl https://bike-back-production.up.railway.app/api/v1/courses/featured?lat=37.481385&lon=126.952779
- curl https://bike-back-production.up.railway.app/api/v1/courses/1
- curl https://bike-back-production.up.railway.app/api/v1/courses/1/route-points
- POST /api/v1/courses/1/ride-policy/evaluate

## 문서 영향 범위
- README만 반영
- current 문서 직접 수정 없음

## self-review 결과
- 판정: OK
- 머지 가능 여부: 바로 가능
- 코스 seed는 idempotent하게 작성해 중복 삽입을 막았습니다.