### PR TITLE
docs: review backend feature flows

### DIFF
--- a/docs/ai-route-generation-review-2026-06-08.md
+++ b/docs/ai-route-generation-review-2026-06-08.md
@@ -1,0 +1,120 @@
+# AI 코스 생성 기능 리뷰
+
+## 비개발자용 요약
+
+AI 코스 생성은 사용자의 현재 위치, 목적지 또는 텍스트 요청을 받아 자전거 경로 후보를 만들고, 날씨/고도/도로 근거를 붙여 추천 이유를 설명하는 기능이다.
+
+현재 구조는 다음 순서로 동작한다.
+
+1. 사용자가 REST 또는 WebSocket으로 요청한다.
+2. 서버가 로그인 사용자 quota를 확인한다.
+3. 텍스트 요청이면 내부 규칙으로 목적지/선호도를 먼저 해석한다.
+4. GraphHopper 자전거 경로를 생성한다.
+5. 경로, 날씨, 고도, 도로 근거를 점수화한다.
+6. AI worker가 가능하면 문장과 추천 설명을 보강한다.
+7. AI worker가 실패하면 서버가 만든 기본 경로 응답을 반환한다.
+
+이번 course-follow 성능 PR에서 AI 코스 생성은 최종 성능 개선 범위에 포함하지 않았다. 실제 Gemini/GraphHopper key를 넣은 smoke에서 `from-text`가 안정적으로 성공하지 못했기 때문이다. 따라서 AI 코스 생성은 "후속 안정화 대상"으로 남겼다.
+
+## 현재 API
+
+- REST 기본 요청: `POST /api/v1/ai-routes/plan`
+- REST 텍스트 요청: `POST /api/v1/ai-routes/plan/from-text`
+- WebSocket 요청: `/ws/v1/ai-routes`
+
+관련 코드:
+
+- `src/main/java/com/bikeprojectminji/bikeback/airoute/controller/AiRouteController.java`
+- `src/main/java/com/bikeprojectminji/bikeback/airoute/service/AiRoutePlannerService.java`
+- `src/main/java/com/bikeprojectminji/bikeback/airoute/service/AiRouteTextIntentResolver.java`
+- `src/main/java/com/bikeprojectminji/bikeback/airoute/service/HttpAiRouteWorkerClient.java`
+- `src/main/java/com/bikeprojectminji/bikeback/routing/infrastructure/GraphHopperBicycleRoutingClient.java`
+- `src/main/java/com/bikeprojectminji/bikeback/airoute/websocket/AiRouteWebSocketHandler.java`
+
+## 왜 지금 구조로 만들었나
+
+AI에게 처음부터 모든 결정을 맡기면 결과가 흔들린다. 그래서 서버가 먼저 자전거 경로의 뼈대를 만든다.
+
+- GraphHopper는 실제 도로 네트워크와 고도 정보를 제공한다.
+- 서버는 거리, 경사, 풍경/자전거길 근거를 점수화한다.
+- AI worker는 이 결과를 사람이 읽기 좋은 설명으로 보강한다.
+
+즉, 현재 방향은 "AI가 경로를 상상해서 만드는 방식"이 아니라 "서버가 검증 가능한 경로를 만들고 AI가 설명을 돕는 방식"이다. 포트폴리오 관점에서도 이쪽이 더 설득력 있다.
+
+## 현재 알고리즘 구조
+
+### 텍스트 해석
+
+`AiRouteTextIntentResolver`는 현재 간단한 키워드 규칙이다.
+
+- "오르막", "업힐", "산", "남산" → 남산 N서울타워, `CLIMB_FIRST`
+- "평지", "완만", "편한" → 안양천합수부, `FLAT_FIRST`
+- "강", "한강", "시원", "풍경" → 반포한강공원, `BALANCED_ELEVATION`
+- 그 외 → 현재 위치 기준 기본 추천
+
+장점:
+
+- 결과가 예측 가능하다.
+- 테스트하기 쉽다.
+- AI 실패와 무관하게 기본 응답을 만들 수 있다.
+
+한계:
+
+- 사용자의 자유 문장을 깊게 이해하지 못한다.
+- 목적지 후보가 하드코딩되어 있다.
+- "서울대입구에서 40km, 업힐 2개, 복귀 루프" 같은 복합 요구를 잘 처리하기 어렵다.
+
+### GraphHopper 경로 생성
+
+`GraphHopperBicycleRoutingClient`는 `/route`를 호출하며 다음 정보를 요청한다.
+
+- `profile=bike`
+- `points_encoded=false`
+- `elevation=true`
+- `road_class`, `road_environment`, `surface`, `smoothness`, `bike_network`
+- `average_slope`, `max_slope`
+
+이 정보는 추천 점수와 고도 요약에 쓰인다.
+
+### AI worker 보강
+
+`HttpAiRouteWorkerClient`는 `fallbackPlan`까지 포함해 AI worker에 보낸다. worker가 실패하면 `Optional.empty()`로 내려가고, 서버는 기본 plan을 그대로 반환한다.
+
+장점:
+
+- AI 서버 장애가 전체 기능 장애로 바로 번지지 않는다.
+- 서버 기본 응답으로 최소 기능을 유지한다.
+
+한계:
+
+- 실패 원인이 응답에 구체적으로 남지 않는다.
+- 현재 성능 gate에서 AI route는 안정적으로 통과하지 못했다.
+
+## 추가 개선 방향
+
+1. 텍스트 해석을 규칙 + 구조화 LLM 결과로 분리
+   - AI가 바로 경로를 만들지 말고, 먼저 `distanceRange`, `elevationPreference`, `sceneryPreference`, `avoidance`, `destinationHint` 같은 구조화 JSON만 만들게 한다.
+   - 서버는 이 JSON을 검증한 뒤 GraphHopper 후보를 생성한다.
+
+2. 후보 경로를 1개가 아니라 여러 개 생성
+   - 같은 출발지에서 `flat`, `climb`, `river`, `canonical` 후보를 각각 만든다.
+   - 점수와 이유가 다른 3~5개 후보를 사용자에게 보여준다.
+
+3. 고도 점수를 더 명확히 분리
+   - `totalAscentM`, `maxSlopePercent`, `averageSlopePercent`를 별도 점수로 둔다.
+   - "평지 원함"이면 상승고도 감점, "업힐 원함"이면 상승고도 가점처럼 정책화한다.
+
+4. 정석 코스 사전 구축
+   - 남산 국립극장 방향, 한강/안양천 합수부 같은 정석 코스를 DB seed 또는 별도 table로 관리한다.
+   - AI가 "남산"을 말하면 정석 코스 anchor를 먼저 고른 뒤 GraphHopper로 보정한다.
+
+5. AI route 전용 성능 gate 분리
+   - course/free 100VU와 섞지 말고 AI route만 별도 k6 시나리오로 측정한다.
+   - GraphHopper warm-up, AI worker timeout, 실패율, p95/p99를 따로 관리한다.
+
+## 리스크
+
+- WebSocket은 인증은 걸려 있지만 allowed origin이 `*`다. 실제 배포에서는 프론트 도메인으로 제한하는 것이 좋다.
+- `from-text`는 아직 최종 안정화 증거가 없다.
+- GraphHopper CPU가 높아 AI route p99를 끌어올릴 수 있다.
+- 텍스트 해석이 현재 하드코딩 규칙이라 확장성이 낮다.

