### PR TITLE
docs: add ALB and Gabia cutover guides

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,12 @@ out/
 
 ### VS Code ###
 .vscode/
+# Terraform local state
+ops/aws/alb-acm-route53/.terraform/
+ops/aws/alb-acm-route53/.terraform.lock.hcl
+ops/aws/alb-acm-route53/terraform.tfstate
+ops/aws/alb-acm-route53/terraform.tfstate.backup
+ops/aws/alb-acm-route53/terraform.tfvars.discovered
+
+# Local verification artifacts
+smoke-check-file-summary.json

--- a/docs/aws-alb-acm-route53.md
+++ b/docs/aws-alb-acm-route53.md
@@ -1,0 +1,131 @@
+# AWS ALB + ACM + DNS 전환 초안
+
+## 목적
+
+이 문서는 현재 `bike-back`의 **EC2 + systemd + SSM** 배포 구조 앞단에 **ALB + ACM 인증서**를 추가해,
+앱 공개 경로를 `HTTP public IP` 에서 `HTTPS 도메인` 으로 전환하는 초안을 정리한다.
+
+현재 저장소 기준 backend 공개 접근은 다음에 가깝다.
+
+- backend app: `Spring Boot` on app EC2
+- deploy: `GitHub Actions -> OIDC -> S3 -> SSM -> systemd restart`
+- frontend base URL: 현재 배포 backend 기준 `http://3.35.168.38`
+
+즉 이번 변경의 핵심은 **배포 방식 변경이 아니라 API 진입점 변경**이다.
+
+## 현재 구조
+
+- Android 앱이 backend 공인 IP로 직접 접근한다.
+- TLS 종료 지점이 앱 공개 API 앞단에 없다.
+- observability는 별도 nginx + certbot 흐름이 있지만, app API 앞단은 아직 ALB 기반이 아니다.
+
+## 목표 구조
+
+```text
+Android App
+  -> https://api.gajabike.shop
+  -> ALB (80 redirect / 443 terminate TLS)
+  -> app EC2 :8080 (Spring Boot)
+  -> PostgreSQL / Redis
+```
+
+## 왜 ALB를 두는가
+
+- 앱 공개 API를 `HTTPS` 로 고정할 수 있다.
+- Android release URL을 공인 IP 대신 도메인으로 관리할 수 있다.
+- 인증서 갱신을 EC2 내부 certbot 흐름 대신 ACM으로 옮길 수 있다.
+- 이후 다중 인스턴스, WAF, access log 같은 edge 확장이 쉬워진다.
+
+## 최소 리소스
+
+- ACM public certificate
+- internet-facing ALB
+- HTTP listener (80 -> 443 redirect)
+- HTTPS listener (443 -> target group forward)
+- EC2 instance target group
+- ALB security group
+- app instance security group rule (source = ALB SG)
+- DNS record
+
+## DNS 전략
+
+### 현재 기준: 가비아 유지
+
+현재 문서에는 `gajabike.shop` DNS를 **가비아** 에서 관리하는 흐름이 이미 있다.
+그래서 1차 적용은 아래가 더 현실적이다.
+
+1. ACM certificate를 `DNS validation` 으로 요청
+2. Terraform output 또는 AWS 콘솔에서 validation CNAME 확인
+3. 가비아 DNS에 validation CNAME 수동 등록
+4. 인증서 발급 완료 후 HTTPS listener를 다시 apply
+5. `api.gajabike.shop` 을 ALB로 연결
+
+즉 **ALB/ACM은 AWS**, **DNS record 입력은 가비아** 로 나뉜다.
+
+가비아 작업자가 실제로 입력해야 하는 값만 보려면 아래 문서를 본다.
+
+- `docs/gabia-dns-alb-acm-guide.md`
+
+### 선택지: Route53으로 이동
+
+만약 이후 DNS를 Route53으로 옮기면,
+같은 Terraform 초안에서 validation record와 alias record까지 함께 자동화할 수 있다.
+
+## 저장소 반영 위치
+
+- Terraform 초안: `ops/aws/alb-acm-route53/`
+- 설명 문서: `docs/aws-alb-acm-route53.md`
+- 가비아 입력 가이드: `docs/gabia-dns-alb-acm-guide.md`
+
+현재 저장소는 `ops/<capability>/<env>` 와 `docs/aws-*.md` 패턴을 쓰고 있어서,
+이 위치가 기존 구조와 가장 잘 맞는다.
+
+## 적용 후 같이 바꿔야 하는 값
+
+### 1. GitHub Actions
+
+`backend-cd.yml` 에서 public smoke check는 `HEALTHCHECK_URL` 변수를 사용한다.
+
+현재:
+- `http://<public-ip>/health`
+
+전환 후:
+- `https://api.gajabike.shop/health`
+
+### 2. Android release base URL
+
+현재 `bike-front` README에는 배포 backend 기준 URL이 `http://3.35.168.38` 로 적혀 있다.
+ALB 전환 후에는 release build URL을 다음처럼 바꾸는 것이 목표다.
+
+- `https://api.gajabike.shop`
+
+### 3. app EC2 security group
+
+- `8080` 인바운드는 인터넷 전체 허용 대신 **ALB security group source only** 로 좁힌다.
+- public direct access를 끊고 ALB 경유만 허용하는 쪽이 맞다.
+
+## 이번 초안에서 하지 않는 것
+
+- ECS/EKS 전환
+- multi-app blue/green 배포
+- WAF 자동화
+- Route53 강제 이전
+- DB/Redis 구조 변경
+
+## 권장 적용 순서
+
+1. ALB + target group + security group 생성
+2. ACM certificate 요청
+3. 가비아 DNS에 validation CNAME 등록
+4. ACM이 `ISSUED` 상태인지 확인
+5. HTTPS listener + HTTP redirect 재적용
+6. `api.gajabike.shop` 을 ALB로 연결
+7. `https://api.gajabike.shop/health` 확인
+8. GitHub Actions `HEALTHCHECK_URL` 변경
+9. Android release base URL 변경
+
+## 운영 메모
+
+- 현재 구조는 단일 app EC2 target이라 ALB를 붙여도 **backend 자체 SPOF는 그대로** 다.
+- 다만 HTTPS 종단, 도메인 진입, SG 축소, 이후 확장성 면에서는 큰 개선이다.
+- observability 도메인에서 사용하던 certbot/nginx 방식과 app API 앞단 ALB 방식은 병행 가능하다.

