### PR TITLE
웹 HUD 베타 삭제 정책과 라우팅 품질 메타데이터 추가

### DIFF
--- a/docs/web-hud-retention-fallback-release-report-2026-06-15.md
+++ b/docs/web-hud-retention-fallback-release-report-2026-06-15.md
@@ -1,0 +1,67 @@
+# 웹 HUD/주행기록 보존/라우팅 품질 마무리 보고서
+
+작성일: 2026-06-15
+
+## 목표
+
+- 웹 테스트 콘솔에서 게스트도 AI 코스 생성, HUD 경로 표시, GPX/주행 저장 흐름을 확인할 수 있게 한다.
+- 주행기록은 사용자가 직접 삭제할 수 있고, 30일 보존 정책에 따라 만료 데이터를 정리한다.
+- GraphHopper 또는 라우팅 provider fallback 여부와 경로 품질 상태를 응답에 드러낸다.
+- 로컬 기준 성능 목표를 통과한다.
+
+## 구현 요약
+
+- `DELETE /api/v1/ride-records/{rideRecordId}`를 추가했다.
+  - 본인 주행기록만 삭제한다.
+  - 주행 원본 점, 보정 점, 연결된 Course source 참조를 함께 정리한다.
+- 30일 지난 주행기록 정리 스케줄러를 추가했다.
+  - 기본 cron: `0 20 3 * * *`
+  - 기준 시각은 `Clock` bean으로 주입해 테스트 가능하게 했다.
+- 라우팅 결과에 품질/폴백 메타데이터를 추가했다.
+  - provider, fallback 사용 여부, fallback 사유, 품질 상태, 품질 메시지를 응답에 포함한다.
+  - 고도 정보가 없으면 실패로 숨기지 않고 `VALID_WITH_WARNINGS`로 표시한다.
+- 로컬 성능 검증용 fake weather provider를 추가했다.
+  - 외부 Open-Meteo 지연이 로컬 API 성능 검증을 흔들지 않게 분리했다.
+- 로컬 웹 콘솔 CORS를 허용했다.
+  - 기본 허용 origin: `http://127.0.0.1:8081`, `http://localhost:8081`
+  - 운영/배포 시 `APP_CORS_ALLOWED_ORIGINS`로 변경한다.
+
+## 성능 결과
+
+환경:
+
+- Backend: `http://127.0.0.1:8080`
+- DB: local Docker PostgreSQL `bike_perf`
+- Redis: local Docker Redis
+- Routing/weather: fake provider
+- 측정 도구: k6
+
+| 시나리오 | 목표 | 결과 |
+| --- | ---: | ---: |
+| 일반 API 50명 혼합 p95 | 300ms 이하 | 16.15ms |
+| 코스 목록/지도 조회 p95 | 200ms 이하 | course-read 16.51ms |
+| route-points 조회 p95 | 300ms 이하 | 15.78ms |
+| weather 조회 p95 | 300ms 이하 | 16.02ms |
+| ride-policy p95 | 300ms 이하 | 15.98ms |
+| AI 코스 생성 50명 동시 p95 | 10초 이하 | 116.96ms |
+| 에러율 | 1% 이하 | 0% |
+
+증거 파일:
+
+- `ops/loadtest/results/local-p6-mixed-50-final-20260615-summary.json`
+- `ops/loadtest/results/local-ai-public-50-final-20260615-summary.json`
+
+## 웹 QA 결과
+
+- `http://127.0.0.1:8081`에서 웹 콘솔을 실행했다.
+- API Base를 `http://127.0.0.1:8080`으로 설정했다.
+- 게스트 데모 버튼으로 고정 경로가 HUD와 지도에 표시됨을 확인했다.
+- 토큰 없는 상태에서 텍스트 코스 생성을 실행했고, 공개 API `/api/v1/ai-routes/plan/from-text`가 성공했다.
+- HUD에 route points, route km, score, elevation, routing metadata가 표시됐다.
+- 브라우저 콘솔 error는 0건이었다.
+
+## 남은 리스크
+
+- 이번 로컬 성능 검증은 fake routing/weather 기준이다. 실제 GraphHopper self-host와 외부 AI worker를 켠 운영형 검증은 별도 EC2/비용 계획에 맞춰 다시 측정해야 한다.
+- 웹 콘솔은 현재 별도 git repo가 아니므로 백엔드 PR에는 포함되지 않는다.
+- Vite 번들 크기 경고가 남아 있다. MapLibre/Turf를 lazy import하면 첫 로드 비용을 더 낮출 수 있다.

--- a/src/main/java/com/bikeprojectminji/bikeback/BikeBackApplication.java
+++ b/src/main/java/com/bikeprojectminji/bikeback/BikeBackApplication.java
@@ -3,9 +3,11 @@ package com.bikeprojectminji.bikeback;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableAsync
+@EnableScheduling
 public class BikeBackApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/bikeprojectminji/bikeback/airoute/dto/AiRoutePlanResponse.java
