### PR TITLE
백엔드 canonical path 저장과 GitHub Actions 배포 경로 반영

### DIFF
--- a/.github/workflows/backend-cd.yml
+++ b/.github/workflows/backend-cd.yml
@@ -1,0 +1,157 @@
+name: bike-back-cd
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  id-token: write
+  contents: read
+
+concurrency:
+  group: bike-back-cd-main
+  cancel-in-progress: true
+
+env:
+  AWS_REGION: ap-northeast-2
+  APP_PORT: ${{ vars.APP_PORT || '8080' }}
+  APP_DEPLOY_DIR: ${{ vars.APP_DEPLOY_DIR || '/opt/bike-back' }}
+  APP_SERVICE_NAME: ${{ vars.APP_SERVICE_NAME || 'bike-back' }}
+  APP_INSTANCE_ID: ${{ vars.APP_INSTANCE_ID }}
+  DEPLOY_S3_BUCKET: ${{ vars.DEPLOY_S3_BUCKET }}
+  HEALTHCHECK_URL: ${{ vars.HEALTHCHECK_URL }}
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Validate required configuration
+        env:
+          AWS_DEPLOY_ROLE_ARN: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
+        run: |
+          set -euo pipefail
+          for value in AWS_DEPLOY_ROLE_ARN APP_INSTANCE_ID DEPLOY_S3_BUCKET HEALTHCHECK_URL; do
+            if [ -z "${!value:-}" ]; then
+              printf '[ERROR] Missing required GitHub Actions setting: %s\n' "$value" >&2
+              exit 1
+            fi
+          done
+
+      - name: Configure AWS credentials with GitHub OIDC
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Set up Java 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+          cache: gradle
+
+      - name: Grant Gradle wrapper permission
+        run: chmod +x ./gradlew
+
+      - name: Run tests before deploy
+        run: ./gradlew --no-daemon test
+
+      - name: Build executable jar
+        run: ./gradlew --no-daemon clean bootJar
+
+      - name: Resolve artifact path
+        id: artifact
+        run: |
+          set -euo pipefail
+          ARTIFACT_PATH="$(find build/libs -maxdepth 1 -type f -name '*.jar' | head -n 1)"
+          if [ -z "$ARTIFACT_PATH" ]; then
+            printf '[ERROR] No Spring Boot jar was produced in build/libs\n' >&2
+            exit 1
+          fi
+          printf 'artifact_path=%s\n' "$ARTIFACT_PATH" >> "$GITHUB_OUTPUT"
+
+      - name: Upload artifact to S3
+        env:
+          ARTIFACT_PATH: ${{ steps.artifact.outputs.artifact_path }}
+        run: |
+          set -euo pipefail
+          aws s3 cp "$ARTIFACT_PATH" "s3://${DEPLOY_S3_BUCKET}/bike-back/releases/${GITHUB_SHA}/app.jar"
+
+      - name: Render SSM deploy command
+        run: |
+          set -euo pipefail
+          cat > ssm-commands.json <<EOF
+          {
+            "commands": [
+              "set -euo pipefail",
+              "APP_DEPLOY_DIR='${APP_DEPLOY_DIR}'",
+              "APP_SERVICE_NAME='${APP_SERVICE_NAME}'",
+              "APP_PORT='${APP_PORT}'",
+              "DEPLOY_BUCKET='${DEPLOY_S3_BUCKET}'",
+              "DEPLOY_SHA='${GITHUB_SHA}'",
+              "mkdir -p \"${APP_DEPLOY_DIR}/releases/${GITHUB_SHA}\"",
+              "PREVIOUS_TARGET=\$(readlink -f \"${APP_DEPLOY_DIR}/current.jar\" || true)",
+              "aws s3 cp \"s3://${DEPLOY_S3_BUCKET}/bike-back/releases/${GITHUB_SHA}/app.jar\" \"${APP_DEPLOY_DIR}/releases/${GITHUB_SHA}/app.jar\"",
+              "ln -sfn \"${APP_DEPLOY_DIR}/releases/${GITHUB_SHA}/app.jar\" \"${APP_DEPLOY_DIR}/current.jar\"",
+              "if systemctl restart \"${APP_SERVICE_NAME}\" && curl -fsS \"http://127.0.0.1:${APP_PORT}/health\" >/tmp/bike-back-health.json; then exit 0; fi",
+              "if [ -n \"${PREVIOUS_TARGET}\" ]; then ln -sfn \"${PREVIOUS_TARGET}\" \"${APP_DEPLOY_DIR}/current.jar\"; systemctl restart \"${APP_SERVICE_NAME}\"; fi",
+              "exit 1"
+            ]
+          }
+          EOF
+
+      - name: Send deploy command to EC2 with SSM
+        id: ssm
+        run: |
+          set -euo pipefail
+          COMMAND_ID="$(aws ssm send-command \
+            --instance-ids "$APP_INSTANCE_ID" \
+            --document-name 'AWS-RunShellScript' \
+            --comment "bike-back deploy ${GITHUB_SHA}" \
+            --parameters file://ssm-commands.json \
+            --query 'Command.CommandId' \
+            --output text)"
+          printf 'command_id=%s\n' "$COMMAND_ID" >> "$GITHUB_OUTPUT"
+
+      - name: Wait for SSM command completion
+        env:
+          COMMAND_ID: ${{ steps.ssm.outputs.command_id }}
+        run: |
+          set -euo pipefail
+          for _ in $(seq 1 60); do
+            STATUS="$(aws ssm get-command-invocation \
+              --command-id "$COMMAND_ID" \
+              --instance-id "$APP_INSTANCE_ID" \
+              --query 'Status' \
+              --output text)"
+
+            case "$STATUS" in
+              Success)
+                exit 0
+                ;;
+              Pending|InProgress|Delayed)
+                sleep 10
+                ;;
+              *)
+                aws ssm get-command-invocation \
+                  --command-id "$COMMAND_ID" \
+                  --instance-id "$APP_INSTANCE_ID"
+                exit 1
+                ;;
+            esac
+          done
+
+          printf '[ERROR] Timed out waiting for SSM deploy command\n' >&2
+          exit 1
+
+      - name: Verify public health endpoint
+        run: |
+          set -euo pipefail
+          curl -fsS "$HEALTHCHECK_URL"

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -1,0 +1,38 @@
+name: bike-back-ci
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: bike-back-ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test-and-build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Java 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+          cache: gradle
+
+      - name: Grant Gradle wrapper permission
+        run: chmod +x ./gradlew
+
+      - name: Run verification lifecycle
+        run: ./gradlew --no-daemon clean check build