--- a/docs/gabia-dns-alb-acm-guide.md
+++ b/docs/gabia-dns-alb-acm-guide.md
@@ -1,0 +1,122 @@
+# 가비아 DNS 작업 가이드
+
+이 문서는 **가비아 DNS에서 무엇을 입력해야 하는지**만 따로 정리한 문서다.
+AWS ALB/ACM/Terraform 자체 설명은 `docs/aws-alb-acm-route53.md` 와
+`ops/aws/alb-acm-route53/APPLY_GABIA_CHECKLIST.md` 를 따른다.
+
+## 지금 가비아에서 해야 하는 일
+
+가비아에서 해야 할 일은 딱 2가지다.
+
+1. **ACM 인증서 검증용 CNAME 등록**
+2. **`api.gajabike.shop` 을 ALB 쪽으로 연결**
+
+즉 가비아는 **DNS 입력 담당**이고,
+ALB/ACM 생성 자체는 AWS/Terraform 쪽 작업이다.
+
+---
+
+## 1. ACM 인증서 검증용 CNAME 등록
+
+Terraform 1차 apply 후 아래 명령으로 값을 확인한다.
+
+```bash
+cd /mnt/c/Users/alswl/Desktop/bike/dev/bike-back/ops/aws/alb-acm-route53
+terraform output -json certificate_validation_records
+```
+
+예시 출력:
+
+```json
+[
+  {
+    "domain_name": "api.gajabike.shop",
+    "name": "_xxxx.api.gajabike.shop.",
+    "type": "CNAME",
+    "value": "_yyyy.acm-validations.aws."
+  }
+]
+```
+
+가비아 DNS 관리 화면에서 위 값을 그대로 넣는다.
+
+### 가비아에 넣는 값
+
+- 레코드 타입: `CNAME`
+- 호스트/이름: Terraform output의 `name`
+- 값/대상: Terraform output의 `value`
+- TTL: 가비아 기본값 또는 `300`
+
+### 주의
+
+- 끝의 `.` 이 붙은 값이 나오면 **가비아 UI 입력 방식에 맞춰** 넣는다.
+- 중요한 건 문자열을 임의로 바꾸지 않는 것이다.
+- 이 CNAME이 들어가야 ACM 인증서가 `ISSUED` 상태가 된다.
+
+---
+
+## 2. `api.gajabike.shop` 을 ALB로 연결
+
+ACM이 `ISSUED` 된 뒤 2차 apply를 마치면,
+아래 명령으로 ALB DNS 이름을 확인한다.
+
+```bash
+cd /mnt/c/Users/alswl/Desktop/bike/dev/bike-back/ops/aws/alb-acm-route53
+terraform output alb_dns_name
+```
+
+예시 출력:
+
+```text
+bike-api-alb-123456789.ap-northeast-2.elb.amazonaws.com
+```
+
+이제 가비아에서 `api.gajabike.shop` 을 위 ALB DNS 이름으로 연결한다.
+
+### 가비아에 넣는 값
+
+- 서브도메인/호스트: `api`
+- 대상 값: `terraform output alb_dns_name` 결과값
+
+### 레코드 방식
+
+- 가비아 UI에서 `CNAME` 이 허용되면 `api` 서브도메인에 CNAME으로 연결
+- 가비아가 ALIAS/ANAME 유사 기능을 지원하면 그 방식 사용 가능
+- 현재 기준은 **`api` 같은 서브도메인이므로 CNAME 연결이 가장 현실적**이다
+
+---
+
+## 입력 순서
+
+순서는 반드시 아래대로 간다.
+
+1. Terraform 1차 apply
+2. 가비아에 **ACM validation CNAME** 등록
+3. ACM `ISSUED` 확인
+4. Terraform 2차 apply (`enable_https_listener = true`)
+5. 가비아에 **`api.gajabike.shop` -> ALB DNS** 연결
+
+즉 `api` 레코드를 먼저 연결하는 게 아니라,
+**ACM 검증 CNAME이 먼저**다.
+
+---
+
+## 가비아 작업 후 확인할 것
+
+```bash
+curl -I http://api.gajabike.shop
+curl -I https://api.gajabike.shop/health
+curl -fsS https://api.gajabike.shop/health
+```
+
+정상 기대값:
+
+- `http://api.gajabike.shop` -> HTTPS redirect
+- `https://api.gajabike.shop/health` -> `200`
+
+---
+
+## 한 줄 요약
+
+가비아에서는 **ACM 검증용 CNAME 1개** 넣고,
+그 다음 **`api.gajabike.shop` 을 ALB DNS로 연결하는 레코드 1개** 넣으면 된다.