--- a/docs/backend-architecture-db-websocket-review-2026-06-08.md
+++ b/docs/backend-architecture-db-websocket-review-2026-06-08.md
@@ -1,0 +1,190 @@
+# 백엔드 아키텍처, DB, WebSocket 리뷰
+
+## 비개발자용 요약
+
+현재 백엔드는 기능별 책임이 비교적 잘 나뉘어 있다.
+
+- Controller: HTTP/WebSocket 요청을 받는다.
+- Service: 실제 업무 흐름을 처리한다.
+- Repository: DB 조회/저장을 담당한다.
+- Entity: DB에 저장되는 데이터 구조다.
+- 외부 연동: GraphHopper, AI worker, weather, Redis 같은 외부 시스템은 별도 client/store로 분리되어 있다.
+
+이번 리뷰에서 큰 방향은 좋다고 판단했다. 다만 다음 개선 여지가 있다.
+
+- 큰 Service 파일을 더 작은 책임으로 나누는 것이 좋다.
+- 일부 쿼리는 데이터가 많아지면 N+1처럼 느려질 수 있다.
+- WebSocket origin 제한을 운영 도메인 기준으로 좁히는 것이 좋다.
+- in-memory cache는 서버 여러 대 운영 시 한계가 있다.
+- async finalization은 장애 복구까지 고려하면 queue 기반으로 발전시키는 것이 좋다.
+
+## WebSocket은 어디서 쓰나
+
+현재 WebSocket은 AI 코스 생성에서만 사용한다.
+
+- 설정: `src/main/java/com/bikeprojectminji/bikeback/airoute/websocket/AiRouteWebSocketConfig.java`
+- 핸들러: `src/main/java/com/bikeprojectminji/bikeback/airoute/websocket/AiRouteWebSocketHandler.java`
+- 경로: `/ws/v1/ai-routes`
+- 테스트: `src/test/java/com/bikeprojectminji/bikeback/airoute/contract/AiRouteContractSmokeTest.java`
+
+동작 방식:
+
+1. 클라이언트가 WebSocket 연결을 연다.
+2. 서버가 `accepted` 메시지를 보낸다.
+3. 클라이언트가 `AiRoutePlanRequest` JSON을 보낸다.
+4. 서버가 quota를 확인한다.
+5. `AiRoutePlannerService.plan()`을 호출한다.
+6. 성공하면 `{ "type": "plan", "data": ... }`를 보낸다.
+7. 실패하면 `{ "type": "error", ... }`를 보낸다.
+8. 연결을 닫는다.
+
+주의:
+
+- 이 WebSocket은 계속 스트리밍하는 구조가 아니라 "한 번 요청하고 한 번 응답한 뒤 닫는 구조"다.
+- `SecurityConfig`에서 `/ws/v1/ai-routes/**`는 authenticated로 되어 있다.
+- `AiRouteWebSocketConfig`의 allowed origin은 `*`다. 운영에서는 프론트 도메인으로 제한하는 것이 좋다.
+
+## N+1 문제 리뷰
+
+전형적인 JPA N+1은 "부모 목록 조회 후 각 부모의 lazy child를 하나씩 조회"할 때 생긴다. 현재 코드는 대부분 JPA 연관관계를 쓰지 않고 `courseId`, `rideRecordId`, `ownerUserId` 같은 id 필드로 직접 조회한다. 그래서 전형적인 lazy loading N+1 위험은 낮다.
+
+다만 아래는 데이터가 커지면 N+1과 비슷한 성능 문제가 될 수 있다.
+
+### 1. featured course 거리 조회
+
+위치 기반 추천 코스 조회에서 native query로 course id를 찾은 뒤 `entityManager.find()`를 반복한다.
+
+관련 코드:
+
+- `src/main/java/com/bikeprojectminji/bikeback/course/repository/CourseRepositoryImpl.java`
+
+현재 limit은 3이라 위험은 낮다. 하지만 추천 개수를 늘리면 `N개 id 조회 + N번 entity 조회`가 된다.
+
+개선 방향:
+
+- native query에서 필요한 목록 응답 필드를 바로 projection으로 가져온다.
+- 또는 `where id in (...)` 한 번으로 course를 묶어 조회한다.
+
+### 2. 업적 지급 exists 반복
+
+코스 완료 후 업적 후보별로 `exists` 확인 후 저장한다.
+
+관련 코드:
+
+- `src/main/java/com/bikeprojectminji/bikeback/achievement/service/AchievementService.java`
+
+현재 후보가 최대 3개 정도라 문제는 작다. 하지만 업적 종류가 많아지면 반복 쿼리가 늘어난다.
+
+개선 방향:
+
+- 현재 사용자/업적 타입의 기존 grant를 한 번에 조회한다.
+- PostgreSQL `ON CONFLICT DO NOTHING` 방식으로 중복을 DB에 맡긴다.
+
+### 3. profile/activity summary 집계
+
+`RideRecordRepository`에는 count/sum 쿼리가 여러 개 있다. 각 API에서 여러 집계를 따로 호출하면 쿼리 수가 늘 수 있다.
+
+개선 방향:
+
+- activity summary 전용 projection query로 count/sum을 한 번에 묶는다.
+- weekly/overall이 자주 호출되면 materialized summary table을 검토한다.
+
+## 락과 트랜잭션 리뷰
+
+### 잘 된 부분
+
+1. 자유주행 finalization
+   - `findByIdForUpdate`로 같은 rideRecordId의 동시 처리를 막는다.
+   - READY 상태는 skip한다.
+   - 실패 상태 기록은 별도 `REQUIRES_NEW`로 남긴다.
+
+2. 코스 생성 후 업적 부여
+   - 코스 저장 트랜잭션 commit 이후 async로 실행한다.
+   - 사용자 응답 경로에서 부가 작업을 분리했다.
+
+3. 코스 route point 교체
+   - route point 변경 후 cache evict와 route geometry refresh를 같이 수행한다.
+
+### 추가 확인이 필요한 부분
+
+1. `resolveNextDisplayOrder`
+   - 새 코스 생성 시 현재 최대 displayOrder를 읽고 +1 한다.
+   - 동시에 여러 사용자가 코스를 만들면 같은 displayOrder가 생길 수 있다.
+   - 현재 displayOrder가 unique가 아니라면 기능상 큰 문제는 아닐 수 있지만, 정렬 안정성이 중요하면 sequence 또는 createdAt/id 정렬로 단순화하는 편이 좋다.
+
+2. course route point update
+   - `deleteByCourseId` 후 `saveAll` 구조다.
+   - 같은 courseId를 동시에 수정하면 마지막 writer가 이긴다.
+   - 운영에서 동시 수정 가능성이 있으면 course row lock 또는 optimistic version column이 필요하다.
+
+3. WebSocket quota
+   - REST와 WebSocket 모두 quota를 확인한다.
+   - 다만 WebSocket subject가 없으면 빈 문자열로 quota 확인이 들어갈 수 있다. Security가 인증을 막는 것이 전제다.
+
+## DB 설계 리뷰
+
+좋은 점:
+
+- `course_route_points(course_id, point_order)` 인덱스가 있다.
+- `ride_record_points(ride_record_id, point_order)` 인덱스가 있다.
+- processed point에는 unique index가 있어 중복을 DB가 막는다.
+- `client_ride_id` unique index로 앱 재전송 중복 저장을 막는다.
+- PostGIS geometry와 GiST index가 있어 위치 기반 추천 코스 확장성이 있다.
+
+개선 후보:
+
+1. 상태 컬럼 enum 명확화
+   - `ride_records.finalization_status`는 DB에서는 varchar, entity에서는 String이다.
+   - Java entity에서 enum mapping을 쓰면 잘못된 문자열 상태를 더 일찍 막을 수 있다.
+
+2. owner/status/endedAt 복합 인덱스
+   - ride list와 activity summary는 owner, status, endedAt 기준 조회가 많다.
+   - 현재 owner 기반 인덱스는 있지만 summary 쿼리까지 최적화하려면 `(owner_user_id, finalization_status, ended_at)` 인덱스를 검토할 수 있다.
+
+3. public course listing 인덱스
+   - public + report_hidden + display_order/id 정렬 조회가 많다.
+   - `(visibility, report_hidden, display_order, id)` 인덱스를 검토할 수 있다.
+
+4. route snapshot cache table
+   - route-points 응답이 계속 커지면 DB에서 매번 point rows를 읽는 대신 encoded polyline 또는 JSON snapshot table을 둘 수 있다.
+
+## 큰 파일/책임 분리 리뷰
+
+순수 LOC 기준으로 큰 파일이 있다.
+
+- `CourseService`: 약 445 LOC
+- `RidePolicyService`: 약 558 LOC
+- `ops/loadtest/run-aws-compose-k6.sh`: 약 394 LOC
+
+이 파일들이 지금 당장 장애를 일으키는 것은 아니다. 하지만 기능이 계속 붙으면 읽기 어렵고 테스트가 커진다.
+
+추천 분리:
+
+- `CourseReadService`: 목록, 상세, 다운로드, 검색
+- `CourseWriteService`: 생성, 수정, 공개범위, 공유
+- `FeaturedCourseService`: 추천 코스 거리 계산
+- `PreStartPolicy`: 출발 가능 판단
+- `OffRoutePolicy`: 경로 이탈 판단
+- `CompletionPolicy`: 완주 판단
+- `ProgressCalculator`: 진행률 계산
+- AWS runner는 `package`, `ec2`, `remote-run`, `evidence` 함수군 또는 별도 shell script로 분리
+
+## 향후 우선순위
+
+1. AI route 안정화
+   - `from-text` 성공률, GraphHopper warm-up, AI worker timeout, 실패 reason metric부터 잡는다.
+
+2. RidePolicyService 분리
+   - 기능은 그대로 두고 정책 계산 클래스를 나눈다.
+   - 테스트를 policy별로 나누면 유지보수가 쉬워진다.
+
+3. course route snapshot 다중 서버 전략
+   - Redis 또는 DB snapshot cache를 검토한다.
+
+4. DB 인덱스 보강
+   - 실제 slow query log 또는 `EXPLAIN ANALYZE`로 owner/status/endedAt, visibility/reportHidden/displayOrder 인덱스 효과를 확인한다.
+
+5. WebSocket 운영 보안
+   - allowed origin 제한
+   - 인증 실패 테스트 추가
+   - 필요하면 WebSocket도 REST와 같은 error code 체계로 정리

