### PR TITLE
feat: 코스 공개게시 상태 관리 추가

### DIFF
--- a/docs/코스_공개게시_기반구현_보고서_2026-06-24.md
+++ b/docs/코스_공개게시_기반구현_보고서_2026-06-24.md
@@ -1,0 +1,38 @@
+# 코스 공개게시 기반구현 보고서
+
+작성일: 2026-06-24
+
+## 목적
+
+코스를 커뮤니티 노출 대상으로 전환하거나 해제하는 별도 publication 상태를 추가했다.
+기존 `courses.visibility`는 코스 접근 범위이고, 이번 변경의 `course_publications.status`는 공개게시 상태를 기록하는 별도 기준이다.
+
+## 변경 범위
+
+- `POST /api/v1/courses/{courseId}/publication`
+  - beta 권한이 있는 코스 소유자가 코스를 `ACTIVE` publication으로 전환한다.
+  - 이미 `ACTIVE`면 기존 publication을 그대로 반환한다.
+- `DELETE /api/v1/courses/{courseId}/publication`
+  - beta 권한이 있는 코스 소유자가 기존 publication을 `INACTIVE`로 전환한다.
+- `course_publications` 테이블 추가
+  - 코스당 publication 1행을 유지한다.
+  - `status`, `published_at`, `unpublished_at`으로 게시 상태 변경 이력을 표현한다.
+
+## 정책
+
+- beta 초대 권한이 없는 사용자는 publication API를 사용할 수 없다.
+- 코스 소유자가 아니면 publication 상태를 바꿀 수 없다.
+- 없는 코스는 404로 응답한다.
+- 공개해제 대상 publication이 없으면 404로 응답한다.
+
+## 검증
+
+- RED: production 구현 없이 테스트만 이관했을 때 `CoursePublicationResponse`, `CoursePublicationService`, `CoursePublicationRepository`, `CoursePublicationEntity` 부재로 컴파일 실패를 확인했다.
+- GREEN: `CoursePublicationServiceTest`, `CourseControllerMutationTest` targeted 테스트 통과.
+- 회귀: course 패키지 controller/service/entity/repository 테스트 통과.
+- 전체: `./gradlew test` 통과.
+
+## 남은 판단
+
+- `course_publications.status`와 `courses.visibility`를 완전히 별도 정책으로 둘지, `ACTIVE` 전환 시 `courses.visibility = PUBLIC`도 함께 강제할지는 별도 제품 정책 결정이 필요하다.
+- 동시에 최초 공개 요청이 들어오는 경우 DB unique constraint가 최종 방어선이다. 운영 트래픽이 늘면 service-level conflict 처리를 추가 검토한다.

--- a/src/main/java/com/bikeprojectminji/bikeback/course/controller/CourseController.java
+++ b/src/main/java/com/bikeprojectminji/bikeback/course/controller/CourseController.java
@@ -1,32 +1,35 @@
 package com.bikeprojectminji.bikeback.course.controller;
 
-import com.bikeprojectminji.bikeback.course.dto.CourseWriteResponse;
+import com.bikeprojectminji.bikeback.course.dto.CourseDetailResponse;
+import com.bikeprojectminji.bikeback.course.dto.CourseDownloadResponse;
+import com.bikeprojectminji.bikeback.course.dto.CourseListResponse;
+import com.bikeprojectminji.bikeback.course.dto.CoursePublicationResponse;
 import com.bikeprojectminji.bikeback.course.dto.CourseReportRequest;
 import com.bikeprojectminji.bikeback.course.dto.CourseReportResponse;
-import com.bikeprojectminji.bikeback.course.dto.CourseShareResponse;
-import com.bikeprojectminji.bikeback.course.dto.CourseDownloadResponse;
-import com.bikeprojectminji.bikeback.course.dto.CreateCourseFromRideRecordRequest;
-import com.bikeprojectminji.bikeback.course.dto.CourseDetailResponse;
 import com.bikeprojectminji.bikeback.course.dto.CourseRoutePointsResponse;