--- a/ops/aws/alb-acm-route53/APPLY_GABIA_CHECKLIST.md
+++ b/ops/aws/alb-acm-route53/APPLY_GABIA_CHECKLIST.md
@@ -1,0 +1,146 @@
+# ALB + ACM + Gabia 적용 체크리스트
+
+이 체크리스트는 `/mnt/c/Users/alswl/Desktop/bike/dev/bike-back/ops/aws/alb-acm-route53/terraform.tfvars.discovered` 기준이다.
+
+## 0. 현재 확인된 실제 값
+
+- region: `ap-northeast-2`
+- app instance: `i-0e5bce97db12b2300` (`bike-back-app`)
+- current public IP: `3.35.168.38`
+- VPC: `vpc-0602381a2cb0a950e`
+- app SG: `sg-0d7393e764b0f7135`
+- public subnets:
+  - `subnet-056cda04cc8cbd0cf` (`ap-northeast-2a`)
+  - `subnet-0cb2f3e103f6a8b46` (`ap-northeast-2c`)
+  - `subnet-0335ced9c5df2f144` (`ap-northeast-2b`)
+  - `subnet-0a34bc7630bfdd7bc` (`ap-northeast-2d`)
+
+## 1. 1차 apply
+
+```bash
+cd /mnt/c/Users/alswl/Desktop/bike/dev/bike-back/ops/aws/alb-acm-route53
+terraform init
+terraform plan -var-file=terraform.tfvars.discovered
+terraform apply -var-file=terraform.tfvars.discovered
+```
+
+1차 apply 목적:
+
+- ALB 생성
+- target group 생성
+- ACM certificate 요청
+- HTTP 80 listener만 생성
+- 아직 HTTPS listener는 만들지 않음
+
+## 2. 가비아 DNS에 ACM validation CNAME 등록
+
+가비아 화면에서 실제로 무엇을 넣는지는 아래 문서를 같이 본다.
+
+- `/mnt/c/Users/alswl/Desktop/bike/dev/bike-back/docs/gabia-dns-alb-acm-guide.md`
+
+아래 명령으로 ACM 검증용 레코드를 확인한다.
+
+```bash
+terraform output -json certificate_validation_records
+```
+
+출력 예시 구조:
+
+```json
+[
+  {
+    "domain_name": "api.gajabike.shop",
+    "name": "_xxxx.api.gajabike.shop.",
+    "type": "CNAME",
+    "value": "_yyyy.acm-validations.aws."
+  }
+]
+```
+
+가비아 DNS에서 위 값을 그대로 CNAME으로 등록한다.
+
+## 3. ACM 발급 완료 확인
+
+AWS 콘솔 또는 CLI에서 인증서가 `ISSUED` 상태인지 확인한다.
+
+예시:
+
+```bash
+aws acm list-certificates --region ap-northeast-2
+```
+
+## 4. 2차 apply
+
+`terraform.tfvars.discovered` 에서 아래 값만 바꾼다.
+
+```hcl
+enable_https_listener = true
+```
+
+그 다음 다시 적용한다.
+
+```bash
+terraform plan -var-file=terraform.tfvars.discovered
+terraform apply -var-file=terraform.tfvars.discovered
+```
+
+2차 apply 목적:
+
+- HTTPS 443 listener 생성
+- HTTP 80 -> HTTPS 443 redirect 적용
+
+## 5. 가비아에 API 도메인 연결
+
+ALB DNS 이름을 확인한다.
+
+```bash
+terraform output alb_dns_name
+```
+
+가비아에서 `api.gajabike.shop` 을 위 ALB DNS 이름으로 연결한다.
+
+- 가비아 UI가 ALIAS/A 지원을 하면 그 방식 우선
+- 아니라면 provider가 허용하는 방식으로 `CNAME` 사용 여부 확인
+
+## 6. 동작 확인
+
+```bash
+curl -I http://api.gajabike.shop
+curl -I https://api.gajabike.shop/health
+curl -fsS https://api.gajabike.shop/health
+```
+
+정상 기대값:
+
+- `http://api.gajabike.shop` -> `301` or `302` redirect to HTTPS
+- `https://api.gajabike.shop/health` -> `200`
+
+## 7. 후속 변경
+
+### GitHub Actions
+
+GitHub Variables의 `HEALTHCHECK_URL` 을 다음으로 바꾼다.
+
+```text
+https://api.gajabike.shop/health
+```
+
+### Android release base URL
+
+현재 README 기준 배포 backend URL은 `http://3.35.168.38` 이다.
+release build 기준값을 아래로 전환한다.
+
+```text
+https://api.gajabike.shop
+```
+
+## 8. 적용 직후 보안 정리
+
+현재 app SG `sg-0d7393e764b0f7135` 는 `80`, `443` 이 public open 상태다.
+
+ALB 전환 후에는 app instance SG에서:
+
+- `8080` 은 ALB SG source only 허용
+- 기존 public `80`, `443` open rule 제거 검토
+
+즉 최종 형태는 **인터넷 -> ALB -> app EC2:8080** 이어야 한다.

