### PR TITLE
fix: 자유주행 기록 삭제 500 오류 수정

### DIFF
--- a/src/main/java/com/bikeprojectminji/bikeback/ride/repository/RideRecordPointRepository.java
+++ b/src/main/java/com/bikeprojectminji/bikeback/ride/repository/RideRecordPointRepository.java
@@ -4,6 +4,9 @@ import com.bikeprojectminji.bikeback.ride.entity.RideRecordPointEntity;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface RideRecordPointRepository extends JpaRepository<RideRecordPointEntity, Long> {
 
@@ -13,5 +16,7 @@ public interface RideRecordPointRepository extends JpaRepository<RideRecordPoint
 
     Optional<RideRecordPointEntity> findTopByRideRecordIdOrderByPointOrderDesc(Long rideRecordId);
 
-    void deleteByRideRecordIdIn(List<Long> rideRecordIds);
+    @Modifying(flushAutomatically = true)
+    @Query("delete from RideRecordPointEntity p where p.rideRecordId in :rideRecordIds")
+    void deleteByRideRecordIdIn(@Param("rideRecordIds") List<Long> rideRecordIds);
 }

--- a/src/main/java/com/bikeprojectminji/bikeback/ride/repository/RideRecordProcessedPointRepository.java
+++ b/src/main/java/com/bikeprojectminji/bikeback/ride/repository/RideRecordProcessedPointRepository.java
@@ -3,6 +3,9 @@ package com.bikeprojectminji.bikeback.ride.repository;
 import com.bikeprojectminji.bikeback.ride.entity.RideRecordProcessedPointEntity;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface RideRecordProcessedPointRepository extends JpaRepository<RideRecordProcessedPointEntity, Long> {
 
@@ -12,5 +15,7 @@ public interface RideRecordProcessedPointRepository extends JpaRepository<RideRe
 
     void deleteByRideRecordId(Long rideRecordId);
 
-    void deleteByRideRecordIdIn(List<Long> rideRecordIds);
+    @Modifying(flushAutomatically = true)
+    @Query("delete from RideRecordProcessedPointEntity p where p.rideRecordId in :rideRecordIds")
+    void deleteByRideRecordIdIn(@Param("rideRecordIds") List<Long> rideRecordIds);
 }

--- a/src/test/java/com/bikeprojectminji/bikeback/ride/service/RideRecordDeletionIntegrationTest.java
+++ b/src/test/java/com/bikeprojectminji/bikeback/ride/service/RideRecordDeletionIntegrationTest.java
@@ -1,0 +1,109 @@
+package com.bikeprojectminji.bikeback.ride.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.BDDMockito.given;
+
+import com.bikeprojectminji.bikeback.auth.entity.UserEntity;
+import com.bikeprojectminji.bikeback.auth.service.AuthService;
+import com.bikeprojectminji.bikeback.course.entity.CourseEntity;
+import com.bikeprojectminji.bikeback.course.entity.CourseVisibility;
+import com.bikeprojectminji.bikeback.course.repository.CourseRepository;
+import com.bikeprojectminji.bikeback.ride.entity.RideRecordEntity;
+import com.bikeprojectminji.bikeback.ride.entity.RideRecordPointEntity;
+import com.bikeprojectminji.bikeback.ride.entity.RideRecordProcessedPointEntity;
+import com.bikeprojectminji.bikeback.ride.repository.RideRecordPointRepository;
+import com.bikeprojectminji.bikeback.ride.repository.RideRecordProcessedPointRepository;
+import com.bikeprojectminji.bikeback.ride.repository.RideRecordRepository;
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class RideRecordDeletionIntegrationTest {
+
+    @Autowired
+    private RideRecordDeletionService rideRecordDeletionService;
+
+    @Autowired
+    private RideRecordRepository rideRecordRepository;
+
+    @Autowired
+    private RideRecordPointRepository rideRecordPointRepository;
+
+    @Autowired
+    private RideRecordProcessedPointRepository rideRecordProcessedPointRepository;
+
+    @Autowired
+    private CourseRepository courseRepository;
+
+    @MockitoBean
+    private AuthService authService;
+
+    @BeforeEach
+    void setUp() {
+        courseRepository.deleteAll();
+        rideRecordProcessedPointRepository.deleteAll();
+        rideRecordPointRepository.deleteAll();
+        rideRecordRepository.deleteAll();
+
+        UserEntity user = new UserEntity("external-1", "bikeoasis@example.com", null, "bikeoasis", null);
+        ReflectionTestUtils.setField(user, "id", 1L);
+        given(authService.findUserBySubject("1")).willReturn(user);
+    }
+
+    @Test
+    @DisplayName("웹 HUD summary와 trace로 생성된 기록 삭제는 포인트를 지우고 연결 코스만 분리한다")
+    void deleteRideRecordCreatedByWebHudSummaryAndTraceDeletesPointsAndDetachesCourse() {
+        RideRecordEntity rideRecord = rideRecordRepository.save(new RideRecordEntity(
+                1L,
+                "web-hud-ride-delete-001",
+                OffsetDateTime.parse("2026-06-16T10:00:00+09:00"),
+                OffsetDateTime.parse("2026-06-16T10:30:00+09:00"),
+                8200,
+                1800
+        ));
+        rideRecordPointRepository.saveAll(List.of(
+                new RideRecordPointEntity(rideRecord.getId(), 1, BigDecimal.valueOf(37.5665000), BigDecimal.valueOf(126.9780000)),
+                new RideRecordPointEntity(rideRecord.getId(), 2, BigDecimal.valueOf(37.5671000), BigDecimal.valueOf(126.9792000))
+        ));
+        rideRecordProcessedPointRepository.saveAll(List.of(
+                new RideRecordProcessedPointEntity(rideRecord.getId(), 1, BigDecimal.valueOf(37.5665000), BigDecimal.valueOf(126.9780000)),
+                new RideRecordProcessedPointEntity(rideRecord.getId(), 2, BigDecimal.valueOf(37.5671000), BigDecimal.valueOf(126.9792000))
+        ));
+        CourseEntity linkedCourse = courseRepository.save(new CourseEntity(
+                "웹 HUD 저장 코스",
+                "삭제 대상 자유 주행 기록에서 만든 코스",
+                BigDecimal.valueOf(8.2),
+                30,
+                1,
+                false,
+                null,
+                BigDecimal.valueOf(37.5665000),
+                BigDecimal.valueOf(126.9780000),
+                1L,
+                rideRecord.getId(),
+                CourseVisibility.PRIVATE
+        ));
+
+        assertThatCode(() -> rideRecordDeletionService.deleteRideRecord("1", rideRecord.getId()))
+                .doesNotThrowAnyException();
+
+        assertThat(rideRecordRepository.findById(rideRecord.getId())).isEmpty();
+        assertThat(rideRecordPointRepository.countByRideRecordId(rideRecord.getId())).isZero();
+        assertThat(rideRecordProcessedPointRepository.countByRideRecordId(rideRecord.getId())).isZero();
+        assertThat(courseRepository.findById(linkedCourse.getId()))
+                .get()
+                .extracting(CourseEntity::getSourceRideRecordId)
+                .isNull();
+    }
+}