--- a/docs/backend-review-index-2026-06-08.md
+++ b/docs/backend-review-index-2026-06-08.md
@@ -1,0 +1,20 @@
+# 2026-06-08 백엔드 기능/아키텍처 리뷰 색인
+
+이번 리뷰는 세 가지 사용자 기능과 전체 백엔드 구조를 분리해서 남겼다.
+
+## 기능별 문서
+
+- AI 코스 생성: `docs/ai-route-generation-review-2026-06-08.md`
+- 코스 따라가기: `docs/course-follow-review-2026-06-08.md`
+- 자유주행모드: `docs/free-ride-mode-review-2026-06-08.md`
+
+## 전체 구조 리뷰
+
+- 아키텍처, DB, N+1, 락, WebSocket 리뷰: `docs/backend-architecture-db-websocket-review-2026-06-08.md`
+
+## 짧은 결론
+
+- 이번에 성능 개선이 확실히 검증된 범위는 코스 따라가기와 자유주행모드다.
+- AI 코스 생성은 GraphHopper/고도/AI worker 구조가 연결되어 있지만, `from-text` 안정화와 AI route 전용 부하테스트가 후속으로 필요하다.
+- WebSocket은 현재 AI 코스 생성 전용 `/ws/v1/ai-routes`에서 사용한다.
+- 전형적인 JPA lazy loading N+1 위험은 낮지만, 일부 반복 조회와 큰 서비스 파일은 개선 후보로 남아 있다.