-import com.bikeprojectminji.bikeback.course.dto.CourseListResponse;
+import com.bikeprojectminji.bikeback.course.dto.CourseShareResponse;
+import com.bikeprojectminji.bikeback.course.dto.CourseWriteResponse;
+import com.bikeprojectminji.bikeback.course.dto.CreateCourseFromRideRecordRequest;
 import com.bikeprojectminji.bikeback.course.dto.FeaturedCourseResponse;
 import com.bikeprojectminji.bikeback.course.dto.UpdateCourseRequest;
 import com.bikeprojectminji.bikeback.course.dto.UpdateCourseVisibilityRequest;
-import com.bikeprojectminji.bikeback.global.exception.BadRequestException;
-import com.bikeprojectminji.bikeback.global.response.ApiResponse;
-import java.math.BigDecimal;
 import com.bikeprojectminji.bikeback.course.entity.CourseReportReason;
+import com.bikeprojectminji.bikeback.course.service.CoursePublicationService;
 import com.bikeprojectminji.bikeback.course.service.CourseQueryService;
 import com.bikeprojectminji.bikeback.course.service.CourseReportService;
 import com.bikeprojectminji.bikeback.course.service.CourseService;
+import com.bikeprojectminji.bikeback.global.exception.BadRequestException;
+import com.bikeprojectminji.bikeback.global.response.ApiResponse;
+import java.math.BigDecimal;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -38,15 +41,18 @@ public class CourseController {
     private final CourseService courseService;
     private final CourseQueryService courseQueryService;
     private final CourseReportService courseReportService;
+    private final CoursePublicationService coursePublicationService;
 
     public CourseController(
             CourseService courseService,
             CourseQueryService courseQueryService,
-            CourseReportService courseReportService
+            CourseReportService courseReportService,
+            CoursePublicationService coursePublicationService
     ) {
         this.courseService = courseService;
         this.courseQueryService = courseQueryService;
         this.courseReportService = courseReportService;
+        this.coursePublicationService = coursePublicationService;
     }
 
     @GetMapping
@@ -128,6 +134,22 @@ public class CourseController {
             @RequestBody UpdateCourseVisibilityRequest request
     ) {
         return ApiResponse.success(courseService.updateCourseVisibility(jwt.getSubject(), courseId, request));
+    }
+
+    @PostMapping("/{courseId}/publication")
+    public ApiResponse<CoursePublicationResponse> publishCourse(
+            @AuthenticationPrincipal Jwt jwt,
+            @PathVariable Long courseId
+    ) {
+        return ApiResponse.success(coursePublicationService.publishCourse(jwt.getSubject(), courseId));
+    }
+
+    @DeleteMapping("/{courseId}/publication")
+    public ApiResponse<CoursePublicationResponse> unpublishCourse(
+            @AuthenticationPrincipal Jwt jwt,
+            @PathVariable Long courseId
+    ) {
+        return ApiResponse.success(coursePublicationService.unpublishCourse(jwt.getSubject(), courseId));
     }
 
     @PostMapping("/{courseId}/reports")

--- a/src/main/java/com/bikeprojectminji/bikeback/course/dto/CoursePublicationResponse.java
+++ b/src/main/java/com/bikeprojectminji/bikeback/course/dto/CoursePublicationResponse.java
@@ -1,0 +1,13 @@
+package com.bikeprojectminji.bikeback.course.dto;
+
+import java.time.OffsetDateTime;
+
+public record CoursePublicationResponse(
+        Long publicationId,
+        Long courseId,
+        Long ownerUserId,
+        String status,
+        OffsetDateTime publishedAt,
+        OffsetDateTime unpublishedAt
+) {
+}

--- a/src/main/java/com/bikeprojectminji/bikeback/course/entity/CoursePublicationEntity.java
+++ b/src/main/java/com/bikeprojectminji/bikeback/course/entity/CoursePublicationEntity.java
@@ -1,0 +1,109 @@
+package com.bikeprojectminji.bikeback.course.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.Clock;
+import java.time.OffsetDateTime;
+
+@Entity
+@Table(name = "course_publications")
+public class CoursePublicationEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "course_id", nullable = false)
+    private Long courseId;
+
+    @Column(name = "owner_user_id", nullable = false)
+    private Long ownerUserId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private CoursePublicationStatus status;
+
+    @Column(name = "published_at", nullable = false)
+    private OffsetDateTime publishedAt;
+
+    @Column(name = "unpublished_at")
+    private OffsetDateTime unpublishedAt;
+
+    @Column(name = "created_at", nullable = false)
+    private OffsetDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private OffsetDateTime updatedAt;
+
+    protected CoursePublicationEntity() {
+    }
+
+    public CoursePublicationEntity(Long courseId, Long ownerUserId, Clock clock) {
+        OffsetDateTime now = OffsetDateTime.now(clock);
+        this.courseId = courseId;
+        this.ownerUserId = ownerUserId;
+        this.status = CoursePublicationStatus.ACTIVE;
+        this.publishedAt = now;
+        this.createdAt = now;
+        this.updatedAt = now;
+    }
+
+    public void publish(Clock clock) {
+        if (status == CoursePublicationStatus.ACTIVE) {
+            return;
+        }
+        OffsetDateTime now = OffsetDateTime.now(clock);
+        this.status = CoursePublicationStatus.ACTIVE;
+        this.publishedAt = now;
+        this.unpublishedAt = null;
+        this.updatedAt = now;
+    }
+
+    public void unpublish(Clock clock) {
+        if (status == CoursePublicationStatus.INACTIVE) {
+            return;
+        }
+        OffsetDateTime now = OffsetDateTime.now(clock);
+        this.status = CoursePublicationStatus.INACTIVE;
+        this.unpublishedAt = now;
+        this.updatedAt = now;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Long getCourseId() {
+        return courseId;
+    }
+
+    public Long getOwnerUserId() {
+        return ownerUserId;
+    }
+
+    public CoursePublicationStatus getStatus() {
+        return status;
+    }
+
+    public OffsetDateTime getPublishedAt() {
+        return publishedAt;
+    }
+
+    public OffsetDateTime getUnpublishedAt() {
+        return unpublishedAt;
+    }
+
+    public OffsetDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public OffsetDateTime getUpdatedAt() {
+        return updatedAt;
+    }
+}