--- a/ops/aws/alb-acm-route53/README.md
+++ b/ops/aws/alb-acm-route53/README.md
@@ -1,0 +1,63 @@
+# AWS ALB + ACM + DNS draft
+
+이 디렉터리는 `bike-back` 앞단에 **Application Load Balancer + ACM 인증서**를 두기 위한 Terraform 초안이다.
+
+## 목적
+
+- 현재 `EC2 + systemd + SSM` 구조는 유지한다.
+- 앱 공개 진입점을 `http://<public-ip>` 에서 `https://api.gajabike.shop` 같은 도메인으로 바꾼다.
+- TLS 종료는 EC2 nginx가 아니라 **ALB** 에서 처리한다.
+
+## 포함 리소스
+
+- public ALB
+- ALB security group
+- backend EC2 security group ingress rule (ALB source only)
+- instance target group
+- HTTP 80 -> HTTPS 443 redirect listener
+- HTTPS 443 forward listener
+- ACM public certificate (`DNS` validation)
+- optional Route53 validation/alias record
+
+## DNS 운영 방식
+
+### 1) 현재처럼 가비아 DNS를 유지하는 경우
+
+- `create_route53_records = false`
+- `enable_https_listener = false` 로 1차 apply
+- `terraform apply` 후 `certificate_validation_records` output을 확인한다.
+- 출력된 ACM validation CNAME을 가비아 DNS에 수동 등록한다.
+- 인증서가 `ISSUED` 되면 `enable_https_listener = true` 로 바꾸고 다시 apply 한다.
+- 그 뒤 가비아에서 `api` 서브도메인을 ALB DNS name 기준으로 연결한다.
+  - 운영 시 DNS provider 제약 때문에 `A/ALIAS` 또는 `CNAME` 구성은 실제 가비아 UI 지원 방식에 맞춘다.
+
+### 2) Route53으로 옮기는 경우
+
+- `create_route53_records = true`
+- 인증서 검증이 자동화되면 `enable_https_listener = true` 로 바로 운영값을 둘 수 있다.
+- `route53_hosted_zone_id` 입력
+- Terraform이 ACM validation record와 ALB alias record를 같이 만든다.
+
+## 적용 순서
+
+1. `terraform.tfvars.example` 를 복사해 실제 값 입력
+2. `terraform init`
+3. `terraform plan`
+4. `terraform apply`
+5. DNS validation 완료 확인
+6. `enable_https_listener = true` 로 재적용
+7. backend smoke URL을 `https://api.gajabike.shop/health` 로 전환
+8. Android release build의 API base URL을 HTTPS 도메인으로 변경
+
+## 후속 반영 포인트
+
+- GitHub Actions `HEALTHCHECK_URL` 변수 변경
+- Android `releaseApiBaseUrl` 변경
+- 필요 시 ALB access log/S3, WAF, blue-green target group 추가
+
+## 주의
+
+- 이 초안은 **단일 app EC2** 를 ALB target으로 쓰는 현재 구조 기준이다.
+- DB/Redis/observability 구조는 바꾸지 않는다.
+- 가비아 DNS를 계속 쓸 경우 Route53 alias 자동화는 적용되지 않는다.
+- 가비아 수동 DNS 흐름에서는 보통 **2단계 apply** 가 필요하다.