+++ b/src/main/java/com/bikeprojectminji/bikeback/airoute/dto/AiRoutePlanResponse.java
@@ -19,7 +19,8 @@ public record AiRoutePlanResponse(
         RecommendationExplanationResponse explanation,
         List<ProviderEvidenceBadgeResponse> evidenceBadges,
         boolean aiGenerated,
-        AiRouteElevationSummaryResponse elevationSummary
+        AiRouteElevationSummaryResponse elevationSummary,
+        AiRouteRoutingMetadataResponse routingMetadata
 ) {
 
     public AiRoutePlanResponse(
@@ -53,6 +54,44 @@ public record AiRoutePlanResponse(
                 explanation,
                 evidenceBadges,
                 aiGenerated,
+                null,
+                null
+        );
+    }
+
+    public AiRoutePlanResponse(
+            String planId,
+            String status,
+            String summary,
+            String confidence,
+            WeatherData weather,
+            WindData wind,
+            List<AiRoutePointResponse> routePoints,
+            List<AiRouteRiskResponse> risks,
+            List<String> actions,
+            int recommendationScore,
+            RecommendationScoreResponse scoreBreakdown,
+            RecommendationExplanationResponse explanation,
+            List<ProviderEvidenceBadgeResponse> evidenceBadges,
+            boolean aiGenerated,
+            AiRouteElevationSummaryResponse elevationSummary
+    ) {
+        this(
+                planId,
+                status,
+                summary,
+                confidence,
+                weather,
+                wind,
+                routePoints,
+                risks,
+                actions,
+                recommendationScore,
+                scoreBreakdown,
+                explanation,
+                evidenceBadges,
+                aiGenerated,
+                elevationSummary,
                 null
         );
     }

--- a/src/main/java/com/bikeprojectminji/bikeback/airoute/dto/AiRouteRoutingMetadataResponse.java
+++ b/src/main/java/com/bikeprojectminji/bikeback/airoute/dto/AiRouteRoutingMetadataResponse.java
@@ -1,0 +1,27 @@
+package com.bikeprojectminji.bikeback.airoute.dto;
+
+import com.bikeprojectminji.bikeback.routing.service.BicycleRoutePlan;
+
+public record AiRouteRoutingMetadataResponse(
+        String routingStatus,
+        String provider,
+        boolean fallbackUsed,
+        String fallbackReason,
+        String qualityStatus,
+        String qualityMessage
+) {
+
+    public static AiRouteRoutingMetadataResponse from(BicycleRoutePlan routePlan) {
+        if (routePlan == null) {
+            return null;
+        }
+        return new AiRouteRoutingMetadataResponse(
+                routePlan.status(),
+                routePlan.provider(),
+                routePlan.fallbackUsed(),
+                routePlan.fallbackReason(),
+                routePlan.qualityStatus(),
+                routePlan.qualityMessage()
+        );
+    }
+}

--- a/src/main/java/com/bikeprojectminji/bikeback/airoute/service/AiRoutePlanComposer.java
+++ b/src/main/java/com/bikeprojectminji/bikeback/airoute/service/AiRoutePlanComposer.java
@@ -5,8 +5,10 @@ import com.bikeprojectminji.bikeback.airoute.dto.AiRoutePlanResponse;
 import com.bikeprojectminji.bikeback.airoute.dto.AiRouteElevationSummaryResponse;
 import com.bikeprojectminji.bikeback.airoute.dto.AiRoutePointResponse;
 import com.bikeprojectminji.bikeback.airoute.dto.AiRouteRiskResponse;
+import com.bikeprojectminji.bikeback.airoute.dto.AiRouteRoutingMetadataResponse;
 import com.bikeprojectminji.bikeback.airoute.dto.ProviderEvidenceBadgeResponse;
 import com.bikeprojectminji.bikeback.routing.service.BicycleRouteCandidate;
+import com.bikeprojectminji.bikeback.routing.service.BicycleRoutePlan;
 import com.bikeprojectminji.bikeback.routing.service.ElevationSummary;
 import com.bikeprojectminji.bikeback.weather.dto.CurrentWeatherResponse;
 import com.bikeprojectminji.bikeback.weather.dto.WeatherData;
@@ -70,6 +72,15 @@ public class AiRoutePlanComposer {
             AiRouteConditionContext context,
             BicycleRouteCandidate candidate
     ) {
+        return composeWithRouteCandidate(request, context, candidate, null);
+    }
+
+    public AiRoutePlanResponse composeWithRouteCandidate(
+            AiRoutePlanRequest request,
+            AiRouteConditionContext context,
+            BicycleRouteCandidate candidate,
+            BicycleRoutePlan routePlan
+    ) {
         Optional<CurrentWeatherResponse> weather = context.weather();
         List<AiRouteRiskResponse> risks = detailsFactory.buildRisks(weather, context);
         List<ProviderEvidenceBadgeResponse> evidenceBadges = detailsFactory.buildEvidenceBadges(weather, context);
@@ -105,7 +116,8 @@ public class AiRoutePlanComposer {
                 detailsFactory.buildExplanation(request, score, evidenceBadges),
                 evidenceBadges,
                 false,
-                toElevationSummaryResponse(candidate.elevationSummary())
+                toElevationSummaryResponse(candidate.elevationSummary()),
+                AiRouteRoutingMetadataResponse.from(routePlan)
         );
     }
 

--- a/src/main/java/com/bikeprojectminji/bikeback/airoute/service/AiRoutePlannerService.java
+++ b/src/main/java/com/bikeprojectminji/bikeback/airoute/service/AiRoutePlannerService.java
@@ -127,7 +127,8 @@ public class AiRoutePlannerService {
         return Optional.of(aiRoutePlanComposer.composeWithRouteCandidate(
                 request,
                 context,
-                routePlan.candidates().get(0)
+                routePlan.candidates().get(0),
+                routePlan
         ));
     }
 

--- a/src/main/java/com/bikeprojectminji/bikeback/course/entity/CourseEntity.java
+++ b/src/main/java/com/bikeprojectminji/bikeback/course/entity/CourseEntity.java
@@ -196,6 +196,10 @@ public class CourseEntity {
         this.shareToken = null;
     }
 
+    public void detachRideRecordSource() {
+        this.sourceRideRecordId = null;
+    }
+
     public Long getId() {
         return id;
     }

--- a/src/main/java/com/bikeprojectminji/bikeback/course/repository/CourseRepository.java
+++ b/src/main/java/com/bikeprojectminji/bikeback/course/repository/CourseRepository.java
@@ -22,6 +22,8 @@ public interface CourseRepository extends JpaRepository<CourseEntity, Long>, Cou
 
     List<CourseEntity> findByOwnerUserIdAndSourceRideRecordIdIn(Long ownerUserId, List<Long> sourceRideRecordIds);
 
+    List<CourseEntity> findBySourceRideRecordIdIn(List<Long> sourceRideRecordIds);
+
     List<CourseEntity> findTop20ByVisibilityAndReportHiddenFalseOrderByIdDesc(CourseVisibility visibility);
 
     List<CourseEntity> findTop20ByVisibilityAndReportHiddenFalseAndTitleContainingIgnoreCaseOrderByIdDesc(CourseVisibility visibility, String title);

--- a/src/main/java/com/bikeprojectminji/bikeback/global/config/SecurityConfig.java
+++ b/src/main/java/com/bikeprojectminji/bikeback/global/config/SecurityConfig.java
@@ -13,6 +13,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
+import org.springframework.security.config.Customizer;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
@@ -30,6 +31,9 @@ import org.springframework.security.oauth2.server.resource.authentication.JwtAut
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 @Configuration
 public class SecurityConfig {
@@ -37,6 +41,7 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http, ObjectMapper objectMapper) throws Exception {
         http
+                .cors(Customizer.withDefaults())
                 .csrf(csrf -> csrf.disable())
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(authorize -> authorize
@@ -76,6 +81,7 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.GET, "/api/v1/ride-records/*").authenticated()
                         .requestMatchers(HttpMethod.POST, "/api/v1/ride-records/*/trace").authenticated()
                         .requestMatchers(HttpMethod.POST, "/api/v1/ride-records/*/regenerate").authenticated()
+                        .requestMatchers(HttpMethod.DELETE, "/api/v1/ride-records/*").authenticated()
                         .requestMatchers(HttpMethod.POST, "/api/v1/courses").authenticated()
                         .requestMatchers(HttpMethod.POST, "/api/v1/courses/*/reports").authenticated()
                         .requestMatchers(HttpMethod.POST, "/api/v1/courses/*/share").authenticated()
@@ -125,6 +131,20 @@ public class SecurityConfig {
         return new BCryptPasswordEncoder();
     }
 
+    @Bean
+    CorsConfigurationSource corsConfigurationSource(
+            @Value("${app.cors.allowed-origins:http://127.0.0.1:8081,http://localhost:8081}") String allowedOrigins
+    ) {
+        CorsConfiguration configuration = new CorsConfiguration();
+        configuration.setAllowedOrigins(parseCsv(allowedOrigins));
+        configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
+        configuration.setAllowedHeaders(List.of("Authorization", "Content-Type", "X-Guest-Device-Id"));
+        configuration.setAllowCredentials(true);
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+        return source;
+    }
+
     private SecretKey secretKey(String secret) {
         byte[] secretBytes = secret.getBytes(StandardCharsets.UTF_8);
         if (secretBytes.length < 32) {
@@ -154,5 +174,16 @@ public class SecurityConfig {
             authorities.add(new SimpleGrantedAuthority(normalizedRole));
         }
         return authorities;
+    }
+
+    private List<String> parseCsv(String value) {
+        if (value == null || value.isBlank()) {
+            return List.of();
+        }
+        return List.of(value.split(","))
+                .stream()
+                .map(String::trim)
+                .filter(origin -> !origin.isBlank())
+                .toList();
     }
 }

--- a/src/main/java/com/bikeprojectminji/bikeback/global/config/TimeConfig.java
+++ b/src/main/java/com/bikeprojectminji/bikeback/global/config/TimeConfig.java
@@ -8,7 +8,7 @@ import org.springframework.context.annotation.Configuration;
 public class TimeConfig {
 
     @Bean
-    public Clock systemClock() {
+    public Clock clock() {
         return Clock.systemUTC();
     }
 }

--- a/src/main/java/com/bikeprojectminji/bikeback/ride/controller/RideRecordController.java
+++ b/src/main/java/com/bikeprojectminji/bikeback/ride/controller/RideRecordController.java
@@ -7,7 +7,10 @@ import com.bikeprojectminji.bikeback.ride.dto.RideRecordFinalizationStatusRespon
 import com.bikeprojectminji.bikeback.ride.dto.RideRecordListResponse;
 import com.bikeprojectminji.bikeback.ride.dto.RideRecordResponse;
 import com.bikeprojectminji.bikeback.ride.dto.RideRecordTraceRequest;
+import com.bikeprojectminji.bikeback.ride.service.RideRecordDeletionService;
 import com.bikeprojectminji.bikeback.ride.service.RideRecordService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -22,9 +25,11 @@ import org.springframework.web.bind.annotation.RestController;
 public class RideRecordController {
 
     private final RideRecordService rideRecordService;
+    private final RideRecordDeletionService rideRecordDeletionService;
 
-    public RideRecordController(RideRecordService rideRecordService) {
+    public RideRecordController(RideRecordService rideRecordService, RideRecordDeletionService rideRecordDeletionService) {
         this.rideRecordService = rideRecordService;
+        this.rideRecordDeletionService = rideRecordDeletionService;
     }
 
     @PostMapping
@@ -71,5 +76,14 @@ public class RideRecordController {
             @PathVariable Long rideRecordId
     ) {
         return ApiResponse.success(rideRecordService.regenerateRideRecord(jwt.getSubject(), rideRecordId));
+    }
+
+    @DeleteMapping("/{rideRecordId}")
+    public ResponseEntity<Void> deleteRideRecord(
+            @AuthenticationPrincipal Jwt jwt,
+            @PathVariable Long rideRecordId
+    ) {
+        rideRecordDeletionService.deleteRideRecord(jwt.getSubject(), rideRecordId);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/bikeprojectminji/bikeback/ride/repository/RideRecordRepository.java
+++ b/src/main/java/com/bikeprojectminji/bikeback/ride/repository/RideRecordRepository.java
@@ -25,6 +25,8 @@ public interface RideRecordRepository extends JpaRepository<RideRecordEntity, Lo
 
     Optional<RideRecordEntity> findFirstByOwnerUserIdAndFinalizationStatusOrderByEndedAtDescIdDesc(Long ownerUserId, String finalizationStatus);
 
+    List<RideRecordEntity> findByEndedAtLessThanEqual(OffsetDateTime endedAt);
+
     @Query("""
             select new com.bikeprojectminji.bikeback.ride.repository.RideRecordActivityAggregate(
                 count(r),

--- a/src/main/java/com/bikeprojectminji/bikeback/ride/service/RideRecordDeletionService.java
+++ b/src/main/java/com/bikeprojectminji/bikeback/ride/service/RideRecordDeletionService.java
@@ -1,0 +1,84 @@
+package com.bikeprojectminji.bikeback.ride.service;
+
+import com.bikeprojectminji.bikeback.auth.entity.UserEntity;
+import com.bikeprojectminji.bikeback.auth.service.AuthService;
+import com.bikeprojectminji.bikeback.course.entity.CourseEntity;
+import com.bikeprojectminji.bikeback.course.repository.CourseRepository;
+import com.bikeprojectminji.bikeback.global.exception.ForbiddenException;
+import com.bikeprojectminji.bikeback.global.exception.NotFoundException;
+import com.bikeprojectminji.bikeback.ride.entity.RideRecordEntity;
+import com.bikeprojectminji.bikeback.ride.repository.RideRecordPointRepository;
+import com.bikeprojectminji.bikeback.ride.repository.RideRecordProcessedPointRepository;
+import com.bikeprojectminji.bikeback.ride.repository.RideRecordRepository;
+import java.time.Clock;
+import java.time.OffsetDateTime;
+import java.util.List;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+public class RideRecordDeletionService {
+
+    private static final long RETENTION_DAYS = 30;
+
+    private final AuthService authService;
+    private final RideRecordRepository rideRecordRepository;
+    private final RideRecordPointRepository rideRecordPointRepository;
+    private final RideRecordProcessedPointRepository rideRecordProcessedPointRepository;
+    private final CourseRepository courseRepository;
+    private final Clock clock;
+
+    public RideRecordDeletionService(
+            AuthService authService,
+            RideRecordRepository rideRecordRepository,
+            RideRecordPointRepository rideRecordPointRepository,
+            RideRecordProcessedPointRepository rideRecordProcessedPointRepository,
+            CourseRepository courseRepository,
+            Clock clock
+    ) {
+        this.authService = authService;
+        this.rideRecordRepository = rideRecordRepository;
+        this.rideRecordPointRepository = rideRecordPointRepository;
+        this.rideRecordProcessedPointRepository = rideRecordProcessedPointRepository;
+        this.courseRepository = courseRepository;
+        this.clock = clock;
+    }
+
+    public void deleteRideRecord(String subject, Long rideRecordId) {
+        UserEntity user = authService.findUserBySubject(subject);
+        RideRecordEntity rideRecord = rideRecordRepository.findById(rideRecordId)
+                .orElseThrow(() -> new NotFoundException("자유 주행 기록을 찾을 수 없습니다."));
+        if (!rideRecord.getOwnerUserId().equals(user.getId())) {
+            throw new ForbiddenException("자유 주행 기록에 접근할 수 없습니다.");
+        }
+
+        deleteRideRecords(List.of(rideRecord));
+    }
+
+    public int deleteExpiredRideRecords() {
+        OffsetDateTime cutoff = OffsetDateTime.now(clock).minusDays(RETENTION_DAYS);
+        List<RideRecordEntity> expiredRideRecords = rideRecordRepository.findByEndedAtLessThanEqual(cutoff);
+        deleteRideRecords(expiredRideRecords);
+        return expiredRideRecords.size();
+    }
+
+    private void deleteRideRecords(List<RideRecordEntity> rideRecords) {
+        if (rideRecords.isEmpty()) {
+            return;
+        }
+        List<Long> rideRecordIds = rideRecords.stream()
+                .map(RideRecordEntity::getId)
+                .toList();
+        detachLinkedCourses(rideRecordIds);
+        rideRecordPointRepository.deleteByRideRecordIdIn(rideRecordIds);
+        rideRecordProcessedPointRepository.deleteByRideRecordIdIn(rideRecordIds);
+        rideRecordRepository.deleteAllByIdInBatch(rideRecordIds);
+    }
+
+    private void detachLinkedCourses(List<Long> rideRecordIds) {
+        // 사용자가 저장한 코스는 유지하되, 삭제된 자유 주행 원본 ID만 끊어 죽은 참조를 남기지 않는다.
+        List<CourseEntity> linkedCourses = courseRepository.findBySourceRideRecordIdIn(rideRecordIds);
+        linkedCourses.forEach(CourseEntity::detachRideRecordSource);
+    }
+}

--- a/src/main/java/com/bikeprojectminji/bikeback/ride/service/RideRecordRetentionScheduler.java
+++ b/src/main/java/com/bikeprojectminji/bikeback/ride/service/RideRecordRetentionScheduler.java
@@ -1,0 +1,24 @@
+package com.bikeprojectminji.bikeback.ride.service;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+public class RideRecordRetentionScheduler {
+
+    private static final Logger log = LoggerFactory.getLogger(RideRecordRetentionScheduler.class);
+
+    private final RideRecordDeletionService rideRecordDeletionService;
+
+    public RideRecordRetentionScheduler(RideRecordDeletionService rideRecordDeletionService) {
+        this.rideRecordDeletionService = rideRecordDeletionService;
+    }
+
+    @Scheduled(cron = "${ride-record.retention.cleanup-cron:0 20 3 * * *}")
+    public void deleteExpiredRideRecords() {
+        int deletedCount = rideRecordDeletionService.deleteExpiredRideRecords();
+        log.info("ride_record_retention_cleanup_completed deleted_count={}", deletedCount);
+    }
+}

--- a/src/main/java/com/bikeprojectminji/bikeback/routing/infrastructure/GraphHopperBicycleRoutingClient.java
+++ b/src/main/java/com/bikeprojectminji/bikeback/routing/infrastructure/GraphHopperBicycleRoutingClient.java
@@ -72,10 +72,18 @@ public class GraphHopperBicycleRoutingClient implements BicycleRoutingClient {
             return providerFailure("missing_base_url");
         }
         BicycleRoutingProviderResult lastResult = BicycleRoutingProviderResult.providerFailure(PROVIDER);
-        for (String baseUrl : baseUrls) {
+        for (int baseUrlIndex = 0; baseUrlIndex < baseUrls.size(); baseUrlIndex++) {
+            String baseUrl = baseUrls.get(baseUrlIndex);
             for (int attempt = 0; attempt < retryMaxAttempts; attempt++) {
                 lastResult = routeOnce(baseUrl, request);
                 if ("SUCCESS".equals(lastResult.status())) {
+                    if (baseUrlIndex > 0) {
+                        return BicycleRoutingProviderResult.successWithFallback(
+                                PROVIDER,
+                                lastResult.candidates(),
+                                "self-host 실패 후 hosted GraphHopper 사용"
+                        );
+                    }
                     return lastResult;
                 }
             }

--- a/src/main/java/com/bikeprojectminji/bikeback/routing/service/BicycleRoutePlan.java
+++ b/src/main/java/com/bikeprojectminji/bikeback/routing/service/BicycleRoutePlan.java
@@ -7,6 +7,19 @@ public record BicycleRoutePlan(
         String provider,
         boolean fallbackUsed,
         String message,
-        List<BicycleRouteCandidate> candidates
+        List<BicycleRouteCandidate> candidates,
+        String qualityStatus,
+        String qualityMessage,
+        String fallbackReason
 ) {
+
+    public BicycleRoutePlan(
+            String status,
+            String provider,
+            boolean fallbackUsed,
+            String message,
+            List<BicycleRouteCandidate> candidates
+    ) {
+        this(status, provider, fallbackUsed, message, candidates, "NOT_EVALUATED", "경로 품질 검증을 수행하지 않았습니다.", null);
+    }
 }

--- a/src/main/java/com/bikeprojectminji/bikeback/routing/service/BicycleRouteQuality.java
+++ b/src/main/java/com/bikeprojectminji/bikeback/routing/service/BicycleRouteQuality.java
@@ -1,0 +1,11 @@
+package com.bikeprojectminji.bikeback.routing.service;
+
+public record BicycleRouteQuality(
+        String status,
+        String message
+) {
+
+    public boolean usable() {
+        return !"INVALID".equals(status);
+    }
+}

--- a/src/main/java/com/bikeprojectminji/bikeback/routing/service/BicycleRouteQualityValidator.java
+++ b/src/main/java/com/bikeprojectminji/bikeback/routing/service/BicycleRouteQualityValidator.java
@@ -1,0 +1,26 @@
+package com.bikeprojectminji.bikeback.routing.service;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class BicycleRouteQualityValidator {
+
+    public BicycleRouteQuality validate(BicycleRouteCandidate candidate) {
+        if (candidate == null) {
+            return new BicycleRouteQuality("INVALID", "경로 후보가 없습니다.");
+        }
+        if (candidate.polyline().size() < 2) {
+            return new BicycleRouteQuality("INVALID", "경로 좌표가 2개 미만입니다.");
+        }
+        if (candidate.distanceMeters() <= 0) {
+            return new BicycleRouteQuality("INVALID", "경로 거리가 0 이하입니다.");
+        }
+        if (candidate.durationSeconds() <= 0) {
+            return new BicycleRouteQuality("INVALID", "예상 시간이 0 이하입니다.");
+        }
+        if (!candidate.elevationSummary().hasElevation()) {
+            return new BicycleRouteQuality("VALID_WITH_WARNINGS", "고도 정보가 없어 평지/오르막 선호 검증 정확도가 낮습니다.");
+        }
+        return new BicycleRouteQuality("VALID", "경로 좌표, 거리, 시간, 고도 정보가 확인되었습니다.");
+    }
+}

--- a/src/main/java/com/bikeprojectminji/bikeback/routing/service/BicycleRoutingProviderResult.java
+++ b/src/main/java/com/bikeprojectminji/bikeback/routing/service/BicycleRoutingProviderResult.java
@@ -5,14 +5,32 @@ import java.util.List;
 public record BicycleRoutingProviderResult(
         String status,
         String provider,
-        List<BicycleRouteCandidate> candidates
+        List<BicycleRouteCandidate> candidates,
+        boolean fallbackUsed,
+        String fallbackReason
 ) {
 
+    public BicycleRoutingProviderResult(
+            String status,
+            String provider,
+            List<BicycleRouteCandidate> candidates
+    ) {
+        this(status, provider, candidates, false, null);
+    }
+
     public static BicycleRoutingProviderResult success(String provider, List<BicycleRouteCandidate> candidates) {
-        return new BicycleRoutingProviderResult("SUCCESS", provider, List.copyOf(candidates));
+        return new BicycleRoutingProviderResult("SUCCESS", provider, List.copyOf(candidates), false, null);
+    }
+
+    public static BicycleRoutingProviderResult successWithFallback(
+            String provider,
+            List<BicycleRouteCandidate> candidates,
+            String fallbackReason
+    ) {
+        return new BicycleRoutingProviderResult("SUCCESS", provider, List.copyOf(candidates), true, fallbackReason);
     }
 
     public static BicycleRoutingProviderResult providerFailure(String provider) {
-        return new BicycleRoutingProviderResult("PROVIDER_FAILURE", provider, List.of());
+        return new BicycleRoutingProviderResult("PROVIDER_FAILURE", provider, List.of(), false, null);
     }
 }

--- a/src/main/java/com/bikeprojectminji/bikeback/routing/service/BicycleRoutingService.java
+++ b/src/main/java/com/bikeprojectminji/bikeback/routing/service/BicycleRoutingService.java
@@ -3,15 +3,23 @@ package com.bikeprojectminji.bikeback.routing.service;
 import com.bikeprojectminji.bikeback.global.exception.BadRequestException;
 import java.math.BigDecimal;
 import java.util.List;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 @Service
 public class BicycleRoutingService {
 
     private final List<BicycleRoutingClient> routingClients;
+    private final BicycleRouteQualityValidator qualityValidator;
 
     public BicycleRoutingService(List<BicycleRoutingClient> routingClients) {
+        this(routingClients, new BicycleRouteQualityValidator());
+    }
+
+    @Autowired
+    public BicycleRoutingService(List<BicycleRoutingClient> routingClients, BicycleRouteQualityValidator qualityValidator) {
         this.routingClients = routingClients;
+        this.qualityValidator = qualityValidator;
     }
 
     public BicycleRoutePlan route(BicycleRouteRequest request) {
@@ -19,12 +27,20 @@ public class BicycleRoutingService {
         for (int index = 0; index < routingClients.size(); index++) {
             BicycleRoutingProviderResult result = routingClients.get(index).route(request);
             if ("SUCCESS".equals(result.status()) && !result.candidates().isEmpty()) {
+                BicycleRouteQuality quality = qualityValidator.validate(result.candidates().get(0));
+                if (!quality.usable()) {
+                    continue;
+                }
+                boolean fallbackUsed = index > 0 || result.fallbackUsed();
                 return new BicycleRoutePlan(
-                        index == 0 ? "SUCCESS" : "FALLBACK_USED",
+                        fallbackUsed ? "FALLBACK_USED" : "SUCCESS",
                         result.provider(),
-                        index > 0,
-                        index == 0 ? "자전거 경로 후보를 찾았습니다." : "기본 provider 실패 후 fallback 경로 후보를 찾았습니다.",
-                        result.candidates()
+                        fallbackUsed,
+                        fallbackUsed ? "기본 provider 실패 후 fallback 경로 후보를 찾았습니다." : "자전거 경로 후보를 찾았습니다.",
+                        result.candidates(),
+                        quality.status(),
+                        quality.message(),
+                        fallbackReason(index, result)
                 );
             }
         }
@@ -33,8 +49,21 @@ public class BicycleRoutingService {
                 "NONE",
                 routingClients.size() > 1,
                 "자전거 경로 provider를 사용할 수 없습니다.",
-                List.of()
+                List.of(),
+                "INVALID",
+                "사용 가능한 경로 후보가 없습니다.",
+                routingClients.size() > 1 ? "모든 provider가 실패했습니다." : null
         );
+    }
+
+    private String fallbackReason(int providerIndex, BicycleRoutingProviderResult result) {
+        if (result.fallbackReason() != null && !result.fallbackReason().isBlank()) {
+            return result.fallbackReason();
+        }
+        if (providerIndex > 0) {
+            return "primary provider 실패 후 fallback provider 사용";
+        }
+        return null;
     }
 
     private void validate(BicycleRouteRequest request) {

--- a/src/main/java/com/bikeprojectminji/bikeback/weather/infrastructure/FakeWeatherProvider.java
+++ b/src/main/java/com/bikeprojectminji/bikeback/weather/infrastructure/FakeWeatherProvider.java
@@ -1,0 +1,37 @@
+package com.bikeprojectminji.bikeback.weather.infrastructure;
+
+import com.bikeprojectminji.bikeback.weather.dto.WeatherData;
+import com.bikeprojectminji.bikeback.weather.dto.WindData;
+import com.bikeprojectminji.bikeback.weather.service.WeatherLocationKey;
+import com.bikeprojectminji.bikeback.weather.service.WeatherProviderPort;
+import com.bikeprojectminji.bikeback.weather.service.WeatherProviderResult;
+import com.bikeprojectminji.bikeback.weather.service.WeatherSnapshot;
+import java.time.Clock;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConditionalOnProperty(prefix = "weather", name = "provider", havingValue = "fake")
+public class FakeWeatherProvider implements WeatherProviderPort {
+
+    private final Clock clock;
+
+    public FakeWeatherProvider(Clock clock) {
+        this.clock = clock;
+    }
+
+    @Override
+    public WeatherProviderResult getCurrent(WeatherLocationKey locationKey) {
+        OffsetDateTime now = OffsetDateTime.ofInstant(clock.instant(), ZoneOffset.UTC);
+        WeatherSnapshot snapshot = new WeatherSnapshot(
+                new WeatherData(21, "clear", "none"),
+                new WindData(12, "북동", 45),
+                false,
+                now,
+                now
+        );
+        return WeatherProviderResult.success(snapshot);
+    }
+}

--- a/src/main/java/com/bikeprojectminji/bikeback/weather/infrastructure/OpenMeteoWeatherProvider.java
+++ b/src/main/java/com/bikeprojectminji/bikeback/weather/infrastructure/OpenMeteoWeatherProvider.java
@@ -14,11 +14,13 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.web.client.RestClient;
 
 @Component
+@ConditionalOnProperty(prefix = "weather", name = "provider", havingValue = "open-meteo", matchIfMissing = true)
 public class OpenMeteoWeatherProvider implements WeatherProviderPort {
 
     private static final Logger log = LoggerFactory.getLogger(OpenMeteoWeatherProvider.class);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -68,6 +68,13 @@ address:
       base-url: ${KAKAO_LOCAL_BASE_URL:https://dapi.kakao.com}
       rest-api-key: ${KAKAO_LOCAL_REST_API_KEY:}
 
+app:
+  cors:
+    allowed-origins: ${APP_CORS_ALLOWED_ORIGINS:http://127.0.0.1:8081,http://localhost:8081}
+
+weather:
+  provider: ${WEATHER_PROVIDER:open-meteo}
+
 routing:
   bicycle:
     provider: ${BICYCLE_ROUTING_PROVIDER:graphhopper}

--- a/src/test/java/com/bikeprojectminji/bikeback/airoute/service/AiRoutePlanComposerTest.java
+++ b/src/test/java/com/bikeprojectminji/bikeback/airoute/service/AiRoutePlanComposerTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.bikeprojectminji.bikeback.airoute.dto.AiRoutePlanRequest;
 import com.bikeprojectminji.bikeback.airoute.dto.AiRoutePlanResponse;
 import com.bikeprojectminji.bikeback.routing.service.BicycleRouteCandidate;
+import com.bikeprojectminji.bikeback.routing.service.BicycleRoutePlan;
 import com.bikeprojectminji.bikeback.routing.service.BicycleRoutePoint;
 import com.bikeprojectminji.bikeback.routing.service.ElevationSummary;
 import com.bikeprojectminji.bikeback.routing.service.RouteEvidenceBadge;
@@ -120,6 +121,41 @@ class AiRoutePlanComposerTest {
         assertThat(response.scoreBreakdown().unknownPenalty()).isGreaterThan(0);
         assertThat(response.evidenceBadges()).extracting("source")
                 .contains("graphhopper.road_class", "graphhopper.surface", "graphhopper.elevation");
+    }
+
+    @Test
+    @DisplayName("route plan metadata는 AI route 응답에 fallback과 품질 상태로 포함된다")
+    void composeRouteCandidateIncludesRoutingMetadata() {
+        AiRoutePlanRequest request = new AiRoutePlanRequest(
+                BigDecimal.valueOf(37.48),
+                BigDecimal.valueOf(126.95),
+                BigDecimal.valueOf(37.50),
+                BigDecimal.valueOf(126.98),
+                "관악 순환",
+                "BIKE_PATH_FIRST"
+        );
+        BicycleRoutePlan routePlan = new BicycleRoutePlan(
+                "FALLBACK_USED",
+                "GRAPHHOPPER",
+                true,
+                "self-host 실패 후 hosted GraphHopper 경로 후보를 찾았습니다.",
+                List.of(climbCandidate()),
+                "VALID_WITH_WARNINGS",
+                "고도 값은 있지만 일부 노면 detail이 부족합니다.",
+                "self-host 실패 후 hosted GraphHopper 사용"
+        );
+
+        AiRoutePlanResponse response = composer.composeWithRouteCandidate(
+                request,
+                new AiRouteConditionContext(Optional.empty(), "공사 정보 미확인", "노면 정보 미확인"),
+                climbCandidate(),
+                routePlan
+        );
+
+        assertThat(response.routingMetadata().provider()).isEqualTo("GRAPHHOPPER");
+        assertThat(response.routingMetadata().fallbackUsed()).isTrue();
+        assertThat(response.routingMetadata().fallbackReason()).contains("hosted GraphHopper");
+        assertThat(response.routingMetadata().qualityStatus()).isEqualTo("VALID_WITH_WARNINGS");
     }
 
     @Test

--- a/src/test/java/com/bikeprojectminji/bikeback/global/config/SecurityConfigTest.java
+++ b/src/test/java/com/bikeprojectminji/bikeback/global/config/SecurityConfigTest.java
@@ -10,6 +10,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 class SecurityConfigTest {
 
@@ -32,6 +34,21 @@ class SecurityConfigTest {
 
         assertThatThrownBy(() -> securityConfig.accessTokenAuthentication(refreshToken))
                 .isInstanceOf(BadCredentialsException.class);
+    }
+
+    @Test
+    @DisplayName("로컬 웹 콘솔 origin은 API CORS 허용 origin으로 등록된다")
+    void localWebConsoleOriginIsCorsAllowed() {
+        UrlBasedCorsConfigurationSource source = (UrlBasedCorsConfigurationSource) securityConfig.corsConfigurationSource(
+                "http://127.0.0.1:8081,http://localhost:8081"
+        );
+
+        CorsConfiguration configuration = source.getCorsConfigurations().get("/**");
+
+        assertThat(configuration.getAllowedOrigins())
+                .containsExactly("http://127.0.0.1:8081", "http://localhost:8081");
+        assertThat(configuration.getAllowedMethods()).contains("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS");
+        assertThat(configuration.getAllowedHeaders()).contains("Authorization", "Content-Type");
     }
 
     private Jwt jwt(String tokenType, List<String> roles) {

--- a/src/test/java/com/bikeprojectminji/bikeback/ride/controller/RideRecordControllerTest.java
+++ b/src/test/java/com/bikeprojectminji/bikeback/ride/controller/RideRecordControllerTest.java
@@ -2,6 +2,7 @@ package com.bikeprojectminji.bikeback.ride.controller;
 
 import static org.mockito.BDDMockito.given;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -13,6 +14,7 @@ import com.bikeprojectminji.bikeback.ride.dto.RideRecordListItemResponse;
 import com.bikeprojectminji.bikeback.ride.dto.RideRecordListResponse;
 import com.bikeprojectminji.bikeback.global.config.SecurityConfig;
 import com.bikeprojectminji.bikeback.global.exception.NotFoundException;
+import com.bikeprojectminji.bikeback.ride.service.RideRecordDeletionService;
 import com.bikeprojectminji.bikeback.ride.service.RideRecordService;
 import java.time.OffsetDateTime;
 import org.junit.jupiter.api.DisplayName;
@@ -39,6 +41,9 @@ class RideRecordControllerTest {
 
     @MockitoBean
     private RideRecordService rideRecordService;
+
+    @MockitoBean
+    private RideRecordDeletionService rideRecordDeletionService;
 
     @Test
     @DisplayName("자유 주행 기록 저장 API는 인증된 사용자의 저장 결과를 응답한다")
@@ -251,5 +256,23 @@ class RideRecordControllerTest {
                 .andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.code").value(404))
                 .andExpect(jsonPath("$.message").value("자유 주행 기록을 찾을 수 없습니다."));
+    }
+
+    @Test
+    @DisplayName("자유 주행 기록 삭제 API는 인증된 사용자의 기록을 삭제하고 204를 반환한다")
+    void deleteRideRecordReturnsNoContent() throws Exception {
+        mockMvc.perform(delete("/api/v1/ride-records/1001")
+                        .with(jwt().jwt(jwt -> jwt.subject("1"))))
+                .andExpect(status().isNoContent());
+
+        org.mockito.Mockito.verify(rideRecordDeletionService).deleteRideRecord("1", 1001L);
+    }
+
+    @Test
+    @DisplayName("자유 주행 기록 삭제 API는 비로그인 요청이면 401을 반환한다")
+    void deleteRideRecordReturnsUnauthorizedWithoutToken() throws Exception {
+        mockMvc.perform(delete("/api/v1/ride-records/1001"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value(401));
     }
 }

--- a/src/test/java/com/bikeprojectminji/bikeback/ride/service/RideRecordDeletionServiceTest.java
+++ b/src/test/java/com/bikeprojectminji/bikeback/ride/service/RideRecordDeletionServiceTest.java
@@ -1,0 +1,178 @@
+package com.bikeprojectminji.bikeback.ride.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import com.bikeprojectminji.bikeback.auth.entity.UserEntity;
+import com.bikeprojectminji.bikeback.auth.service.AuthService;
+import com.bikeprojectminji.bikeback.course.entity.CourseEntity;
+import com.bikeprojectminji.bikeback.course.entity.CourseVisibility;
+import com.bikeprojectminji.bikeback.course.repository.CourseRepository;
+import com.bikeprojectminji.bikeback.global.exception.ForbiddenException;
+import com.bikeprojectminji.bikeback.global.exception.NotFoundException;
+import com.bikeprojectminji.bikeback.ride.entity.RideRecordEntity;
+import com.bikeprojectminji.bikeback.ride.repository.RideRecordPointRepository;
+import com.bikeprojectminji.bikeback.ride.repository.RideRecordProcessedPointRepository;
+import com.bikeprojectminji.bikeback.ride.repository.RideRecordRepository;
+import java.math.BigDecimal;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class RideRecordDeletionServiceTest {
+
+    private static final Clock FIXED_CLOCK = Clock.fixed(
+            Instant.parse("2026-06-15T00:00:00Z"),
+            ZoneOffset.UTC
+    );
+
+    @Mock
+    private AuthService authService;
+
+    @Mock
+    private RideRecordRepository rideRecordRepository;
+
+    @Mock
+    private RideRecordPointRepository rideRecordPointRepository;
+
+    @Mock
+    private RideRecordProcessedPointRepository rideRecordProcessedPointRepository;
+
+    @Mock
+    private CourseRepository courseRepository;
+
+    private RideRecordDeletionService rideRecordDeletionService;
+
+    @BeforeEach
+    void setUp() {
+        rideRecordDeletionService = new RideRecordDeletionService(
+                authService,
+                rideRecordRepository,
+                rideRecordPointRepository,
+                rideRecordProcessedPointRepository,
+                courseRepository,
+                FIXED_CLOCK
+        );
+    }
+
+    @Test
+    @DisplayName("소유자의 자유 주행 기록 삭제는 포인트를 지우고 연결된 코스의 원본 기록 참조를 끊는다")
+    void deleteRideRecordDeletesOwnedRecordAndDetachesLinkedCourse() {
+        UserEntity user = user(1L);
+        RideRecordEntity rideRecord = rideRecord(1001L, 1L, "2026-06-10T10:00:00Z");
+        CourseEntity linkedCourse = course(2001L, 1L, 1001L);
+
+        given(authService.findUserBySubject("1")).willReturn(user);
+        given(rideRecordRepository.findById(1001L)).willReturn(Optional.of(rideRecord));
+        given(courseRepository.findBySourceRideRecordIdIn(List.of(1001L))).willReturn(List.of(linkedCourse));
+
+        rideRecordDeletionService.deleteRideRecord("1", 1001L);
+
+        assertThat(linkedCourse.getSourceRideRecordId()).isNull();
+        verify(rideRecordPointRepository).deleteByRideRecordIdIn(List.of(1001L));
+        verify(rideRecordProcessedPointRepository).deleteByRideRecordIdIn(List.of(1001L));
+        verify(rideRecordRepository).deleteAllByIdInBatch(List.of(1001L));
+    }
+
+    @Test
+    @DisplayName("다른 사용자의 자유 주행 기록 삭제는 403으로 거절한다")
+    void deleteRideRecordRejectsDifferentOwner() {
+        UserEntity user = user(1L);
+        RideRecordEntity rideRecord = rideRecord(1001L, 2L, "2026-06-10T10:00:00Z");
+
+        given(authService.findUserBySubject("1")).willReturn(user);
+        given(rideRecordRepository.findById(1001L)).willReturn(Optional.of(rideRecord));
+
+        assertThatThrownBy(() -> rideRecordDeletionService.deleteRideRecord("1", 1001L))
+                .isInstanceOf(ForbiddenException.class)
+                .hasMessage("자유 주행 기록에 접근할 수 없습니다.");
+
+        verifyNoInteractions(rideRecordPointRepository, rideRecordProcessedPointRepository, courseRepository);
+        verify(rideRecordRepository, never()).deleteAllByIdInBatch(List.of(1001L));
+    }
+
+    @Test
+    @DisplayName("없는 자유 주행 기록 삭제는 404를 반환한다")
+    void deleteRideRecordRejectsMissingRecord() {
+        given(authService.findUserBySubject("1")).willReturn(user(1L));
+        given(rideRecordRepository.findById(999L)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> rideRecordDeletionService.deleteRideRecord("1", 999L))
+                .isInstanceOf(NotFoundException.class)
+                .hasMessage("자유 주행 기록을 찾을 수 없습니다.");
+
+        verifyNoInteractions(rideRecordPointRepository, rideRecordProcessedPointRepository, courseRepository);
+        verify(rideRecordRepository, never()).deleteAllByIdInBatch(List.of(999L));
+    }
+
+    @Test
+    @DisplayName("30일이 지난 자유 주행 기록 정리는 만료 기록만 삭제하고 연결된 코스 참조를 끊는다")
+    void deleteExpiredRideRecordsDeletesOnlyExpiredRecordsAndDetachesLinkedCourses() {
+        RideRecordEntity expiredRideRecord = rideRecord(1001L, 1L, "2026-05-15T00:00:00Z");
+        CourseEntity linkedCourse = course(2001L, 1L, 1001L);
+
+        given(rideRecordRepository.findByEndedAtLessThanEqual(OffsetDateTime.parse("2026-05-16T00:00:00Z")))
+                .willReturn(List.of(expiredRideRecord));
+        given(courseRepository.findBySourceRideRecordIdIn(List.of(1001L))).willReturn(List.of(linkedCourse));
+
+        int deletedCount = rideRecordDeletionService.deleteExpiredRideRecords();
+
+        assertThat(deletedCount).isEqualTo(1);
+        assertThat(linkedCourse.getSourceRideRecordId()).isNull();
+        verify(rideRecordPointRepository).deleteByRideRecordIdIn(List.of(1001L));
+        verify(rideRecordProcessedPointRepository).deleteByRideRecordIdIn(List.of(1001L));
+        verify(rideRecordRepository).deleteAllByIdInBatch(List.of(1001L));
+    }
+
+    private UserEntity user(Long id) {
+        UserEntity user = new UserEntity(null, "bikeoasis@example.com", "encoded-password", "bikeoasis", null);
+        ReflectionTestUtils.setField(user, "id", id);
+        return user;
+    }
+
+    private RideRecordEntity rideRecord(Long id, Long ownerUserId, String endedAt) {
+        RideRecordEntity rideRecord = new RideRecordEntity(
+                ownerUserId,
+                OffsetDateTime.parse("2026-05-01T00:00:00Z"),
+                OffsetDateTime.parse(endedAt),
+                18250,
+                3600
+        );
+        ReflectionTestUtils.setField(rideRecord, "id", id);
+        return rideRecord;
+    }
+
+    private CourseEntity course(Long id, Long ownerUserId, Long sourceRideRecordId) {
+        CourseEntity course = new CourseEntity(
+                "퇴근길 코스",
+                "삭제된 자유 주행 기록에서 저장한 코스",
+                BigDecimal.valueOf(18.2),
+                60,
+                1,
+                false,
+                null,
+                BigDecimal.valueOf(37.5665),
+                BigDecimal.valueOf(126.9780),
+                ownerUserId,
+                sourceRideRecordId,
+                CourseVisibility.PRIVATE
+        );
+        ReflectionTestUtils.setField(course, "id", id);
+        return course;
+    }
+}

--- a/src/test/java/com/bikeprojectminji/bikeback/routing/infrastructure/GraphHopperBicycleRoutingClientTest.java
+++ b/src/test/java/com/bikeprojectminji/bikeback/routing/infrastructure/GraphHopperBicycleRoutingClientTest.java
@@ -216,6 +216,8 @@ class GraphHopperBicycleRoutingClientTest {
         assertThat(selfHostedHits).hasValue(2);
         assertThat(result.status()).isEqualTo("SUCCESS");
         assertThat(result.provider()).isEqualTo("GRAPHHOPPER");
+        assertThat(result.fallbackUsed()).isTrue();
+        assertThat(result.fallbackReason()).contains("hosted GraphHopper");
         assertThat(result.candidates()).hasSize(1);
         assertThat(result.candidates().get(0).polyline()).hasSize(2);
     }

--- a/src/test/java/com/bikeprojectminji/bikeback/routing/service/BicycleRoutingServiceIntegrationTest.java
+++ b/src/test/java/com/bikeprojectminji/bikeback/routing/service/BicycleRoutingServiceIntegrationTest.java
@@ -15,6 +15,7 @@ import org.springframework.context.annotation.Bean;
 
 @SpringBootTest(classes = {
         BicycleRoutingService.class,
+        BicycleRouteQualityValidator.class,
         BicycleRoutingServiceIntegrationTest.TestRoutingConfig.class
 })
 class BicycleRoutingServiceIntegrationTest {
@@ -45,6 +46,7 @@ class BicycleRoutingServiceIntegrationTest {
         assertThat(plan.status()).isEqualTo("SUCCESS");
         assertThat(plan.provider()).isEqualTo("KAKAO_MOBILITY");
         assertThat(plan.fallbackUsed()).isFalse();
+        assertThat(plan.qualityStatus()).isEqualTo("VALID_WITH_WARNINGS");
         assertThat(plan.candidates())
                 .extracting(BicycleRouteCandidate::routeType)
                 .containsExactly("RECOMMENDED", "SCENIC", "BIKE_PATH");
@@ -61,6 +63,7 @@ class BicycleRoutingServiceIntegrationTest {
         assertThat(plan.status()).isEqualTo("FALLBACK_USED");
         assertThat(plan.provider()).isEqualTo("FAKE");
         assertThat(plan.fallbackUsed()).isTrue();
+        assertThat(plan.fallbackReason()).contains("primary provider");
         assertThat(plan.candidates()).isNotEmpty();
     }
 

--- a/src/test/java/com/bikeprojectminji/bikeback/weather/infrastructure/FakeWeatherProviderTest.java
+++ b/src/test/java/com/bikeprojectminji/bikeback/weather/infrastructure/FakeWeatherProviderTest.java
@@ -1,0 +1,33 @@
+package com.bikeprojectminji.bikeback.weather.infrastructure;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.bikeprojectminji.bikeback.weather.service.WeatherLocationKey;
+import com.bikeprojectminji.bikeback.weather.service.WeatherProviderResult;
+import java.math.BigDecimal;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class FakeWeatherProviderTest {
+
+    private final FakeWeatherProvider fakeWeatherProvider = new FakeWeatherProvider(
+            Clock.fixed(Instant.parse("2026-06-15T00:00:00Z"), ZoneOffset.UTC)
+    );
+
+    @Test
+    @DisplayName("fake weather provider는 외부 네트워크 없이 현재 날씨 snapshot을 반환한다")
+    void getCurrentReturnsDeterministicSnapshotWithoutNetwork() {
+        WeatherProviderResult result = fakeWeatherProvider.getCurrent(
+                WeatherLocationKey.from(BigDecimal.valueOf(37.5665), BigDecimal.valueOf(126.9780))
+        );
+
+        assertThat(result.success()).isTrue();
+        assertThat(result.snapshot().weather().sky()).isEqualTo("clear");
+        assertThat(result.snapshot().wind().directionText()).isEqualTo("북동");
+        assertThat(result.snapshot().forecastFallbackUsed()).isFalse();
+        assertThat(result.snapshot().observedAt()).isEqualTo("2026-06-15T00:00Z");
+    }
+}


### PR DESCRIPTION
## 변경 내용

- 웹 HUD 베타용 주행기록 직접 삭제 API와 30일 만료 삭제 스케줄러를 추가했습니다.
- GraphHopper/self-host 실패 이후 hosted fallback 여부와 라우팅 품질 상태를 응답 metadata로 노출했습니다.
- 로컬 웹 콘솔이 8081에서 8080 백엔드를 호출할 수 있도록 CORS 설정을 추가했습니다.
- 외부 날씨 API 지연을 분리하기 위한 fake weather provider를 추가했습니다.
- 검증 결과와 포트폴리오용 수치를 `docs/web-hud-retention-fallback-release-report-2026-06-15.md`에 정리했습니다.

## 검증

- `./gradlew --no-daemon test` 성공
- `npm run build` 성공: 웹 콘솔은 별도 git repo가 아니라 로컬 검증으로만 수행
- `node --experimental-strip-types tests/api-request-mode.test.ts` 성공: 웹 콘솔 게스트 API 선택/헤더 테스트
- Playwright QA 성공: 게스트 데모, 게스트 AI 코스 생성, HUD/routing metadata 표시, 브라우저 console error 0건
- k6 일반 API 50명 혼합: p95 16.15ms, 실패율 0%
- k6 AI 코스 생성 50명 동시: p95 116.96ms, 실패율 0%

## 리뷰 관점

### 백엔드 아키텍처/도메인 리뷰어

- Controller는 삭제 요청 위임만 담당하고, 삭제/보존 정책은 `RideRecordDeletionService`와 scheduler로 분리했습니다.
- 라우팅 provider 결과와 품질 검증을 DTO metadata로 분리해 UI가 fallback/경고 상태를 설명할 수 있게 했습니다.

### QA/보안/운영 리뷰어

- 삭제 API는 인증 사용자 본인 기록만 허용합니다.
- CORS origin은 설정값 `APP_CORS_ALLOWED_ORIGINS`로 제한하며, 기본값은 로컬 웹 콘솔 origin만 허용합니다.
- 외부 provider 지연과 내부 API 성능을 분리하기 위해 fake provider 조건에서 로컬 부하 검증을 수행했습니다.

## 남은 리스크

- 실제 GraphHopper self-host와 외부 AI worker를 켠 EC2 검증은 비용 판단 후 별도 1회 검증이 필요합니다.
- 웹 콘솔은 현재 별도 git repo가 아니라 이번 백엔드 PR에는 포함되지 않습니다.
- `ARTIFACTS/`는 기존 untracked 산출물이라 PR에서 제외했습니다.