--- a/src/main/java/com/bikeprojectminji/bikeback/course/entity/CoursePublicationStatus.java
+++ b/src/main/java/com/bikeprojectminji/bikeback/course/entity/CoursePublicationStatus.java
@@ -1,0 +1,6 @@
+package com.bikeprojectminji.bikeback.course.entity;
+
+public enum CoursePublicationStatus {
+    ACTIVE,
+    INACTIVE
+}

--- a/src/main/java/com/bikeprojectminji/bikeback/course/repository/CoursePublicationRepository.java
+++ b/src/main/java/com/bikeprojectminji/bikeback/course/repository/CoursePublicationRepository.java
@@ -1,0 +1,10 @@
+package com.bikeprojectminji.bikeback.course.repository;
+
+import com.bikeprojectminji.bikeback.course.entity.CoursePublicationEntity;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CoursePublicationRepository extends JpaRepository<CoursePublicationEntity, Long> {
+
+    Optional<CoursePublicationEntity> findByCourseId(Long courseId);
+}

--- a/src/main/java/com/bikeprojectminji/bikeback/course/service/CoursePublicationService.java
+++ b/src/main/java/com/bikeprojectminji/bikeback/course/service/CoursePublicationService.java
@@ -1,0 +1,86 @@
+package com.bikeprojectminji.bikeback.course.service;
+
+import com.bikeprojectminji.bikeback.auth.entity.UserEntity;
+import com.bikeprojectminji.bikeback.auth.service.AuthService;
+import com.bikeprojectminji.bikeback.beta.service.BetaAccessPolicy;
+import com.bikeprojectminji.bikeback.course.dto.CoursePublicationResponse;
+import com.bikeprojectminji.bikeback.course.entity.CourseEntity;
+import com.bikeprojectminji.bikeback.course.entity.CoursePublicationEntity;
+import com.bikeprojectminji.bikeback.course.repository.CoursePublicationRepository;
+import com.bikeprojectminji.bikeback.course.repository.CourseRepository;
+import com.bikeprojectminji.bikeback.global.exception.NotFoundException;
+import java.time.Clock;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+public class CoursePublicationService {
+
+    private final AuthService authService;
+    private final CourseRepository courseRepository;
+    private final CoursePublicationRepository coursePublicationRepository;
+    private final BetaAccessPolicy betaAccessPolicy;
+    private final Clock clock;
+    private final CourseAccessPolicy courseAccessPolicy = new CourseAccessPolicy();
+
+    public CoursePublicationService(
+            AuthService authService,
+            CourseRepository courseRepository,
+            CoursePublicationRepository coursePublicationRepository,
+            BetaAccessPolicy betaAccessPolicy,
+            Clock clock
+    ) {
+        this.authService = authService;
+        this.courseRepository = courseRepository;
+        this.coursePublicationRepository = coursePublicationRepository;
+        this.betaAccessPolicy = betaAccessPolicy;
+        this.clock = clock;
+    }
+
+    public CoursePublicationResponse publishCourse(String subject, Long courseId) {
+        UserEntity user = authService.findUserBySubject(subject);
+        betaAccessPolicy.assertBetaAccess(user);
+        CourseEntity course = findOwnedCourse(courseId, user.getId());
+
+        CoursePublicationEntity publication = coursePublicationRepository.findByCourseId(course.getId())
+                .map(existingPublication -> {
+                    existingPublication.publish(clock);
+                    return existingPublication;
+                })
+                .orElseGet(() -> coursePublicationRepository.save(
+                        new CoursePublicationEntity(course.getId(), user.getId(), clock)
+                ));
+
+        return toResponse(publication);
+    }
+
+    public CoursePublicationResponse unpublishCourse(String subject, Long courseId) {
+        UserEntity user = authService.findUserBySubject(subject);
+        betaAccessPolicy.assertBetaAccess(user);
+        CourseEntity course = findOwnedCourse(courseId, user.getId());
+
+        CoursePublicationEntity publication = coursePublicationRepository.findByCourseId(course.getId())
+                .orElseThrow(() -> new NotFoundException("공개 게시 정보를 찾을 수 없습니다."));
+        publication.unpublish(clock);
+        return toResponse(publication);
+    }
+
+    private CourseEntity findOwnedCourse(Long courseId, Long ownerUserId) {
+        CourseEntity course = courseRepository.findById(courseId)
+                .orElseThrow(() -> new NotFoundException("코스를 찾을 수 없습니다."));
+        courseAccessPolicy.assertOwned(course, ownerUserId);
+        return course;
+    }
+
+    private CoursePublicationResponse toResponse(CoursePublicationEntity publication) {
+        return new CoursePublicationResponse(
+                publication.getId(),
+                publication.getCourseId(),
+                publication.getOwnerUserId(),
+                publication.getStatus().name(),
+                publication.getPublishedAt(),
+                publication.getUnpublishedAt()
+        );
+    }
+}