--- a/ops/aws/alb-acm-route53/main.tf
+++ b/ops/aws/alb-acm-route53/main.tf
@@ -1,0 +1,195 @@
+locals {
+  base_tags = merge(
+    var.tags,
+    {
+      Name = var.name_prefix
+    }
+  )
+
+  route53_enabled = var.create_route53_records && var.route53_hosted_zone_id != null && var.route53_hosted_zone_id != ""
+}
+
+resource "aws_security_group" "alb" {
+  name_prefix = "${var.name_prefix}-alb-"
+  description = "Public ALB security group"
+  vpc_id      = var.vpc_id
+
+  tags = merge(local.base_tags, {
+    Name = "${var.name_prefix}-alb-sg"
+  })
+}
+
+resource "aws_vpc_security_group_ingress_rule" "alb_http" {
+  for_each          = toset(var.alb_ingress_cidrs)
+  security_group_id = aws_security_group.alb.id
+  cidr_ipv4         = each.value
+  from_port         = 80
+  to_port           = 80
+  ip_protocol       = "tcp"
+  description       = "Allow HTTP to ALB"
+}
+
+resource "aws_vpc_security_group_ingress_rule" "alb_https" {
+  for_each          = toset(var.alb_ingress_cidrs)
+  security_group_id = aws_security_group.alb.id
+  cidr_ipv4         = each.value
+  from_port         = 443
+  to_port           = 443
+  ip_protocol       = "tcp"
+  description       = "Allow HTTPS to ALB"
+}
+
+resource "aws_vpc_security_group_egress_rule" "alb_to_app" {
+  security_group_id            = aws_security_group.alb.id
+  referenced_security_group_id = var.app_instance_security_group_id
+  from_port                    = var.app_port
+  to_port                      = var.app_port
+  ip_protocol                  = "tcp"
+  description                  = "Allow ALB to app instance"
+}
+
+resource "aws_vpc_security_group_ingress_rule" "app_from_alb" {
+  security_group_id            = var.app_instance_security_group_id
+  referenced_security_group_id = aws_security_group.alb.id
+  from_port                    = var.app_port
+  to_port                      = var.app_port
+  ip_protocol                  = "tcp"
+  description                  = "Allow ALB to reach Spring Boot app"
+}
+
+resource "aws_lb" "api" {
+  name               = substr(replace("${var.name_prefix}-alb", "/[^a-zA-Z0-9-]/", "-"), 0, 32)
+  internal           = false
+  load_balancer_type = "application"
+  security_groups    = [aws_security_group.alb.id]
+  subnets            = var.public_subnet_ids
+
+  enable_deletion_protection = false
+
+  tags = merge(local.base_tags, {
+    Name = "${var.name_prefix}-alb"
+  })
+}
+
+resource "aws_lb_target_group" "api" {
+  name        = substr(replace("${var.name_prefix}-tg", "/[^a-zA-Z0-9-]/", "-"), 0, 32)
+  port        = var.app_port
+  protocol    = "HTTP"
+  target_type = "instance"
+  vpc_id      = var.vpc_id
+
+  health_check {
+    enabled             = true
+    protocol            = "HTTP"
+    path                = var.health_check_path
+    matcher             = "200-399"
+    interval            = 30
+    timeout             = 5
+    healthy_threshold   = 2
+    unhealthy_threshold = 3
+  }
+
+  tags = merge(local.base_tags, {
+    Name = "${var.name_prefix}-tg"
+  })
+}
+
+resource "aws_lb_target_group_attachment" "app" {
+  target_group_arn = aws_lb_target_group.api.arn
+  target_id        = var.app_instance_id
+  port             = var.app_port
+}
+
+resource "aws_acm_certificate" "api" {
+  domain_name       = var.domain_name
+  validation_method = "DNS"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  tags = merge(local.base_tags, {
+    Name = "${var.name_prefix}-cert"
+  })
+}
+
+resource "aws_route53_record" "certificate_validation" {
+  for_each = local.route53_enabled ? {
+    for dvo in aws_acm_certificate.api.domain_validation_options : dvo.domain_name => {
+      name   = dvo.resource_record_name
+      record = dvo.resource_record_value
+      type   = dvo.resource_record_type
+    }
+  } : {}
+
+  zone_id = var.route53_hosted_zone_id
+  name    = each.value.name
+  type    = each.value.type
+  ttl     = 60
+  records = [each.value.record]
+}
+
+resource "aws_acm_certificate_validation" "api" {
+  count = local.route53_enabled ? 1 : 0
+
+  certificate_arn         = aws_acm_certificate.api.arn
+  validation_record_fqdns = [for record in aws_route53_record.certificate_validation : record.fqdn]
+}
+
+resource "aws_lb_listener" "http" {
+  load_balancer_arn = aws_lb.api.arn
+  port              = 80
+  protocol          = "HTTP"
+
+  dynamic "default_action" {
+    for_each = var.enable_https_listener ? [] : [1]
+
+    content {
+      type             = "forward"
+      target_group_arn = aws_lb_target_group.api.arn
+    }
+  }
+
+  dynamic "default_action" {
+    for_each = var.enable_https_listener ? [1] : []
+
+    content {
+      type = "redirect"
+
+      redirect {
+        port        = "443"
+        protocol    = "HTTPS"
+        status_code = "HTTP_301"
+      }
+    }
+  }
+}
+
+resource "aws_lb_listener" "https" {
+  count = var.enable_https_listener ? 1 : 0
+
+  load_balancer_arn = aws_lb.api.arn
+  port              = 443
+  protocol          = "HTTPS"
+  ssl_policy        = "ELBSecurityPolicy-TLS13-1-2-2021-06"
+  certificate_arn   = local.route53_enabled ? aws_acm_certificate_validation.api[0].certificate_arn : aws_acm_certificate.api.arn
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.api.arn
+  }
+}
+
+resource "aws_route53_record" "api_alias" {
+  count = local.route53_enabled ? 1 : 0
+
+  zone_id = var.route53_hosted_zone_id
+  name    = var.domain_name
+  type    = "A"
+
+  alias {
+    name                   = aws_lb.api.dns_name
+    zone_id                = aws_lb.api.zone_id
+    evaluate_target_health = true
+  }
+}