--- a/README.md
+++ b/README.md
@@ -102,6 +102,13 @@ com.bikeprojectminji.bikeback
 - 서비스 테스트는 `@SpringBootTest` 기반 통합 테스트를 사용합니다.
 - README는 계획이 아니라 **실제로 구현된 범위만** 기록합니다.
 
+## CI/CD
+
+- GitHub Actions CI: `.github/workflows/backend-ci.yml`
+- GitHub Actions CD: `.github/workflows/backend-cd.yml`
+- 기본 CD 경로: GitHub OIDC -> AWS IAM role -> S3 artifact -> SSM Run Command -> app EC2 `systemd` restart
+- 자세한 서버 준비 조건과 GitHub 설정값은 `docs/aws-ec2-github-actions-cicd.md`를 따릅니다.
+
 ## Current docs
 
 - `DOCS/00_기준/프로젝트_헌법.md`

--- a/docs/aws-ec2-github-actions-cicd.md
+++ b/docs/aws-ec2-github-actions-cicd.md
@@ -1,0 +1,111 @@
+# AWS EC2 + GitHub Actions CI/CD
+
+## 목적
+
+이 문서는 `bike-back`를 **저비용 AWS EC2 환경**에 배포할 때 사용하는 GitHub Actions CI/CD 기준을 정리합니다.
+
+기본 경로는 아래와 같습니다.
+
+1. GitHub Actions CI가 `test`, `bootJar`를 실행합니다.
+2. `main` 반영 시 GitHub Actions CD가 GitHub OIDC로 AWS IAM role을 가정합니다.
+3. 빌드된 jar를 private S3 bucket에 업로드합니다.
+4. AWS SSM Run Command가 app EC2에서 새 jar를 내려받아 `systemd` 서비스를 재시작합니다.
+5. 내부 `/health`와 외부 `HEALTHCHECK_URL`을 함께 확인합니다.
+
+## 왜 이 방식을 쓰는가
+
+- GitHub Secrets에 장기 AWS access key를 넣지 않기 위해서입니다.
+- GitHub runner의 동적 IP 때문에 SSH 인바운드를 GitHub에 넓게 열지 않기 위해서입니다.
+- ALB, ECS, CodeDeploy, ECR 없이도 저비용으로 안전한 자동 배포를 만들기 위해서입니다.
+
+## GitHub Actions 파일
+
+- `.github/workflows/backend-ci.yml`
+- `.github/workflows/backend-cd.yml`
+
+## GitHub 설정값
+
+### Secret
+
+- `AWS_DEPLOY_ROLE_ARN`
+
+### Variable
+
+- `APP_INSTANCE_ID`
+- `DEPLOY_S3_BUCKET`
+- `HEALTHCHECK_URL`
+- `APP_SERVICE_NAME` (기본값: `bike-back`)
+- `APP_DEPLOY_DIR` (기본값: `/opt/bike-back`)
+- `APP_PORT` (기본값: `8080`)
+
+## AWS 선행 조건
+
+### 1. GitHub OIDC IAM role
+
+GitHub Actions가 assume 할 수 있는 IAM role이 필요합니다.
+
+최소 권한 기준은 아래 범위만 먼저 검토합니다.
+
+- `s3:PutObject`
+- `s3:GetObject`
+- `s3:ListBucket`
+- `ssm:SendCommand`
+- `ssm:GetCommandInvocation`
+- `ssm:ListCommandInvocations`
+- `ec2:DescribeInstances`
+
+권한 범위는 deploy bucket과 app EC2 instance로 최대한 좁힙니다.
+
+### 2. app EC2 조건
+
+- SSM Agent가 동작 중이어야 합니다.
+- 인스턴스 프로파일에 S3 read 권한이 있어야 합니다.
+- `systemd` 서비스명이 `bike-back` 또는 `APP_SERVICE_NAME`과 일치해야 합니다.
+- 애플리케이션 jar 경로는 `/opt/bike-back/current.jar` 기준으로 맞추는 것을 권장합니다.
+
+### 3. S3 bucket 조건
+
+- private bucket이어야 합니다.
+- 예시 경로: `s3://<bucket>/bike-back/releases/<git-sha>/app.jar`
+
+## app EC2 systemd 예시
+
+```ini
+[Unit]
+Description=bike-back application
+After=network.target
+
+[Service]
+User=ubuntu
+WorkingDirectory=/opt/bike-back
+EnvironmentFile=/opt/bike-back/.env
+ExecStart=/usr/bin/java -jar /opt/bike-back/current.jar
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+```
+
+`User`는 실제 서버 사용자에 맞춰 바꿉니다.
+
+## 배포 시 동작
+
+1. 새 jar를 S3에 업로드합니다.
+2. SSM Run Command가 app EC2에서 새 jar를 `/opt/bike-back/releases/<sha>/app.jar`로 내려받습니다.
+3. `/opt/bike-back/current.jar` 심볼릭 링크를 새 jar로 교체합니다.
+4. `systemctl restart bike-back`을 실행합니다.
+5. `http://127.0.0.1:<APP_PORT>/health`를 확인합니다.
+6. 실패하면 이전 `current.jar`로 롤백하고 서비스를 다시 시작합니다.
+
+## 롤백 방식
+
+- 기본 롤백은 **직전 symlink target 복구 + systemd 재시작**입니다.
+- 앱 외부 공개 health는 `HEALTHCHECK_URL`로 마지막에 다시 확인합니다.
+- DB migration이 포함된 배포라면 jar 롤백만으로 충분한지 별도 점검해야 합니다.
+
+## 주의사항
+
+- 이 흐름은 app EC2 배포 자동화 기준입니다.
+- db EC2 schema 변경은 Flyway migration 영향이 있으므로, 대규모 schema 변경 시에는 배포 전 백업 기준을 먼저 잠가야 합니다.
+- Redis는 현재 코드와 `/health/monitor`에 연결 흔적이 있으므로, 운영에서 제거할 때는 앱 계약과 monitor 기준을 먼저 정리해야 합니다.