--- a/src/main/resources/db/migration/V28__create_course_publications.sql
+++ b/src/main/resources/db/migration/V28__create_course_publications.sql
@@ -1,0 +1,19 @@
+CREATE TABLE IF NOT EXISTS course_publications (
+    id BIGSERIAL PRIMARY KEY,
+    course_id BIGINT NOT NULL,
+    owner_user_id BIGINT NOT NULL,
+    status VARCHAR(20) NOT NULL,
+    published_at TIMESTAMP WITH TIME ZONE NOT NULL,
+    unpublished_at TIMESTAMP WITH TIME ZONE,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+    CONSTRAINT fk_course_publications_course
+        FOREIGN KEY (course_id) REFERENCES courses (id) ON DELETE CASCADE,
+    CONSTRAINT fk_course_publications_owner
+        FOREIGN KEY (owner_user_id) REFERENCES users (id),
+    CONSTRAINT uq_course_publications_course
+        UNIQUE (course_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_course_publications_owner_status
+    ON course_publications (owner_user_id ASC, status ASC);

--- a/src/test/java/com/bikeprojectminji/bikeback/course/controller/CourseControllerMutationTest.java
+++ b/src/test/java/com/bikeprojectminji/bikeback/course/controller/CourseControllerMutationTest.java
@@ -2,15 +2,18 @@ package com.bikeprojectminji.bikeback.course.controller;
 
 import static org.mockito.BDDMockito.given;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.bikeprojectminji.bikeback.course.dto.CoursePublicationResponse;
 import com.bikeprojectminji.bikeback.course.dto.CourseRoutePointRequest;
 import com.bikeprojectminji.bikeback.course.dto.CourseWriteResponse;
 import java.math.BigDecimal;
+import java.time.OffsetDateTime;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -100,6 +103,53 @@ class CourseControllerMutationTest extends CourseControllerWebMvcTestSupport {
                                 """))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.visibility").value("PUBLIC"));
+    }
+
+    @Test
+    @DisplayName("코스 공개 게시 API는 인증된 사용자의 publication 생성 결과를 응답한다")
+    void publishCourseReturnsPublicationResponse() throws Exception {
+        given(coursePublicationService.publishCourse("1", 2001L))
+                .willReturn(new CoursePublicationResponse(
+                        3001L,
+                        2001L,
+                        1L,
+                        "ACTIVE",
+                        OffsetDateTime.parse("2026-06-18T09:00:00+09:00"),
+                        null
+                ));
+
+        mockMvc.perform(post("/api/v1/courses/2001/publication")
+                        .with(jwt().jwt(jwt -> jwt.subject("1"))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(200))
+                .andExpect(jsonPath("$.data.publicationId").value(3001))
+                .andExpect(jsonPath("$.data.courseId").value(2001))
+                .andExpect(jsonPath("$.data.ownerUserId").value(1))
+                .andExpect(jsonPath("$.data.status").value("ACTIVE"))
+                .andExpect(jsonPath("$.data.publishedAt").isNotEmpty())
+                .andExpect(jsonPath("$.data.unpublishedAt").doesNotExist());
+    }
+
+    @Test
+    @DisplayName("코스 공개 해제 API는 인증된 사용자의 publication 비활성 결과를 응답한다")
+    void unpublishCourseReturnsPublicationResponse() throws Exception {
+        given(coursePublicationService.unpublishCourse("1", 2001L))
+                .willReturn(new CoursePublicationResponse(
+                        3001L,
+                        2001L,
+                        1L,
+                        "INACTIVE",
+                        OffsetDateTime.parse("2026-06-18T09:00:00+09:00"),
+                        OffsetDateTime.parse("2026-06-18T09:30:00+09:00")
+                ));
+
+        mockMvc.perform(delete("/api/v1/courses/2001/publication")
+                        .with(jwt().jwt(jwt -> jwt.subject("1"))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(200))
+                .andExpect(jsonPath("$.data.publicationId").value(3001))
+                .andExpect(jsonPath("$.data.status").value("INACTIVE"))
+                .andExpect(jsonPath("$.data.unpublishedAt").isNotEmpty());
     }
 
     @Test

--- a/src/test/java/com/bikeprojectminji/bikeback/course/controller/CourseControllerWebMvcTestSupport.java
+++ b/src/test/java/com/bikeprojectminji/bikeback/course/controller/CourseControllerWebMvcTestSupport.java
@@ -1,6 +1,7 @@
 package com.bikeprojectminji.bikeback.course.controller;
 
 import com.bikeprojectminji.bikeback.course.service.CourseReportService;
+import com.bikeprojectminji.bikeback.course.service.CoursePublicationService;
 import com.bikeprojectminji.bikeback.course.service.CourseQueryService;
 import com.bikeprojectminji.bikeback.course.service.CourseService;
 import com.bikeprojectminji.bikeback.global.config.SecurityConfig;
@@ -31,4 +32,7 @@ abstract class CourseControllerWebMvcTestSupport {
 
     @MockitoBean
     protected CourseReportService courseReportService;
+
+    @MockitoBean
+    protected CoursePublicationService coursePublicationService;
 }

--- a/src/test/java/com/bikeprojectminji/bikeback/course/controller/FeaturedCourseControllerTest.java
+++ b/src/test/java/com/bikeprojectminji/bikeback/course/controller/FeaturedCourseControllerTest.java
@@ -7,10 +7,11 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.bikeprojectminji.bikeback.course.dto.FeaturedCourseItemResponse;
 import com.bikeprojectminji.bikeback.course.dto.FeaturedCourseResponse;
-import com.bikeprojectminji.bikeback.global.config.SecurityConfig;
+import com.bikeprojectminji.bikeback.course.service.CoursePublicationService;
 import com.bikeprojectminji.bikeback.course.service.CourseQueryService;
 import com.bikeprojectminji.bikeback.course.service.CourseReportService;
 import com.bikeprojectminji.bikeback.course.service.CourseService;
+import com.bikeprojectminji.bikeback.global.config.SecurityConfig;
 import com.bikeprojectminji.bikeback.ride.policy.service.RidePolicyService;
 import java.math.BigDecimal;
 import java.util.List;
@@ -43,6 +44,9 @@ class FeaturedCourseControllerTest {
 
     @MockitoBean
     private CourseReportService courseReportService;
+
+    @MockitoBean
+    private CoursePublicationService coursePublicationService;
 
     @MockitoBean
     private RidePolicyService ridePolicyService;

--- a/src/test/java/com/bikeprojectminji/bikeback/course/service/CoursePublicationServiceTest.java
+++ b/src/test/java/com/bikeprojectminji/bikeback/course/service/CoursePublicationServiceTest.java
@@ -1,0 +1,199 @@
+package com.bikeprojectminji.bikeback.course.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.bikeprojectminji.bikeback.auth.entity.UserEntity;
+import com.bikeprojectminji.bikeback.auth.service.AuthService;
+import com.bikeprojectminji.bikeback.beta.service.BetaAccessPolicy;
+import com.bikeprojectminji.bikeback.course.dto.CoursePublicationResponse;
+import com.bikeprojectminji.bikeback.course.entity.CourseEntity;
+import com.bikeprojectminji.bikeback.course.entity.CoursePublicationEntity;
+import com.bikeprojectminji.bikeback.course.entity.CoursePublicationStatus;
+import com.bikeprojectminji.bikeback.course.entity.CourseVisibility;
+import com.bikeprojectminji.bikeback.course.repository.CoursePublicationRepository;
+import com.bikeprojectminji.bikeback.course.repository.CourseRepository;
+import com.bikeprojectminji.bikeback.global.exception.ForbiddenException;
+import com.bikeprojectminji.bikeback.global.exception.NotFoundException;
+import java.math.BigDecimal;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class CoursePublicationServiceTest {
+
+    private static final Clock FIXED_CLOCK = Clock.fixed(
+            Instant.parse("2026-06-18T00:00:00Z"),
+            ZoneOffset.UTC
+    );
+
+    @Mock
+    private AuthService authService;
+
+    @Mock
+    private CourseRepository courseRepository;
+
+    @Mock
+    private CoursePublicationRepository coursePublicationRepository;
+
+    private CoursePublicationService coursePublicationService;
+
+    @BeforeEach
+    void setUp() {
+        coursePublicationService = new CoursePublicationService(
+                authService,
+                courseRepository,
+                coursePublicationRepository,
+                new BetaAccessPolicy(),
+                FIXED_CLOCK
+        );
+    }
+
+    @Test
+    @DisplayName("beta 권한이 있는 소유자는 본인 코스를 공개 게시할 수 있다")
+    void publishCourseCreatesActivePublicationForOwnerWithBetaAccess() {
+        UserEntity user = user(1L, true);
+        CourseEntity course = course(2001L, 1L);
+        given(authService.findUserBySubject("1")).willReturn(user);
+        given(courseRepository.findById(2001L)).willReturn(Optional.of(course));
+        given(coursePublicationRepository.findByCourseId(2001L)).willReturn(Optional.empty());
+        given(coursePublicationRepository.save(org.mockito.ArgumentMatchers.any(CoursePublicationEntity.class)))
+                .willAnswer(invocation -> {
+                    CoursePublicationEntity publication = invocation.getArgument(0);
+                    ReflectionTestUtils.setField(publication, "id", 3001L);
+                    return publication;
+                });
+
+        CoursePublicationResponse response = coursePublicationService.publishCourse("1", 2001L);
+
+        assertThat(response.publicationId()).isEqualTo(3001L);
+        assertThat(response.courseId()).isEqualTo(2001L);
+        assertThat(response.ownerUserId()).isEqualTo(1L);
+        assertThat(response.status()).isEqualTo("ACTIVE");
+        assertThat(response.publishedAt()).isNotNull();
+        assertThat(response.unpublishedAt()).isNull();
+    }
+
+    @Test
+    @DisplayName("이미 공개된 코스의 공개 요청은 기존 active publication을 반환한다")
+    void publishCourseReturnsExistingActivePublicationWhenAlreadyPublished() {
+        UserEntity user = user(1L, true);
+        CourseEntity course = course(2001L, 1L);
+        CoursePublicationEntity publication = publication(3001L, 2001L, 1L, CoursePublicationStatus.ACTIVE);
+        given(authService.findUserBySubject("1")).willReturn(user);
+        given(courseRepository.findById(2001L)).willReturn(Optional.of(course));
+        given(coursePublicationRepository.findByCourseId(2001L)).willReturn(Optional.of(publication));
+
+        CoursePublicationResponse response = coursePublicationService.publishCourse("1", 2001L);
+
+        assertThat(response.publicationId()).isEqualTo(3001L);
+        assertThat(response.status()).isEqualTo("ACTIVE");
+        verify(coursePublicationRepository, never()).save(org.mockito.ArgumentMatchers.any());
+    }
+
+    @Test
+    @DisplayName("소유자는 공개 게시를 비공개 상태로 전환할 수 있다")
+    void unpublishCourseMarksActivePublicationInactiveForOwnerWithBetaAccess() {
+        UserEntity user = user(1L, true);
+        CourseEntity course = course(2001L, 1L);
+        CoursePublicationEntity publication = publication(3001L, 2001L, 1L, CoursePublicationStatus.ACTIVE);
+        given(authService.findUserBySubject("1")).willReturn(user);
+        given(courseRepository.findById(2001L)).willReturn(Optional.of(course));
+        given(coursePublicationRepository.findByCourseId(2001L)).willReturn(Optional.of(publication));
+
+        CoursePublicationResponse response = coursePublicationService.unpublishCourse("1", 2001L);
+
+        assertThat(response.publicationId()).isEqualTo(3001L);
+        assertThat(response.status()).isEqualTo("INACTIVE");
+        assertThat(response.unpublishedAt()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("beta 권한이 없는 사용자는 코스를 공개할 수 없다")
+    void publishCourseRejectsUserWithoutBetaAccess() {
+        given(authService.findUserBySubject("1")).willReturn(user(1L, false));
+
+        assertThatThrownBy(() -> coursePublicationService.publishCourse("1", 2001L))
+                .isInstanceOf(ForbiddenException.class)
+                .hasMessage("베타 초대 권한이 필요합니다.");
+
+        verify(courseRepository, never()).findById(2001L);
+    }
+
+    @Test
+    @DisplayName("타인 코스 공개 전환은 거부한다")
+    void publishCourseRejectsDifferentOwner() {
+        UserEntity user = user(1L, true);
+        given(authService.findUserBySubject("1")).willReturn(user);
+        given(courseRepository.findById(2001L)).willReturn(Optional.of(course(2001L, 2L)));
+
+        assertThatThrownBy(() -> coursePublicationService.publishCourse("1", 2001L))
+                .isInstanceOf(ForbiddenException.class)
+                .hasMessage("이 코스를 수정할 권한이 없습니다.");
+    }
+
+    @Test
+    @DisplayName("없는 코스 공개 전환은 404로 거부한다")
+    void publishCourseRejectsMissingCourse() {
+        UserEntity user = user(1L, true);
+        given(authService.findUserBySubject("1")).willReturn(user);
+        given(courseRepository.findById(9999L)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> coursePublicationService.publishCourse("1", 9999L))
+                .isInstanceOf(NotFoundException.class)
+                .hasMessage("코스를 찾을 수 없습니다.");
+    }
+
+    private UserEntity user(Long id, boolean betaAccessGranted) {
+        UserEntity user = new UserEntity(null, "bikeoasis@example.com", "encoded-password", "bikeoasis", null);
+        ReflectionTestUtils.setField(user, "id", id);
+        if (betaAccessGranted) {
+            user.grantBetaAccess();
+        }
+        return user;
+    }
+
+    private CourseEntity course(Long id, Long ownerUserId) {
+        CourseEntity course = new CourseEntity(
+                "한강 코스",
+                "설명",
+                BigDecimal.valueOf(18.3),
+                60,
+                1,
+                false,
+                null,
+                BigDecimal.valueOf(37.5665),
+                BigDecimal.valueOf(126.9780),
+                ownerUserId,
+                CourseVisibility.PRIVATE
+        );
+        ReflectionTestUtils.setField(course, "id", id);
+        return course;
+    }
+
+    private CoursePublicationEntity publication(
+            Long id,
+            Long courseId,
+            Long ownerUserId,
+            CoursePublicationStatus status
+    ) {
+        CoursePublicationEntity publication = new CoursePublicationEntity(courseId, ownerUserId, FIXED_CLOCK);
+        ReflectionTestUtils.setField(publication, "id", id);
+        if (status == CoursePublicationStatus.INACTIVE) {
+            publication.unpublish(FIXED_CLOCK);
+        }
+        return publication;
+    }
+}

--- a/src/test/resources/schema-h2.sql
+++ b/src/test/resources/schema-h2.sql
@@ -98,6 +98,18 @@ CREATE TABLE course_reports (
     CONSTRAINT uq_course_reports_course_reporter UNIQUE (course_id, reporter_user_id)
 );
 
+CREATE TABLE course_publications (
+    id BIGSERIAL PRIMARY KEY,
+    course_id BIGINT NOT NULL,
+    owner_user_id BIGINT NOT NULL,
+    status VARCHAR(20) NOT NULL,
+    published_at TIMESTAMP WITH TIME ZONE NOT NULL,
+    unpublished_at TIMESTAMP WITH TIME ZONE,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+    CONSTRAINT uq_course_publications_course UNIQUE (course_id)
+);
+
 CREATE TABLE course_list_summaries (
     course_id BIGINT PRIMARY KEY,
     title VARCHAR(120) NOT NULL,
@@ -199,6 +211,9 @@ CREATE INDEX idx_courses_public_list_page
 
 CREATE INDEX idx_course_list_summaries_page
     ON course_list_summaries (display_order, course_id);
+
+CREATE INDEX idx_course_publications_owner_status
+    ON course_publications (owner_user_id, status);
 
 CREATE TABLE ai_route_generation_sessions (
     id BIGSERIAL PRIMARY KEY,


### PR DESCRIPTION
## 변경 요약
- 코스 공개게시 상태를 관리하는 `course_publications` 테이블과 JPA 엔티티/리포지토리를 추가했습니다.
- `POST /api/v1/courses/{courseId}/publication`, `DELETE /api/v1/courses/{courseId}/publication` API를 추가했습니다.
- beta 권한 확인, 코스 소유권 확인, publication `ACTIVE`/`INACTIVE` 전환 정책을 `CoursePublicationService`로 분리했습니다.
- H2 테스트 스키마와 한글 구현 보고서를 추가했습니다.

## 검증
- RED: 테스트만 이관했을 때 publication 관련 production 클래스 부재로 `compileTestJava` 실패 확인
- `./gradlew test --tests 'com.bikeprojectminji.bikeback.course.service.CoursePublicationServiceTest' --tests 'com.bikeprojectminji.bikeback.course.controller.CourseControllerMutationTest'`
- `./gradlew test --tests 'com.bikeprojectminji.bikeback.course.controller.*' --tests 'com.bikeprojectminji.bikeback.course.service.*' --tests 'com.bikeprojectminji.bikeback.course.entity.*' --tests 'com.bikeprojectminji.bikeback.course.repository.*'`
- `./gradlew test`
- `git diff --cached --check`

## 리뷰 관점
- 백엔드 아키텍처/도메인 리뷰어: publication 상태를 `courses.visibility`와 별도 정책으로 둔 것이 제품 의도와 맞는지 확인 필요
- QA/보안/운영 리뷰어: 동시 최초 publish 요청은 DB unique constraint가 최종 방어선입니다. 운영 트래픽 증가 시 conflict 처리 보강 검토 필요

## 남은 리스크
- 이 PR은 PR #50(`feature/source-detached-foundation`) 위에 쌓인 기능 PR입니다.
- `ACTIVE` publication 전환 시 `courses.visibility = PUBLIC`까지 강제할지는 별도 제품 정책 결정이 필요합니다.