--- a/docs/course-follow-review-2026-06-08.md
+++ b/docs/course-follow-review-2026-06-08.md
@@ -1,0 +1,102 @@
+# 코스 따라가기 기능 리뷰
+
+## 비개발자용 요약
+
+코스 따라가기는 사용자가 저장된 코스를 선택하고, 현재 위치가 코스 위에 있는지, 출발 가능한지, 경로를 벗어났는지, 완주 조건을 만족했는지 판단하는 기능이다.
+
+이번 성능 개선에서 가장 크게 빨라진 부분이 이 기능이다.
+
+- 코스 경로점 조회 p95: `3003.64ms -> 431.05ms`
+- EC2 course-follow p95: `19823.79ms -> 2938.27ms`
+- EC2 course-follow p99: `33603.90ms -> 4369.44ms`
+
+쉽게 말하면, "코스를 따라갈 때 서버가 경로 데이터를 읽고 판단하는 시간이 크게 줄었다."
+
+## 현재 API
+
+- 코스 상세: `GET /api/v1/courses/{courseId}`
+- 경로점 조회: `GET /api/v1/courses/{courseId}/route-points`
+- 코스 다운로드: `GET /api/v1/courses/{courseId}/download`
+- 주행 정책 판단: `POST /api/v1/courses/{courseId}/ride-policy/evaluate`
+
+관련 코드:
+
+- `src/main/java/com/bikeprojectminji/bikeback/course/service/CourseService.java`
+- `src/main/java/com/bikeprojectminji/bikeback/course/service/CourseRouteSnapshotService.java`
+- `src/main/java/com/bikeprojectminji/bikeback/ride/policy/service/RidePolicyService.java`
+- `src/main/java/com/bikeprojectminji/bikeback/ride/policy/service/RouteProjectionIndex.java`
+- `src/main/java/com/bikeprojectminji/bikeback/course/repository/CourseRoutePointRepository.java`
+
+## 이번에 개선한 방식
+
+### 1. 경로점 snapshot cache
+
+기존에는 route-points cache miss 시 여러 요청이 한 줄로 대기했다. 특히 서로 다른 코스를 읽는 요청까지 같은 lock에 묶이면 100명 부하에서 느린 요청이 길게 늘어진다.
+
+개선 후에는 `courseId`별로 cache miss 계산을 분리했다.
+
+- 같은 코스의 첫 조회는 한 번만 DB에서 읽는다.
+- 다른 코스 조회는 서로 기다리지 않는다.
+- route-points 응답용 DTO와 ride-policy 계산용 `RouteProjectionIndex`를 한 snapshot에 같이 담는다.
+
+왜 이렇게 했나:
+
+- Redis 같은 외부 캐시를 붙이면 운영 복잡도가 커진다.
+- 현재 병목은 "전역 lock"이었기 때문에, 단일 JVM in-memory cache를 개선하는 것이 가장 작고 빠른 해결책이었다.
+
+### 2. 주행 정책 계산용 index 재사용
+
+`RidePolicyService`는 현재 위치를 코스 선분에 투영해서 다음을 판단한다.
+
+- 출발점 50m 이내인지
+- ACTIVE 상태에서 경로 이탈인지
+- 완주율이 80% 이상인지
+- 루프 코스인지, 도착형 코스인지
+
+이 계산은 코스 경로점 전체를 여러 번 훑을 수 있다. 그래서 `RouteProjectionIndex`를 snapshot으로 만들어 재사용한다.
+
+## 현재 알고리즘 구조
+
+### 출발 전 PRE_START
+
+- 현재 위치와 코스 시작점 거리를 계산한다.
+- 50m 이내면 시작 가능.
+- 그 이상이면 시작 불가.
+
+### 주행 중 ACTIVE
+
+- 위치 정확도가 낮거나 오래된 위치면 판단 보류.
+- trace를 시간순으로 정렬한다.
+- 각 위치를 경로 선분에 투영한다.
+- 경로에서 50m 이상 벗어나면 candidate.
+- 15초 이상 지속되면 warning.
+- 30m 이내로 돌아오면 recovered.
+- 전체 경로 중 지나간 비율이 80% 이상이고, 도착점 또는 루프 시작점 조건을 만족하면 완주 가능.
+
+## 추가 개선 방향
+
+1. `RidePolicyService` 책임 분리
+   - 현재 파일은 순수 LOC 기준 250줄을 넘는다.
+   - `PreStartPolicy`, `OffRoutePolicy`, `CompletionPolicy`, `ProgressCalculator`로 나누면 테스트와 수정이 쉬워진다.
+
+2. 경로 index 계산 최적화
+   - 현재 `RouteProjectionIndex`는 preferred segment 주변 window를 먼저 보고, 필요하면 전체 segment를 훑는다.
+   - 코스 경로점이 수천 개로 커지면 R-tree, grid index, geohash bucket 같은 공간 index를 검토할 수 있다.
+
+3. 다중 서버 cache 전략
+   - 현재 cache는 한 서버 JVM 안에서만 유효하다.
+   - 서버가 여러 대로 늘면 Redis cache 또는 DB materialized snapshot 전략이 필요하다.
+
+4. route-points 응답 압축
+   - 경로점이 많아지면 응답 크기 자체가 병목이 된다.
+   - polyline encoding, zoom-level simplification, paging 또는 chunk download를 검토할 수 있다.
+
+5. 권한과 공개 정책 명확화
+   - ride-policy evaluate는 현재 public permit이다.
+   - private/unlisted 접근은 service에서 shareToken/owner 정책으로 막지만, 운영 문서에는 public endpoint라는 점을 명확히 적어야 한다.
+
+## 남은 리스크
+
+- in-memory cache는 서버 재시작 시 비워진다.
+- route point가 수정되면 evict가 필요하다. 현재 create/update에서는 evict가 들어가 있지만, future bulk job이 생기면 같이 챙겨야 한다.
+- `CourseService`와 `RidePolicyService`가 큰 파일이라 기능 추가가 계속되면 구조가 복잡해질 수 있다.

