### PR TITLE
권한 JWT beta 기반 구현

### DIFF
--- a/docs/auth-role-beta-foundation-report-2026-06-17.md
+++ b/docs/auth-role-beta-foundation-report-2026-06-17.md
@@ -1,0 +1,93 @@
+# 권한/JWT/beta 기반 구현 보고서
+
+- 작성일: 2026-06-17
+- 브랜치: `feature/auth-role-beta-foundation`
+- 기준 커밋: `94e4254`
+- 작업 범위: 커뮤니티/팟 구현 PR-1 권한/JWT/beta 기반
+
+## 1. 목표
+
+커뮤니티/팟 후속 기능의 전제인 권한 기반을 작게 구현한다. 이번 범위는 `USER`, `OPS_ADMIN` role 저장, JWT `roles` claim 발급, Spring Security 인가 판단, beta guard까지만 포함한다.
+
+## 2. 변경 요약
+
+- `user_roles` 테이블을 추가해 사용자 role을 저장할 수 있게 했다.
+- `UserRole` enum을 추가하고 기본 role을 `USER`로 두었다.
+- access token 발급 시 `roles` claim에 사용자 role 목록을 넣는다.
+- `/api/v1/admin/**` 경로는 `ROLE_OPS_ADMIN` authority가 있어야 접근 가능하게 했다.
+- 후속 기능에서 재사용할 `BetaAccessPolicy`를 추가했다.
+- H2 테스트 스키마에 `user_roles`를 동기화했다.
+
+## 3. 변경 파일
+
+- `src/main/java/com/bikeprojectminji/bikeback/auth/entity/UserRole.java`
+- `src/main/java/com/bikeprojectminji/bikeback/auth/entity/UserEntity.java`
+- `src/main/java/com/bikeprojectminji/bikeback/auth/service/AuthTokenService.java`
+- `src/main/java/com/bikeprojectminji/bikeback/global/config/SecurityConfig.java`
+- `src/main/java/com/bikeprojectminji/bikeback/beta/service/BetaAccessPolicy.java`
+- `src/main/resources/db/migration/V26__create_user_roles.sql`
+- `src/test/resources/schema-h2.sql`
+- `src/test/java/com/bikeprojectminji/bikeback/auth/service/AuthTokenServiceTest.java`
+- `src/test/java/com/bikeprojectminji/bikeback/auth/entity/UserRolePersistenceIntegrationTest.java`
+- `src/test/java/com/bikeprojectminji/bikeback/beta/service/BetaAccessPolicyTest.java`
+- `src/test/java/com/bikeprojectminji/bikeback/global/config/AdminEndpointSecurityTest.java`
+
+## 4. 권한/JWT/beta 정책 결정
+
+- 저장 role 값은 `USER`, `OPS_ADMIN`으로 시작한다.
+- 기존 `ROLE_OPS`는 `/health/monitor` 보호용으로 유지하고, 커뮤니티 운영 권한은 `OPS_ADMIN`으로 분리한다.
+- JWT `roles` claim에는 `USER`, `OPS_ADMIN`처럼 `ROLE_` prefix 없는 role 값을 넣는다.
+- Spring Security는 기존 converter를 통해 `ROLE_USER`, `ROLE_OPS_ADMIN` authority로 변환한다.
+- beta 권한은 기존 `users.beta_access_granted`를 기준으로 판단한다.
+- beta 권한 부족은 `ForbiddenException("베타 초대 권한이 필요합니다.")`로 막는다.
+
+## 5. API 계약 변경 여부
+
+외부 API path, request DTO, response DTO는 변경하지 않았다.
+
+단, 내부 인증 토큰의 access token claim에 `roles`가 추가된다. 기존 `tokenType`, `displayName`, `email` claim은 유지된다.
+
+## 6. 검증
+
+### RED
+
+아래 테스트를 먼저 추가했고, 구현 전에는 `UserRole`, `BetaAccessPolicy` 부재로 컴파일 실패했다.
+
+```bash
+./gradlew --no-daemon test --tests 'com.bikeprojectminji.bikeback.auth.service.AuthTokenServiceTest' --tests 'com.bikeprojectminji.bikeback.beta.service.BetaAccessPolicyTest' --tests 'com.bikeprojectminji.bikeback.global.config.AdminEndpointSecurityTest' --tests 'com.bikeprojectminji.bikeback.auth.entity.UserRolePersistenceIntegrationTest'
+```
+
+### GREEN
+
+같은 targeted test 재실행 결과 성공했다.
+
+```bash
+./gradlew --no-daemon test --tests 'com.bikeprojectminji.bikeback.auth.service.AuthTokenServiceTest' --tests 'com.bikeprojectminji.bikeback.beta.service.BetaAccessPolicyTest' --tests 'com.bikeprojectminji.bikeback.global.config.AdminEndpointSecurityTest' --tests 'com.bikeprojectminji.bikeback.auth.entity.UserRolePersistenceIntegrationTest'
+```
+
+결과: `BUILD SUCCESSFUL`
+
+### 회귀 검증
+
+```bash
+./gradlew --no-daemon test --tests '*Auth*' --tests '*Security*' --tests '*Beta*' --tests '*MonitoringControllerTest'
+```
+
+결과: `BUILD SUCCESSFUL`
+
+```bash
+./gradlew --no-daemon test
+```
+
+결과: `BUILD SUCCESSFUL`
+
+## 7. 남은 리스크
+
+- `OPS_ADMIN`을 부여하는 운영 API나 관리자 화면은 아직 없다. 초기 부여는 DB seed, 운영 스크립트, 별도 관리자 API 중 후속 결정이 필요하다.
+- 기존 사용자에게 `USER` role을 backfill하는 migration은 포함했지만, 운영 배포 전 Flyway checksum/기존 DB 상태 확인이 필요하다.
+- beta 초대코드 해시 저장, 발급 주체, 기존 가입자 redeem API는 이번 범위가 아니다.
+- Course publication, sourceDetached, moderation, public list, 팟 도메인은 구현하지 않았다.
+
+## 8. 다음 PR 추천
+
+다음 PR은 ADR 순서에 따라 `sourceDetached` 보강만 다루는 것이 좋다. `course_publications`나 moderation은 그 다음 PR로 분리한다.