--- a/src/main/java/com/bikeprojectminji/bikeback/ride/service/RideRecordService.java
+++ b/src/main/java/com/bikeprojectminji/bikeback/ride/service/RideRecordService.java
@@ -11,16 +11,24 @@ import com.bikeprojectminji.bikeback.ride.entity.RideRecordPointEntity;
 import com.bikeprojectminji.bikeback.ride.repository.RideRecordPointRepository;
 import com.bikeprojectminji.bikeback.ride.repository.RideRecordRepository;
 import com.bikeprojectminji.bikeback.auth.service.AuthService;
+import java.math.BigDecimal;
 import java.time.OffsetDateTime;
+import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 public class RideRecordService {
+
+    private static final Logger log = LoggerFactory.getLogger(RideRecordService.class);
+    private static final double MIN_POINT_DISTANCE_METERS = 5.0;
+    private static final double CANONICAL_EPSILON_METERS = 8.0;
 
     private final AuthService authService;
     private final RideRecordRepository rideRecordRepository;
@@ -54,11 +62,14 @@ public class RideRecordService {
                 request.summary().durationSec()
         ));
 
-        List<RideRecordPointEntity> routePoints = normalizeRoutePoints(request.routePoints()).stream()
+        List<RideRecordPointRequest> canonicalRoutePoints = canonicalizeRoutePoints(normalizeRoutePoints(request.routePoints()));
+        List<RideRecordPointEntity> routePoints = canonicalRoutePoints.stream()
                 .map(point -> new RideRecordPointEntity(rideRecord.getId(), point.pointOrder(), point.latitude(), point.longitude()))
                 .toList();
         rideRecordPointRepository.saveAll(routePoints);
         cacheLatestCompletedLocation(subject, rideRecord.getId(), routePoints, request.endedAt());