--- a/docs/free-ride-mode-review-2026-06-08.md
+++ b/docs/free-ride-mode-review-2026-06-08.md
@@ -1,0 +1,122 @@
+# 자유주행모드 기능 리뷰
+
+## 비개발자용 요약
+
+자유주행모드는 사용자가 앱에서 자유롭게 주행한 GPS 기록을 서버에 저장하는 기능이다. 저장된 원본 GPS는 그대로 두고, 서버가 한 번 더 정리한 최종 경로를 만든다. 이 최종 경로는 나중에 코스로 저장할 때 사용된다.
+
+이번 개선에서 자유주행모드는 "속도 개선"보다 "데이터가 꼬이지 않게 하는 안정성 개선"이 핵심이었다.
+
+기존 문제:
+
+- 저장 직후 후처리와 재처리가 동시에 들어오면 같은 processed point를 중복 insert할 수 있었다.
+- 이때 `duplicate key`, `UnexpectedRollbackException`이 발생했다.
+
+개선 결과:
+
+- before error scan에서는 중복키/rollback 오류가 있었다.
+- after error scan은 비어 있었다.
+- course/free 100명 부하에서 HTTP failure 0%로 통과했다.
+
+## 현재 API
+
+- 주행 기록 저장: `POST /api/v1/ride-records`
+- 주행 기록 목록: `GET /api/v1/ride-records`
+- 후처리 상태 조회: `GET /api/v1/ride-records/{rideRecordId}`
+- 후처리 재요청: `POST /api/v1/ride-records/{rideRecordId}/regenerate`
+
+관련 코드:
+
+- `src/main/java/com/bikeprojectminji/bikeback/ride/service/RideRecordService.java`
+- `src/main/java/com/bikeprojectminji/bikeback/ride/service/RideRecordFinalizationService.java`
+- `src/main/java/com/bikeprojectminji/bikeback/ride/service/RideRecordFinalizationProcessor.java`
+- `src/main/java/com/bikeprojectminji/bikeback/ride/service/RideRecordFinalizationWriter.java`
+- `src/main/java/com/bikeprojectminji/bikeback/ride/service/RideRecordFinalizationFailureService.java`
+- `src/main/java/com/bikeprojectminji/bikeback/ride/repository/RideRecordRepository.java`
+
+## 현재 저장 흐름
+
+1. 요청 검증
+   - 시작/종료 시각
+   - 거리/시간
+   - GPS 포인트
+   - pointOrder 중복 여부
+   - 좌표 범위
+
+2. 사용자 확인
+   - JWT subject로 현재 사용자 조회
+
+3. 중복 저장 방지
+   - `clientRideId`가 있으면 같은 사용자/같은 clientRideId 기록을 다시 만들지 않는다.
+
+4. raw point 저장
+   - `ride_records`
+   - `ride_record_points`
+
+5. commit 이후 async finalization 요청
+   - 원본 저장 트랜잭션이 성공한 뒤에만 후처리를 시작한다.
+
+6. processed point 생성
+   - raw point를 canonicalize한다.
+   - 기존 processed point 삭제 후 flush한다.
+   - 새 processed point를 저장한다.
+   - 상태를 READY로 바꾼다.
+
+## 이번에 개선한 방식
+
+### 1. row lock으로 같은 주행 기록 동시 처리 방지
+
+`RideRecordRepository.findByIdForUpdate`가 `PESSIMISTIC_WRITE` lock을 건다.
+
+쉽게 말하면, 같은 rideRecordId를 두 작업자가 동시에 수정하려고 하면 한 명씩 줄 세운다.
+
+왜 이렇게 했나:
+
+- processed point는 `(ride_record_id, point_order)`가 unique다.
+- 두 작업자가 동시에 insert하면 같은 번호를 중복 저장하려고 한다.
+- DB row lock으로 상태 전이와 processed point 교체 순서를 고정해야 한다.
+
+### 2. READY 상태면 skip
+
+이미 READY인 기록은 finalization worker가 다시 처리하지 않는다.
+
+왜 이렇게 했나:
+
+- 이미 최종 경로가 준비된 기록을 다시 건드리면 불필요한 delete/insert가 생긴다.
+- 부하 상황에서는 이 중복 작업이 DB lock과 pool을 더 압박한다.
+
+### 3. 실패 처리 트랜잭션 분리
+
+processed point 교체 중 실패하면 교체 트랜잭션은 rollback된다. 실패 상태 기록은 별도 `REQUIRES_NEW` 트랜잭션에서 저장한다.
+
+왜 이렇게 했나:
+
+- 실패했는데 기존 processed point까지 지워지면 사용자가 이전 정상 경로를 잃는다.
+- 실패 상태는 남겨야 운영자가 원인을 볼 수 있다.
+
+## 추가 개선 방향
+
+1. finalization job queue 도입
+   - 현재는 Spring `@Async`로 바로 실행한다.
+   - 작업량이 커지면 DB 기반 queue, Redis queue, 또는 message queue로 전환할 수 있다.
+
+2. processed point upsert 전략 검토
+   - 지금은 delete + flush + insert다.
+   - PostgreSQL `ON CONFLICT` 기반 upsert 또는 temp table 교체 방식이 더 빠를 수 있다.
+
+3. canonicalizer 고도화
+   - 현재는 raw GPS를 정리하는 단계다.
+   - 향후 GraphHopper map matching 또는 snapping을 붙이면 실제 도로에 더 가까운 경로가 된다.
+
+4. 상태 전이 enum 저장 개선
+   - 현재 entity 내부 필드는 String이고 getter에서 enum으로 변환한다.
+   - JPA `@Enumerated(EnumType.STRING)`으로 명확히 바꿀 수 있다.
+
+5. 대량 삭제 성능
+   - 회원 탈퇴나 대량 정리 시 point 삭제가 커질 수 있다.
+   - FK cascade와 bulk delete 전략을 더 명확히 정리하면 좋다.
+
+## 남은 리스크
+
+- `@Async`는 process 내부 실행이라 서버 재시작 중인 작업 복구가 어렵다.
+- finalization 실패가 반복될 때 retry/backoff 정책이 아직 명확하지 않다.
+- processed point 생성은 DB 쓰기량이 많다. 포인트 수가 커지면 batch size와 DB pool 설정이 중요해진다.


### PR DESCRIPTION
## Summary

AI 코스 생성, 코스 따라가기, 자유주행모드, 전체 백엔드 아키텍처/DB/WebSocket 리뷰 문서를 추가했습니다.

## Documents

- `docs/backend-review-index-2026-06-08.md`
- `docs/ai-route-generation-review-2026-06-08.md`
- `docs/course-follow-review-2026-06-08.md`
- `docs/free-ride-mode-review-2026-06-08.md`
- `docs/backend-architecture-db-websocket-review-2026-06-08.md`

## Covered

- 이번에 실제 개선/검증된 범위와 AI route 미완료 범위 구분
- 각 기능의 현재 API, 코드 위치, 처리 흐름
- 왜 그런 방식으로 개선했는지
- 알고리즘/코드 추가 개선 방향
- N+1 후보, 락/트랜잭션 리스크, DB 인덱스 개선 후보
- WebSocket 사용 위치와 운영 보안 주의점

## Verification

- `git diff --cached --check` before commit: pass
- Docs only; no production code changed