--- a/ops/aws/alb-acm-route53/outputs.tf
+++ b/ops/aws/alb-acm-route53/outputs.tf
@@ -1,0 +1,31 @@
+output "alb_dns_name" {
+  description = "Public DNS name of the ALB."
+  value       = aws_lb.api.dns_name
+}
+
+output "alb_zone_id" {
+  description = "Canonical hosted zone ID of the ALB. Useful for Route53 alias records."
+  value       = aws_lb.api.zone_id
+}
+
+output "https_endpoint" {
+  description = "Expected HTTPS API endpoint after DNS is connected."
+  value       = "https://${var.domain_name}"
+}
+
+output "certificate_validation_records" {
+  description = "DNS records that must exist for ACM validation. Use these in Gabia when Route53 automation is disabled."
+  value = [
+    for dvo in aws_acm_certificate.api.domain_validation_options : {
+      domain_name = dvo.domain_name
+      name        = dvo.resource_record_name
+      type        = dvo.resource_record_type
+      value       = dvo.resource_record_value
+    }
+  ]
+}
+
+output "route53_alias_record_fqdn" {
+  description = "Created Route53 alias FQDN when Route53 automation is enabled."
+  value       = local.route53_enabled ? aws_route53_record.api_alias[0].fqdn : null
+}

