### PR TITLE
CD rollback 변수 확장 오류 수정

### DIFF
--- a/.github/workflows/backend-cd.yml
+++ b/.github/workflows/backend-cd.yml
@@ -101,7 +101,7 @@ jobs:
               "aws s3 cp \"s3://${DEPLOY_S3_BUCKET}/bike-back/releases/${GITHUB_SHA}/app.jar\" \"${APP_DEPLOY_DIR}/releases/${GITHUB_SHA}/app.jar\"",
               "ln -sfn \"${APP_DEPLOY_DIR}/releases/${GITHUB_SHA}/app.jar\" \"${APP_DEPLOY_DIR}/current.jar\"",
               "if systemctl restart \"${APP_SERVICE_NAME}\" && curl -fsS \"http://127.0.0.1:${APP_PORT}/health\" >/tmp/bike-back-health.json; then exit 0; fi",
-              "if [ -n \"${PREVIOUS_TARGET}\" ]; then ln -sfn \"${PREVIOUS_TARGET}\" \"${APP_DEPLOY_DIR}/current.jar\"; systemctl restart \"${APP_SERVICE_NAME}\"; fi",
+              "if [ -n \"\${PREVIOUS_TARGET}\" ]; then ln -sfn \"\${PREVIOUS_TARGET}\" \"${APP_DEPLOY_DIR}/current.jar\"; systemctl restart \"${APP_SERVICE_NAME}\"; fi",
               "exit 1"
             ]
           }


### PR DESCRIPTION
## Summary
- backend CD workflow에서 remote shell 변수 `PREVIOUS_TARGET`가 GitHub runner에서 먼저 확장되던 문제를 수정했습니다.
- rollback 경로가 runner 셸이 아니라 EC2 원격 셸에서만 해석되도록 escape를 보정했습니다.

## Verification
- workflow YAML parse check
- previous CD failure log review