+        log.info("ride record saved subject={} rideRecordId={} routePointCount={} startedAt={} endedAt={}",
+                subject, rideRecord.getId(), routePoints.size(), request.startedAt(), request.endedAt());
 
         return new RideRecordResponse(rideRecord.getId(), user.getId(), routePoints.size());
     }
@@ -126,5 +137,158 @@ public class RideRecordService {
         return routePoints.stream()
                 .sorted(Comparator.comparing(RideRecordPointRequest::pointOrder))
                 .toList();
+    }
+
+    private List<RideRecordPointRequest> canonicalizeRoutePoints(List<RideRecordPointRequest> routePoints) {
+        // 현재 저장 경계에서는 raw 포인트를 그대로 영구 저장하지 않고,
+        // 시작/끝과 주요 굴곡은 유지하면서 중복·지터와 과도한 직선 구간 포인트를 줄인 canonical path를 만든다.
+        List<RideRecordPointRequest> deduplicated = dropNearDuplicatePoints(routePoints);
+        List<RideRecordPointRequest> simplified = simplifyWithRamerDouglasPeucker(deduplicated);
+
+        List<RideRecordPointRequest> canonical = new ArrayList<>();
+        for (int i = 0; i < simplified.size(); i++) {
+            RideRecordPointRequest point = simplified.get(i);
+            canonical.add(new RideRecordPointRequest(i + 1, point.latitude(), point.longitude()));
+        }
+        return canonical;
+    }
+
+    private List<RideRecordPointRequest> dropNearDuplicatePoints(List<RideRecordPointRequest> routePoints) {
+        if (routePoints.size() <= 2) {
+            return routePoints;
+        }
+
+        List<RideRecordPointRequest> deduplicated = new ArrayList<>();
+        RideRecordPointRequest lastKept = routePoints.get(0);
+        deduplicated.add(lastKept);
+
+        for (int i = 1; i < routePoints.size() - 1; i++) {
+            RideRecordPointRequest candidate = routePoints.get(i);
+            if (distanceMeters(lastKept, candidate) >= MIN_POINT_DISTANCE_METERS) {
+                deduplicated.add(candidate);
+                lastKept = candidate;
+            }
+        }
+
+        RideRecordPointRequest lastPoint = routePoints.get(routePoints.size() - 1);
+        if (deduplicated.get(deduplicated.size() - 1) != lastPoint) {
+            deduplicated.add(lastPoint);
+        }
+        return deduplicated;
+    }
+
+    private List<RideRecordPointRequest> simplifyWithRamerDouglasPeucker(List<RideRecordPointRequest> routePoints) {
+        if (routePoints.size() <= 2) {
+            return routePoints;
+        }
+
+        boolean[] keep = new boolean[routePoints.size()];
+        keep[0] = true;
+        keep[routePoints.size() - 1] = true;
+        markRamerDouglasPeucker(routePoints, 0, routePoints.size() - 1, keep);
+
+        List<RideRecordPointRequest> simplified = new ArrayList<>();
+        for (int i = 0; i < routePoints.size(); i++) {
+            if (keep[i]) {
+                simplified.add(routePoints.get(i));
+            }
+        }
+        return simplified;
+    }
+
+    private void markRamerDouglasPeucker(
+            List<RideRecordPointRequest> routePoints,
+            int startIndex,
+            int endIndex,
+            boolean[] keep
+    ) {
+        if (endIndex - startIndex <= 1) {
+            return;
+        }
+
+        double maxDistance = -1.0;
+        int maxDistanceIndex = -1;
+
+        for (int i = startIndex + 1; i < endIndex; i++) {
+            double perpendicularDistance = perpendicularDistanceMeters(
+                    routePoints.get(startIndex),
+                    routePoints.get(endIndex),
+                    routePoints.get(i)
+            );
+            if (perpendicularDistance > maxDistance) {
+                maxDistance = perpendicularDistance;
+                maxDistanceIndex = i;
+            }
+        }
+
+        if (maxDistanceIndex != -1 && maxDistance > CANONICAL_EPSILON_METERS) {
+            keep[maxDistanceIndex] = true;
+            markRamerDouglasPeucker(routePoints, startIndex, maxDistanceIndex, keep);
+            markRamerDouglasPeucker(routePoints, maxDistanceIndex, endIndex, keep);
+        }
+    }
+
+    private double perpendicularDistanceMeters(
+            RideRecordPointRequest start,
+            RideRecordPointRequest end,
+            RideRecordPointRequest candidate
+    ) {
+        if (start.latitude().compareTo(end.latitude()) == 0 && start.longitude().compareTo(end.longitude()) == 0) {
+            return distanceMeters(start, candidate);
+        }
+
+        double[] startPoint = toLocalMeters(start, start);
+        double[] endPoint = toLocalMeters(start, end);
+        double[] candidatePoint = toLocalMeters(start, candidate);
+
+        double lineX = endPoint[0] - startPoint[0];
+        double lineY = endPoint[1] - startPoint[1];
+        double pointX = candidatePoint[0] - startPoint[0];
+        double pointY = candidatePoint[1] - startPoint[1];
+        double lineLengthSquared = lineX * lineX + lineY * lineY;
+
+        if (lineLengthSquared == 0.0) {
+            return Math.sqrt(pointX * pointX + pointY * pointY);
+        }
+
+        double projection = (pointX * lineX + pointY * lineY) / lineLengthSquared;
+        if (projection < 0.0) {
+            return Math.sqrt(pointX * pointX + pointY * pointY);
+        }
+        if (projection > 1.0) {
+            double dx = candidatePoint[0] - endPoint[0];
+            double dy = candidatePoint[1] - endPoint[1];
+            return Math.sqrt(dx * dx + dy * dy);
+        }
+
+        double projectedX = startPoint[0] + projection * lineX;
+        double projectedY = startPoint[1] + projection * lineY;
+        double dx = candidatePoint[0] - projectedX;
+        double dy = candidatePoint[1] - projectedY;
+        return Math.sqrt(dx * dx + dy * dy);
+    }
+
+    private double distanceMeters(RideRecordPointRequest start, RideRecordPointRequest end) {
+        double lat1 = Math.toRadians(start.latitude().doubleValue());
+        double lon1 = Math.toRadians(start.longitude().doubleValue());
+        double lat2 = Math.toRadians(end.latitude().doubleValue());
+        double lon2 = Math.toRadians(end.longitude().doubleValue());
+
+        double dLat = lat2 - lat1;
+        double dLon = lon2 - lon1;
+        double a = Math.sin(dLat / 2) * Math.sin(dLat / 2)
+                + Math.cos(lat1) * Math.cos(lat2) * Math.sin(dLon / 2) * Math.sin(dLon / 2);
+        return 6371000.0 * 2.0 * Math.atan2(Math.sqrt(a), Math.sqrt(1.0 - a));
+    }
+
+    private double[] toLocalMeters(RideRecordPointRequest origin, RideRecordPointRequest target) {
+        double originLat = Math.toRadians(origin.latitude().doubleValue());
+        double originLon = Math.toRadians(origin.longitude().doubleValue());
+        double targetLat = Math.toRadians(target.latitude().doubleValue());
+        double targetLon = Math.toRadians(target.longitude().doubleValue());
+        double meanLat = (originLat + targetLat) / 2.0;
+        double x = (targetLon - originLon) * Math.cos(meanLat) * 6371000.0;
+        double y = (targetLat - originLat) * 6371000.0;
+        return new double[] {x, y};
     }
 }

