### PR TITLE
CD health 확인 재시도 추가

### DIFF
--- a/.github/workflows/backend-cd.yml
+++ b/.github/workflows/backend-cd.yml
@@ -100,7 +100,7 @@ jobs:
               "PREVIOUS_TARGET=\$(readlink -f \"${APP_DEPLOY_DIR}/current.jar\" || true)",
               "aws s3 cp \"s3://${DEPLOY_S3_BUCKET}/bike-back/releases/${GITHUB_SHA}/app.jar\" \"${APP_DEPLOY_DIR}/releases/${GITHUB_SHA}/app.jar\"",
               "ln -sfn \"${APP_DEPLOY_DIR}/releases/${GITHUB_SHA}/app.jar\" \"${APP_DEPLOY_DIR}/current.jar\"",
-              "if systemctl restart \"${APP_SERVICE_NAME}\" && curl -fsS \"http://127.0.0.1:${APP_PORT}/health\" >/tmp/bike-back-health.json; then exit 0; fi",
+              "if systemctl restart \"${APP_SERVICE_NAME}\"; then for _ in $(seq 1 15); do if curl -fsS \"http://127.0.0.1:${APP_PORT}/health\" >/tmp/bike-back-health.json; then exit 0; fi; sleep 2; done; fi",
               "if [ -n \"\${PREVIOUS_TARGET}\" ]; then ln -sfn \"\${PREVIOUS_TARGET}\" \"${APP_DEPLOY_DIR}/current.jar\"; systemctl restart \"${APP_SERVICE_NAME}\"; fi",
               "exit 1"
             ]


### PR DESCRIPTION
## Summary
- backend CD workflow의 EC2 내부 health 확인을 재시도 루프로 보강했습니다.
- Spring Boot 재기동 직후 바로 응답하지 않는 타이밍 실패를 줄입니다.

## Verification
- workflow YAML parse check
- previous CD failure log review