--- a/ops/aws/alb-acm-route53/providers.tf
+++ b/ops/aws/alb-acm-route53/providers.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+}

--- a/ops/aws/alb-acm-route53/terraform.tfvars.example
+++ b/ops/aws/alb-acm-route53/terraform.tfvars.example
@@ -1,0 +1,23 @@
+aws_region                    = "ap-northeast-2"
+name_prefix                   = "bike-api"
+vpc_id                        = "vpc-xxxxxxxx"
+public_subnet_ids             = ["subnet-aaaaaaa", "subnet-bbbbbbb"]
+app_instance_id               = "i-xxxxxxxxxxxxxxxxx"
+app_instance_security_group_id = "sg-xxxxxxxxxxxxxxxxx"
+domain_name                   = "api.gajabike.shop"
+health_check_path             = "/health"
+app_port                      = 8080
+
+# Keep false when DNS stays in Gabia.
+create_route53_records        = false
+route53_hosted_zone_id        = null
+
+# Step 1: false  -> create cert request + HTTP listener only
+# Step 2: true   -> after ACM ISSUED, create HTTPS listener + HTTP redirect
+enable_https_listener         = false
+
+tags = {
+  Project = "bike"
+  Env     = "prod"
+  Owner   = "bike-team"
+}

--- a/ops/aws/alb-acm-route53/variables.tf
+++ b/ops/aws/alb-acm-route53/variables.tf
@@ -1,0 +1,82 @@
+variable "aws_region" {
+  description = "AWS region for ALB/ACM resources."
+  type        = string
+  default     = "ap-northeast-2"
+}
+
+variable "name_prefix" {
+  description = "Resource name prefix."
+  type        = string
+  default     = "bike-api"
+}
+
+variable "vpc_id" {
+  description = "VPC ID where the ALB and target instance live."
+  type        = string
+}
+
+variable "public_subnet_ids" {
+  description = "At least two public subnet IDs for the internet-facing ALB."
+  type        = list(string)
+}
+
+variable "app_instance_id" {
+  description = "EC2 instance ID currently running the Spring Boot app."
+  type        = string
+}
+
+variable "app_instance_security_group_id" {
+  description = "Security group ID attached to the backend EC2 instance."
+  type        = string
+}
+
+variable "domain_name" {
+  description = "Public API domain to attach to the ALB, e.g. api.gajabike.shop."
+  type        = string
+}
+
+variable "health_check_path" {
+  description = "Application health check path exposed by Spring Boot."
+  type        = string
+  default     = "/health"
+}
+
+variable "app_port" {
+  description = "Spring Boot application port on the EC2 target."
+  type        = number
+  default     = 8080
+}
+
+variable "alb_ingress_cidrs" {
+  description = "CIDR blocks allowed to reach the public ALB."
+  type        = list(string)
+  default     = ["0.0.0.0/0"]
+}
+
+variable "create_route53_records" {
+  description = "Whether Terraform should create Route53 validation and alias records. Keep false when DNS is managed in Gabia."
+  type        = bool
+  default     = false
+}
+
+variable "enable_https_listener" {
+  description = "Create the HTTPS listener only after ACM validation is complete. Useful for Gabia/manual DNS flow."
+  type        = bool
+  default     = false
+}
+
+variable "route53_hosted_zone_id" {
+  description = "Route53 hosted zone ID. Required only when create_route53_records=true."
+  type        = string
+  default     = null
+}
+
+variable "tags" {
+  description = "Common tags for created resources."
+  type        = map(string)
+  default = {
+    Project = "bike"
+    Stack   = "api-edge"
+    Managed = "terraform-draft"
+  }
+}


### PR DESCRIPTION
## Summary
- add a Terraform draft for ALB + ACM fronting the EC2-hosted backend
- document the Gabia DNS validation and ALB cutover flow for operators
- ignore local Terraform state and verification artifacts from the repo