--- a/src/test/resources/schema-h2.sql
+++ b/src/test/resources/schema-h2.sql
@@ -137,7 +137,10 @@ CREATE TABLE ride_record_points (
     altitude_m NUMERIC(8,2),
     distance_to_route_m NUMERIC(8,2),
     route_progress_pct NUMERIC(5,2),
-    CONSTRAINT uq_ride_record_points_record_order UNIQUE (ride_record_id, point_order)
+    CONSTRAINT uq_ride_record_points_record_order UNIQUE (ride_record_id, point_order),
+    CONSTRAINT fk_ride_record_points_ride_record
+        FOREIGN KEY (ride_record_id) REFERENCES ride_records (id)
+        ON DELETE CASCADE
 );
 
 CREATE TABLE ride_record_processed_points (
@@ -147,7 +150,10 @@ CREATE TABLE ride_record_processed_points (
     latitude NUMERIC(10,7) NOT NULL,
     longitude NUMERIC(10,7) NOT NULL,
     created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
-    CONSTRAINT uq_ride_record_processed_points_record_order UNIQUE (ride_record_id, point_order)
+    CONSTRAINT uq_ride_record_processed_points_record_order UNIQUE (ride_record_id, point_order),
+    CONSTRAINT fk_ride_record_processed_points_ride_record
+        FOREIGN KEY (ride_record_id) REFERENCES ride_records (id)
+        ON DELETE CASCADE
 );
 
 CREATE TABLE client_events (


### PR DESCRIPTION
## 변경 요약
- `DELETE /api/v1/ride-records/{rideRecordId}`가 실제 DB cascade 환경에서 500을 반환하던 문제를 수정했습니다.
- raw/processed point 삭제를 Spring Data derived delete가 아닌 JPQL bulk delete로 변경해, 부모 `ride_records` 삭제의 `ON DELETE CASCADE`와 Hibernate entity delete action이 중복되지 않게 했습니다.
- H2 테스트 스키마에 운영과 같은 FK cascade를 추가하고, summary+trace 후 삭제 통합 테스트를 추가했습니다.

## 원인 요약
- 기존 삭제 로직은 child point를 entity delete로 예약한 뒤 부모 ride record를 batch delete했습니다.
- 운영 DB에서는 부모 삭제가 FK `ON DELETE CASCADE`로 child row를 먼저 제거했고, commit flush 때 Hibernate가 이미 사라진 `ride_record_points.id`를 다시 삭제하려 하면서 `ObjectOptimisticLockingFailureException`이 발생했습니다.

## 검증
- [x] `./gradlew --no-daemon test --tests '*RideRecordDeletionIntegrationTest'`\n- [x] `./gradlew --no-daemon test --tests '*RideRecordControllerTest' --tests '*RideRecordServiceTest' --tests '*RideRecordDeletionServiceTest' --tests '*RideRecordDeletionIntegrationTest' --tests '*RideRecordRetentionSchedulerTest'`\n- [x] `./gradlew --no-daemon test`\n- [x] 실제 HTTP smoke: register 200, summary 200, trace 200, DELETE 204, body 0 byte, DB ride/point 0건\n\n## self-review\n### 백엔드 아키텍처/도메인 리뷰어\n- blocking issue: 없음\n- non-blocking improvement: 향후 삭제 정책이 늘어나면 repository bulk delete 반환 count를 운영 로그에 남길 수 있습니다.\n- 검증 근거: 실제 FK cascade를 테스트 스키마에 반영했고, 통합 테스트에서 row count 0 회귀를 잠갔습니다.\n\n### QA/보안/운영 리뷰어\n- blocking issue: 없음\n- non-blocking improvement: smoke 스크립트를 별도 runbook/script로 승격하면 리뷰테스트 세션 재현성이 더 좋아집니다.\n- 검증 근거: 실제 PostGIS/Redis/bootRun 환경에서 JWT 기반 HTTP smoke를 수행했고 DELETE 204/body 0 byte를 확인했습니다.\n\n## 남은 리스크\n- 이번 PR은 GraphHopper/self-host fallback 검증 범위가 아닙니다.\n- 기존 untracked `ARTIFACTS/`는 이번 변경 범위가 아니라 제외했습니다.\n