--- a/src/test/java/com/bikeprojectminji/bikeback/ride/service/RideRecordServiceTest.java
+++ b/src/test/java/com/bikeprojectminji/bikeback/ride/service/RideRecordServiceTest.java
@@ -11,12 +11,14 @@ import com.bikeprojectminji.bikeback.ride.dto.RideRecordPointRequest;
 import com.bikeprojectminji.bikeback.ride.dto.RideRecordResponse;
 import com.bikeprojectminji.bikeback.ride.dto.RideRecordSummaryRequest;
 import com.bikeprojectminji.bikeback.ride.entity.RideRecordEntity;
+import com.bikeprojectminji.bikeback.ride.entity.RideRecordPointEntity;
 import com.bikeprojectminji.bikeback.ride.repository.RideRecordPointRepository;
 import com.bikeprojectminji.bikeback.ride.repository.RideRecordRepository;
 import com.bikeprojectminji.bikeback.auth.service.AuthService;
 import java.math.BigDecimal;
 import java.time.OffsetDateTime;
 import java.util.List;
+import org.mockito.ArgumentCaptor;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -77,5 +79,38 @@ class RideRecordServiceTest {
                 eq(BigDecimal.valueOf(126.9792)),
                 eq(OffsetDateTime.parse("2026-03-29T11:00:00+09:00"))
         );