--- a/src/main/java/com/bikeprojectminji/bikeback/auth/entity/UserEntity.java
+++ b/src/main/java/com/bikeprojectminji/bikeback/auth/entity/UserEntity.java
@@ -1,13 +1,22 @@
 package com.bikeprojectminji.bikeback.auth.entity;
 
 import jakarta.persistence.Column;
+import jakarta.persistence.CollectionTable;
+import jakarta.persistence.ElementCollection;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
 import jakarta.persistence.Table;
 import java.time.Clock;
 import java.time.OffsetDateTime;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.Set;
 
 @Entity
 @Table(name = "users")
@@ -46,6 +55,12 @@ public class UserEntity {
 
     @Column(name = "deleted_at")
     private OffsetDateTime deletedAt;
+
+    @ElementCollection(fetch = FetchType.EAGER)
+    @CollectionTable(name = "user_roles", joinColumns = @JoinColumn(name = "user_id"))
+    @Enumerated(EnumType.STRING)
+    @Column(name = "role", nullable = false, length = 40)
+    private Set<UserRole> roles = EnumSet.of(UserRole.USER);
 
     protected UserEntity() {
     }
@@ -90,6 +105,10 @@ public class UserEntity {
 
     public void grantBetaAccess() {
         this.betaAccessGranted = true;
+    }
+
+    public void grantRole(UserRole role) {
+        roles.add(role);
     }
 
     public boolean isDeleted() {
@@ -138,5 +157,9 @@ public class UserEntity {
 
     public OffsetDateTime getDeletedAt() {
         return deletedAt;
+    }
+
+    public Set<UserRole> getRoles() {
+        return Collections.unmodifiableSet(roles);
     }
 }

--- a/src/main/java/com/bikeprojectminji/bikeback/auth/entity/UserRole.java
+++ b/src/main/java/com/bikeprojectminji/bikeback/auth/entity/UserRole.java
@@ -1,0 +1,6 @@
+package com.bikeprojectminji.bikeback.auth.entity;
+
+public enum UserRole {
+    USER,
+    OPS_ADMIN
+}

--- a/src/main/java/com/bikeprojectminji/bikeback/auth/service/AuthTokenService.java
+++ b/src/main/java/com/bikeprojectminji/bikeback/auth/service/AuthTokenService.java
@@ -101,6 +101,9 @@ public class AuthTokenService {
         if (user.getEmail() != null) {
             claimsBuilder.claim("email", user.getEmail());
         }
+        if (TOKEN_TYPE_ACCESS.equals(tokenType)) {
+            claimsBuilder.claim("roles", user.getRoles().stream().sorted().map(Enum::name).toList());
+        }
 
         if (TOKEN_TYPE_REFRESH.equals(tokenType)) {
             claimsBuilder.claim("jti", UUID.randomUUID().toString());

--- a/src/main/java/com/bikeprojectminji/bikeback/beta/service/BetaAccessPolicy.java
+++ b/src/main/java/com/bikeprojectminji/bikeback/beta/service/BetaAccessPolicy.java
@@ -1,0 +1,20 @@
+package com.bikeprojectminji.bikeback.beta.service;
+
+import com.bikeprojectminji.bikeback.auth.entity.UserEntity;
+import com.bikeprojectminji.bikeback.global.exception.ForbiddenException;
+import org.springframework.stereotype.Component;
+
+@Component
+public class BetaAccessPolicy {
+
+    public void assertBetaAccess(UserEntity user) {
+        if (hasBetaAccess(user)) {
+            return;
+        }
+        throw new ForbiddenException("베타 초대 권한이 필요합니다.");
+    }
+
+    public boolean hasBetaAccess(UserEntity user) {
+        return user != null && user.isBetaAccessGranted();
+    }
+}

--- a/src/main/java/com/bikeprojectminji/bikeback/global/config/SecurityConfig.java
+++ b/src/main/java/com/bikeprojectminji/bikeback/global/config/SecurityConfig.java
@@ -71,6 +71,7 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.DELETE, "/api/v1/auth/me").authenticated()
                         .requestMatchers(HttpMethod.DELETE, "/api/v1/account/me").authenticated()
                         .requestMatchers(HttpMethod.GET, "/health/monitor").hasAuthority("ROLE_OPS")
+                        .requestMatchers("/api/v1/admin/**").hasAuthority("ROLE_OPS_ADMIN")
                         .requestMatchers(HttpMethod.GET, "/api/v1/location/me/recent").authenticated()
                         .requestMatchers(HttpMethod.GET, "/api/v1/addresses/search").authenticated()
                         .requestMatchers(HttpMethod.GET, "/api/v1/me/achievements").authenticated()

--- a/src/main/resources/db/migration/V26__create_user_roles.sql
+++ b/src/main/resources/db/migration/V26__create_user_roles.sql
@@ -1,0 +1,16 @@
+CREATE TABLE IF NOT EXISTS user_roles (
+    user_id BIGINT NOT NULL,
+    role VARCHAR(40) NOT NULL,
+    CONSTRAINT pk_user_roles PRIMARY KEY (user_id, role),
+    CONSTRAINT fk_user_roles_user
+        FOREIGN KEY (user_id) REFERENCES users (id)
+        ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_user_roles_role
+    ON user_roles (role ASC);
+
+INSERT INTO user_roles (user_id, role)
+SELECT id, 'USER'
+FROM users
+ON CONFLICT DO NOTHING;

--- a/src/test/java/com/bikeprojectminji/bikeback/auth/entity/UserRolePersistenceIntegrationTest.java
+++ b/src/test/java/com/bikeprojectminji/bikeback/auth/entity/UserRolePersistenceIntegrationTest.java
@@ -1,0 +1,35 @@
+package com.bikeprojectminji.bikeback.auth.entity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.bikeprojectminji.bikeback.auth.repository.UserRepository;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class UserRolePersistenceIntegrationTest {
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private EntityManager entityManager;
+
+    @Test
+    @DisplayName("사용자 role은 user_roles 테이블에 저장되고 다시 조회된다")
+    void userRolesAreStoredAndLoaded() {
+        UserEntity user = new UserEntity("role-user", "role@example.com", "hash", "role-rider", null);
+        user.grantRole(UserRole.OPS_ADMIN);
+        UserEntity savedUser = userRepository.saveAndFlush(user);
+        entityManager.clear();
+
+        UserEntity loadedUser = userRepository.findById(savedUser.getId()).orElseThrow();
+
+        assertThat(loadedUser.getRoles()).containsExactlyInAnyOrder(UserRole.USER, UserRole.OPS_ADMIN);
+    }
+}

--- a/src/test/java/com/bikeprojectminji/bikeback/auth/service/AuthTokenServiceTest.java
+++ b/src/test/java/com/bikeprojectminji/bikeback/auth/service/AuthTokenServiceTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.verify;
 
 import com.bikeprojectminji.bikeback.auth.dto.LoginResponse;
 import com.bikeprojectminji.bikeback.auth.entity.UserEntity;
+import com.bikeprojectminji.bikeback.auth.entity.UserRole;
 import com.bikeprojectminji.bikeback.global.exception.UnauthorizedException;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
@@ -75,6 +76,39 @@ class AuthTokenServiceTest {
         );
         assertThat(sessionCaptor.getValue().subject()).isEqualTo("1");
         assertThat(sessionCaptor.getValue().tokenHash()).isEqualTo(tokenHash("refresh-token"));
+    }
+
+    @Test
+    @DisplayName("access token은 사용자 role을 roles claim으로 발급한다")
+    void issueLoginResponseAddsRolesClaimToAccessToken() {
+        AuthTokenService authTokenService = createAuthTokenService();
+        UserEntity user = new UserEntity(null, "ops@example.com", "password-hash", "ops-rider", null);
+        ReflectionTestUtils.setField(user, "id", 9L);
+        user.grantRole(UserRole.OPS_ADMIN);
+        given(jwtEncoder.encode(any(JwtEncoderParameters.class))).willReturn(
+                Jwt.withTokenValue("access-token")
+                        .header("alg", "HS256")
+                        .subject("9")
+                        .issuedAt(clock.instant())
+                        .expiresAt(clock.instant().plusSeconds(900))
+                        .build()
+        ).willReturn(
+                Jwt.withTokenValue("refresh-token")
+                        .header("alg", "HS256")
+                        .subject("9")
+                        .issuedAt(clock.instant())
+                        .expiresAt(clock.instant().plusSeconds(1209600))
+                        .build()
+        );
+
+        authTokenService.issueLoginResponse(user);
+
+        ArgumentCaptor<JwtEncoderParameters> tokenCaptor = ArgumentCaptor.forClass(JwtEncoderParameters.class);
+        verify(jwtEncoder, org.mockito.Mockito.times(2)).encode(tokenCaptor.capture());
+        JwtEncoderParameters accessTokenParameters = tokenCaptor.getAllValues().get(0);
+        assertThat(accessTokenParameters.getClaims().getClaims().get("roles"))
+                .asList()
+                .containsExactly("USER", "OPS_ADMIN");
     }
 
     @Test

--- a/src/test/java/com/bikeprojectminji/bikeback/beta/service/BetaAccessPolicyTest.java
+++ b/src/test/java/com/bikeprojectminji/bikeback/beta/service/BetaAccessPolicyTest.java
@@ -1,0 +1,34 @@
+package com.bikeprojectminji.bikeback.beta.service;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.bikeprojectminji.bikeback.auth.entity.UserEntity;
+import com.bikeprojectminji.bikeback.global.exception.ForbiddenException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class BetaAccessPolicyTest {
+
+    private final BetaAccessPolicy betaAccessPolicy = new BetaAccessPolicy();
+
+    @Test
+    @DisplayName("beta 권한이 있는 사용자는 beta 전용 기능 guard를 통과한다")
+    void assertBetaAccessAllowsGrantedUser() {
+        UserEntity user = new UserEntity("external", "beta@example.com", "hash", "beta-rider", null);
+        user.grantBetaAccess();
+
+        assertThatCode(() -> betaAccessPolicy.assertBetaAccess(user))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("beta 권한이 없는 사용자는 beta 전용 기능 guard에서 403으로 거부된다")
+    void assertBetaAccessRejectsUserWithoutBetaAccess() {
+        UserEntity user = new UserEntity("external", "regular@example.com", "hash", "regular-rider", null);
+
+        assertThatThrownBy(() -> betaAccessPolicy.assertBetaAccess(user))
+                .isInstanceOf(ForbiddenException.class)
+                .hasMessage("베타 초대 권한이 필요합니다.");
+    }
+}

--- a/src/test/java/com/bikeprojectminji/bikeback/global/config/AdminEndpointSecurityTest.java
+++ b/src/test/java/com/bikeprojectminji/bikeback/global/config/AdminEndpointSecurityTest.java
@@ -1,0 +1,70 @@
+package com.bikeprojectminji.bikeback.global.config;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@WebMvcTest(AdminEndpointSecurityTest.AdminSecurityProbeController.class)
+@Import({SecurityConfig.class, AdminEndpointSecurityTest.AdminSecurityProbeController.class})
+@TestPropertySource(properties = {
+        "auth.jwt.secret=test-only-jwt-secret-32-byte-key!",
+        "auth.jwt.issuer=bike-back-test",
+        "auth.jwt.token-validity-sec=900"
+})
+class AdminEndpointSecurityTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    @DisplayName("admin API 경로는 인증 없이는 접근할 수 없다")
+    void adminApiRejectsAnonymousUser() throws Exception {
+        mockMvc.perform(get("/api/v1/admin/security-probe"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DisplayName("admin API 경로는 일반 USER 권한으로 접근할 수 없다")
+    void adminApiRejectsRegularUserRole() throws Exception {
+        mockMvc.perform(get("/api/v1/admin/security-probe")
+                        .with(jwt().jwt(jwt -> jwt
+                                        .subject("1")
+                                        .claim("tokenType", "access")
+                                        .claim("roles", List.of("USER")))
+                                .authorities(new SimpleGrantedAuthority("ROLE_USER"))))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("admin API 경로는 OPS_ADMIN 권한으로 접근할 수 있다")
+    void adminApiAllowsOpsAdminRole() throws Exception {
+        mockMvc.perform(get("/api/v1/admin/security-probe")
+                        .with(jwt().jwt(jwt -> jwt
+                                        .subject("2")
+                                        .claim("tokenType", "access")
+                                        .claim("roles", List.of("USER", "OPS_ADMIN")))
+                                .authorities(new SimpleGrantedAuthority("ROLE_OPS_ADMIN"))))
+                .andExpect(status().isOk());
+    }
+
+    @RestController
+    public static class AdminSecurityProbeController {
+
+        @GetMapping("/api/v1/admin/security-probe")
+        String probe() {
+            return "ok";
+        }
+    }
+}

--- a/src/test/resources/schema-h2.sql
+++ b/src/test/resources/schema-h2.sql
@@ -44,6 +44,15 @@ CREATE TABLE beta_invitation_codes (
     created_at TIMESTAMP WITH TIME ZONE NOT NULL
 );
 
+CREATE TABLE user_roles (
+    user_id BIGINT NOT NULL,
+    role VARCHAR(40) NOT NULL,
+    CONSTRAINT pk_user_roles PRIMARY KEY (user_id, role),
+    CONSTRAINT fk_user_roles_user
+        FOREIGN KEY (user_id) REFERENCES users (id)
+        ON DELETE CASCADE
+);
+
 CREATE TABLE user_preference (
     id BIGSERIAL PRIMARY KEY,
     user_id BIGINT NOT NULL UNIQUE,


### PR DESCRIPTION
## 변경 요약
- user_roles 저장 구조와 UserRole(USER, OPS_ADMIN)을 추가했습니다.
- access token에 roles claim을 발급하고, Spring Security에서 /api/v1/admin/** 경로를 ROLE_OPS_ADMIN으로 보호하도록 했습니다.
- 후속 커뮤니티/팟 기능에서 재사용할 BetaAccessPolicy를 추가했습니다.
- Course publication, sourceDetached, moderation, public list, 팟 도메인은 이번 PR에 포함하지 않았습니다.

## 검증
- RED 확인: 신규 targeted test 추가 후 UserRole/BetaAccessPolicy 부재로 컴파일 실패 확인
- ./gradlew --no-daemon test --tests 'com.bikeprojectminji.bikeback.auth.service.AuthTokenServiceTest' --tests 'com.bikeprojectminji.bikeback.beta.service.BetaAccessPolicyTest' --tests 'com.bikeprojectminji.bikeback.global.config.AdminEndpointSecurityTest' --tests 'com.bikeprojectminji.bikeback.auth.entity.UserRolePersistenceIntegrationTest'
- ./gradlew --no-daemon test --tests '*Auth*' --tests '*Security*' --tests '*Beta*' --tests '*MonitoringControllerTest'
- ./gradlew --no-daemon test

## API 계약
- 외부 API request/response 변경 없음
- access token 내부 claim에 roles 추가

## 남은 리스크
- OPS_ADMIN 부여 운영 경로는 아직 없습니다. DB seed, 운영 스크립트, 관리자 API 중 후속 결정이 필요합니다.
- beta 초대코드 해시 저장, 발급 주체, 기존 가입자 redeem API는 후속 범위입니다.