+    }
+
+    @Test
+    @DisplayName("자유 주행 기록 저장은 직선 구간 포인트를 canonical path로 간소화한다")
+    void saveRideRecordSimplifiesStraightLinePoints() {
+        UserEntity user = new UserEntity(null, "bikeoasis@example.com", "encoded-password", "bikeoasis", null);
+        ReflectionTestUtils.setField(user, "id", 1L);
+        RideRecordEntity savedRideRecord = new RideRecordEntity(1L, OffsetDateTime.parse("2026-03-29T10:00:00+09:00"), OffsetDateTime.parse("2026-03-29T11:00:00+09:00"), 18250, 3600);
+        ReflectionTestUtils.setField(savedRideRecord, "id", 1001L);
+
+        given(authService.findUserBySubject("1")).willReturn(user);
+        given(rideRecordRepository.save(any(RideRecordEntity.class))).willReturn(savedRideRecord);
+
+        RideRecordResponse response = rideRecordService.saveRideRecord("1", new CreateRideRecordRequest(
+                OffsetDateTime.parse("2026-03-29T10:00:00+09:00"),
+                OffsetDateTime.parse("2026-03-29T11:00:00+09:00"),
+                new RideRecordSummaryRequest(18250, 3600),
+                List.of(
+                        new RideRecordPointRequest(1, BigDecimal.valueOf(37.5665), BigDecimal.valueOf(126.9780)),
+                        new RideRecordPointRequest(2, BigDecimal.valueOf(37.56655), BigDecimal.valueOf(126.9785)),
+                        new RideRecordPointRequest(3, BigDecimal.valueOf(37.56660), BigDecimal.valueOf(126.9790)),
+                        new RideRecordPointRequest(4, BigDecimal.valueOf(37.56665), BigDecimal.valueOf(126.9795))
+                )
+        ));
+
+        assertThat(response.routePointCount()).isEqualTo(2);
+        ArgumentCaptor<List<RideRecordPointEntity>> captor = ArgumentCaptor.forClass(List.class);
+        verify(rideRecordPointRepository).saveAll(captor.capture());
+        assertThat(captor.getValue()).hasSize(2);
+        assertThat(captor.getValue().get(0).getPointOrder()).isEqualTo(1);
+        assertThat(captor.getValue().get(1).getPointOrder()).isEqualTo(2);
+        assertThat(captor.getValue().get(0).getLatitude()).isEqualTo(BigDecimal.valueOf(37.5665));
+        assertThat(captor.getValue().get(1).getLatitude()).isEqualTo(BigDecimal.valueOf(37.56665));
     }
 }


### PR DESCRIPTION
## Summary
- 자유 주행 route point 저장을 canonical path 간소화 기준으로 정리하고 관련 테스트를 추가했습니다.
- bike-back 저장소에 GitHub Actions CI/CD 워크플로우와 AWS EC2 배포 문서를 추가했습니다.
- README를 현재 공개 저장소 기준으로 정리했습니다.

## Verification
- ./gradlew --no-daemon test build
- workflow YAML parse check
- app /health smoke on EC2