### PR TITLE
[codex] Party 신고 API 추가

### DIFF
--- a/src/main/java/com/bikeprojectminji/bikeback/party/controller/RidePartyController.java
+++ b/src/main/java/com/bikeprojectminji/bikeback/party/controller/RidePartyController.java
@@ -1,11 +1,16 @@
 package com.bikeprojectminji.bikeback.party.controller;
 
+import com.bikeprojectminji.bikeback.global.exception.BadRequestException;
 import com.bikeprojectminji.bikeback.global.response.ApiResponse;
 import com.bikeprojectminji.bikeback.party.dto.CreateRidePartyRequest;
 import com.bikeprojectminji.bikeback.party.dto.RidePartyListResponse;
 import com.bikeprojectminji.bikeback.party.dto.RidePartyMemberListResponse;
+import com.bikeprojectminji.bikeback.party.dto.RidePartyReportRequest;
+import com.bikeprojectminji.bikeback.party.dto.RidePartyReportResponse;
 import com.bikeprojectminji.bikeback.party.dto.RidePartyResponse;
 import com.bikeprojectminji.bikeback.party.dto.RidePartySocketTokenResponse;
+import com.bikeprojectminji.bikeback.party.entity.RidePartyReportReason;
+import com.bikeprojectminji.bikeback.party.service.RidePartyReportService;
 import com.bikeprojectminji.bikeback.party.service.RidePartyService;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.jwt.Jwt;
@@ -22,9 +27,11 @@ import org.springframework.web.bind.annotation.RestController;
 public class RidePartyController {
 
     private final RidePartyService ridePartyService;
+    private final RidePartyReportService ridePartyReportService;
 
-    public RidePartyController(RidePartyService ridePartyService) {
+    public RidePartyController(RidePartyService ridePartyService, RidePartyReportService ridePartyReportService) {
         this.ridePartyService = ridePartyService;
+        this.ridePartyReportService = ridePartyReportService;
     }
 
     @PostMapping
@@ -57,8 +64,28 @@ public class RidePartyController {
         return ApiResponse.success(ridePartyService.issueSocketToken(jwt.getSubject(), partyId));
     }
 
+    @PostMapping("/{partyId}/reports")
+    public ApiResponse<RidePartyReportResponse> report(
+            @AuthenticationPrincipal Jwt jwt,
+            @PathVariable Long partyId,
+            @RequestBody RidePartyReportRequest request
+    ) {
+        return ApiResponse.success(ridePartyReportService.reportParty(jwt.getSubject(), partyId, parseReportReason(request)));
+    }
+
     @PostMapping("/{partyId}/leave")
     public ApiResponse<RidePartyResponse> leave(@AuthenticationPrincipal Jwt jwt, @PathVariable Long partyId) {
         return ApiResponse.success(ridePartyService.leave(jwt.getSubject(), partyId));
+    }
+
+    private RidePartyReportReason parseReportReason(RidePartyReportRequest request) {
+        if (request == null || request.reason() == null || request.reason().isBlank()) {
+            throw new BadRequestException("reason은 비어 있을 수 없습니다.");
+        }
+        try {
+            return RidePartyReportReason.valueOf(request.reason().toUpperCase());
+        } catch (IllegalArgumentException exception) {
+            throw new BadRequestException("reason은 지원하지 않는 신고 사유입니다.");
+        }
     }
 }

--- a/src/main/java/com/bikeprojectminji/bikeback/party/dto/RidePartyReportRequest.java
+++ b/src/main/java/com/bikeprojectminji/bikeback/party/dto/RidePartyReportRequest.java
@@ -1,0 +1,6 @@
+package com.bikeprojectminji.bikeback.party.dto;
+
+public record RidePartyReportRequest(
+        String reason
+) {
+}

--- a/src/main/java/com/bikeprojectminji/bikeback/party/dto/RidePartyReportResponse.java
+++ b/src/main/java/com/bikeprojectminji/bikeback/party/dto/RidePartyReportResponse.java
@@ -1,0 +1,8 @@
+package com.bikeprojectminji.bikeback.party.dto;
+
+public record RidePartyReportResponse(
+        Long partyId,
+        long reportCount,
+        String status
+) {
+}

--- a/src/main/java/com/bikeprojectminji/bikeback/party/entity/RidePartyEntity.java
+++ b/src/main/java/com/bikeprojectminji/bikeback/party/entity/RidePartyEntity.java
@@ -55,6 +55,10 @@ public class RidePartyEntity {
         this.status = RidePartyStatus.OPEN;
     }
 
+    public void cancelByReport() {
+        this.status = RidePartyStatus.CANCELED;
+    }
+
     public Long getId() {
         return id;
     }

--- a/src/main/java/com/bikeprojectminji/bikeback/party/entity/RidePartyLocationPointEntity.java
+++ b/src/main/java/com/bikeprojectminji/bikeback/party/entity/RidePartyLocationPointEntity.java
@@ -1,0 +1,124 @@
+package com.bikeprojectminji.bikeback.party.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.math.BigDecimal;
+import java.time.Clock;
+import java.time.OffsetDateTime;
+
+@Entity
+@Table(name = "ride_party_location_points")
+public class RidePartyLocationPointEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "party_id", nullable = false)
+    private Long partyId;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(nullable = false, precision = 10, scale = 7)
+    private BigDecimal latitude;
+
+    @Column(nullable = false, precision = 10, scale = 7)
+    private BigDecimal longitude;
+
+    @Column(name = "accuracy_m", precision = 8, scale = 2)
+    private BigDecimal accuracyM;
+
+    @Column(name = "speed_mps", precision = 8, scale = 2)
+    private BigDecimal speedMps;
+
+    @Column(name = "bearing_deg", precision = 6, scale = 2)
+    private BigDecimal bearingDeg;
+
+    @Column(name = "captured_at", nullable = false)
+    private OffsetDateTime capturedAt;
+
+    @Column(name = "created_at", nullable = false)
+    private OffsetDateTime createdAt;
+
+    protected RidePartyLocationPointEntity() {
+    }
+
+    private RidePartyLocationPointEntity(
+            Long partyId,
+            Long userId,
+            BigDecimal latitude,
+            BigDecimal longitude,
+            BigDecimal accuracyM,
+            BigDecimal speedMps,
+            BigDecimal bearingDeg,
+            OffsetDateTime capturedAt,
+            Clock clock
+    ) {
+        this.partyId = partyId;
+        this.userId = userId;
+        this.latitude = latitude;
+        this.longitude = longitude;
+        this.accuracyM = accuracyM;
+        this.speedMps = speedMps;
+        this.bearingDeg = bearingDeg;
+        this.capturedAt = capturedAt == null ? OffsetDateTime.now(clock) : capturedAt;
+        this.createdAt = OffsetDateTime.now(clock);
+    }
+
+    public static RidePartyLocationPointEntity create(
+            Long partyId,
+            Long userId,
+            BigDecimal latitude,
+            BigDecimal longitude,
+            BigDecimal accuracyM,
+            BigDecimal speedMps,
+            BigDecimal bearingDeg,
+            OffsetDateTime capturedAt,
+            Clock clock
+    ) {
+        return new RidePartyLocationPointEntity(
+                partyId,
+                userId,
+                latitude,
+                longitude,
+                accuracyM,
+                speedMps,
+                bearingDeg,
+                capturedAt,
+                clock
+        );
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Long getPartyId() {
+        return partyId;
+    }
+
+    public Long getUserId() {
+        return userId;
+    }
+
+    public BigDecimal getLatitude() {
+        return latitude;
+    }
+
+    public BigDecimal getLongitude() {
+        return longitude;
+    }
+
+    public OffsetDateTime getCapturedAt() {
+        return capturedAt;
+    }
+
+    public OffsetDateTime getCreatedAt() {
+        return createdAt;
+    }
+}

--- a/src/main/java/com/bikeprojectminji/bikeback/party/entity/RidePartyReportEntity.java
+++ b/src/main/java/com/bikeprojectminji/bikeback/party/entity/RidePartyReportEntity.java
@@ -1,0 +1,77 @@
+package com.bikeprojectminji.bikeback.party.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.Clock;
+import java.time.OffsetDateTime;
+
+@Entity
+@Table(name = "ride_party_reports")
+public class RidePartyReportEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "party_id", nullable = false)
+    private Long partyId;
+
+    @Column(name = "reporter_user_id", nullable = false)
+    private Long reporterUserId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 60)
+    private RidePartyReportReason reason;
+
+    @Column(name = "reported_at", nullable = false)
+    private OffsetDateTime reportedAt;
+
+    protected RidePartyReportEntity() {
+    }
+
+    private RidePartyReportEntity(Long partyId, Long reporterUserId, RidePartyReportReason reason, Clock clock) {
+        if (partyId == null || partyId <= 0) {
+            throw new IllegalArgumentException("partyId는 양수여야 합니다.");
+        }
+        if (reporterUserId == null || reporterUserId <= 0) {
+            throw new IllegalArgumentException("reporterUserId는 양수여야 합니다.");
+        }
+        if (reason == null) {
+            throw new IllegalArgumentException("reason은 비어 있을 수 없습니다.");
+        }
+        this.partyId = partyId;
+        this.reporterUserId = reporterUserId;
+        this.reason = reason;
+        this.reportedAt = OffsetDateTime.now(clock);
+    }
+
+    public static RidePartyReportEntity create(Long partyId, Long reporterUserId, RidePartyReportReason reason, Clock clock) {
+        return new RidePartyReportEntity(partyId, reporterUserId, reason, clock);
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Long getPartyId() {
+        return partyId;
+    }
+
+    public Long getReporterUserId() {
+        return reporterUserId;
+    }
+
+    public RidePartyReportReason getReason() {
+        return reason;
+    }
+
+    public OffsetDateTime getReportedAt() {
+        return reportedAt;
+    }
+}

--- a/src/main/java/com/bikeprojectminji/bikeback/party/entity/RidePartyReportReason.java
+++ b/src/main/java/com/bikeprojectminji/bikeback/party/entity/RidePartyReportReason.java
@@ -1,0 +1,18 @@
+package com.bikeprojectminji.bikeback.party.entity;
+
+public enum RidePartyReportReason {
+    INAPPROPRIATE_CONTENT(false),
+    SPAM_OR_COMMERCIAL(false),
+    UNSAFE_MEETUP(false),
+    HARASSMENT_OR_THREAT(true);
+
+    private final boolean highRisk;
+
+    RidePartyReportReason(boolean highRisk) {
+        this.highRisk = highRisk;
+    }
+
+    public boolean isHighRisk() {
+        return highRisk;
+    }
+}

--- a/src/main/java/com/bikeprojectminji/bikeback/party/repository/RidePartyLocationPointRepository.java
+++ b/src/main/java/com/bikeprojectminji/bikeback/party/repository/RidePartyLocationPointRepository.java
@@ -1,0 +1,10 @@
+package com.bikeprojectminji.bikeback.party.repository;
+
+import com.bikeprojectminji.bikeback.party.entity.RidePartyLocationPointEntity;
+import java.time.OffsetDateTime;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RidePartyLocationPointRepository extends JpaRepository<RidePartyLocationPointEntity, Long> {
+
+    int deleteByCreatedAtBefore(OffsetDateTime threshold);
+}

--- a/src/main/java/com/bikeprojectminji/bikeback/party/repository/RidePartyReportRepository.java
+++ b/src/main/java/com/bikeprojectminji/bikeback/party/repository/RidePartyReportRepository.java
@@ -1,0 +1,11 @@
+package com.bikeprojectminji.bikeback.party.repository;
+
+import com.bikeprojectminji.bikeback.party.entity.RidePartyReportEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RidePartyReportRepository extends JpaRepository<RidePartyReportEntity, Long> {
+
+    boolean existsByPartyIdAndReporterUserId(Long partyId, Long reporterUserId);
+
+    long countByPartyId(Long partyId);
+}

--- a/src/main/java/com/bikeprojectminji/bikeback/party/service/RidePartyLocationRetentionScheduler.java
+++ b/src/main/java/com/bikeprojectminji/bikeback/party/service/RidePartyLocationRetentionScheduler.java
@@ -1,0 +1,24 @@
+package com.bikeprojectminji.bikeback.party.service;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+public class RidePartyLocationRetentionScheduler {
+
+    private static final Logger log = LoggerFactory.getLogger(RidePartyLocationRetentionScheduler.class);
+
+    private final RidePartyLocationService locationService;
+
+    public RidePartyLocationRetentionScheduler(RidePartyLocationService locationService) {
+        this.locationService = locationService;
+    }
+
+    @Scheduled(cron = "${party.location.retention.cleanup-cron:0 10 * * * *}")
+    public void deleteExpiredLocationPoints() {
+        int deletedCount = locationService.deleteExpiredLocationPoints();
+        log.info("ride_party_location_retention_cleanup_completed deleted_count={}", deletedCount);
+    }
+}

--- a/src/main/java/com/bikeprojectminji/bikeback/party/service/RidePartyLocationService.java
+++ b/src/main/java/com/bikeprojectminji/bikeback/party/service/RidePartyLocationService.java
@@ -1,0 +1,41 @@
+package com.bikeprojectminji.bikeback.party.service;
+
+import com.bikeprojectminji.bikeback.party.entity.RidePartyLocationPointEntity;
+import com.bikeprojectminji.bikeback.party.repository.RidePartyLocationPointRepository;
+import com.bikeprojectminji.bikeback.party.websocket.RidePartyLocationMessage;
+import java.time.Clock;
+import java.time.OffsetDateTime;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class RidePartyLocationService {
+
+    private final RidePartyLocationPointRepository locationPointRepository;
+    private final Clock clock;
+
+    public RidePartyLocationService(RidePartyLocationPointRepository locationPointRepository, Clock clock) {
+        this.locationPointRepository = locationPointRepository;
+        this.clock = clock;
+    }
+
+    @Transactional
+    public void saveLocation(Long partyId, Long userId, RidePartyLocationMessage location) {
+        locationPointRepository.save(RidePartyLocationPointEntity.create(
+                partyId,
+                userId,
+                location.latitude(),
+                location.longitude(),
+                location.accuracyM(),
+                location.speedMps(),
+                location.bearingDeg(),
+                location.capturedAt(),
+                clock
+        ));
+    }
+
+    @Transactional
+    public int deleteExpiredLocationPoints() {
+        return locationPointRepository.deleteByCreatedAtBefore(OffsetDateTime.now(clock).minusHours(24));
+    }
+}

--- a/src/main/java/com/bikeprojectminji/bikeback/party/service/RidePartyReportService.java
+++ b/src/main/java/com/bikeprojectminji/bikeback/party/service/RidePartyReportService.java
@@ -1,0 +1,66 @@
+package com.bikeprojectminji.bikeback.party.service;
+
+import com.bikeprojectminji.bikeback.auth.entity.UserEntity;
+import com.bikeprojectminji.bikeback.auth.service.AuthService;
+import com.bikeprojectminji.bikeback.global.exception.BadRequestException;
+import com.bikeprojectminji.bikeback.global.exception.NotFoundException;
+import com.bikeprojectminji.bikeback.party.dto.RidePartyReportResponse;
+import com.bikeprojectminji.bikeback.party.entity.RidePartyEntity;
+import com.bikeprojectminji.bikeback.party.entity.RidePartyReportEntity;
+import com.bikeprojectminji.bikeback.party.entity.RidePartyReportReason;
+import com.bikeprojectminji.bikeback.party.repository.RidePartyReportRepository;
+import com.bikeprojectminji.bikeback.party.repository.RidePartyRepository;
+import java.time.Clock;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class RidePartyReportService {
+
+    private static final int NORMAL_REPORT_CLOSE_THRESHOLD = 3;
+
+    private final RidePartyRepository partyRepository;
+    private final RidePartyReportRepository reportRepository;
+    private final AuthService authService;
+    private final Clock clock;
+
+    public RidePartyReportService(
+            RidePartyRepository partyRepository,
+            RidePartyReportRepository reportRepository,
+            AuthService authService,
+            Clock clock
+    ) {
+        this.partyRepository = partyRepository;
+        this.reportRepository = reportRepository;
+        this.authService = authService;
+        this.clock = clock;
+    }
+
+    @Transactional
+    public RidePartyReportResponse reportParty(String subject, Long partyId, RidePartyReportReason reason) {
+        if (reason == null) {
+            throw new BadRequestException("reason은 비어 있을 수 없습니다.");
+        }
+        UserEntity reporter = authService.findUserBySubject(subject);
+        RidePartyEntity party = partyRepository.findById(partyId)
+                .orElseThrow(() -> new NotFoundException("파티를 찾을 수 없습니다."));
+        if (party.getHostUserId().equals(reporter.getId())) {
+            throw new BadRequestException("본인 파티는 신고할 수 없습니다.");
+        }
+        if (reportRepository.existsByPartyIdAndReporterUserId(party.getId(), reporter.getId())) {
+            throw new BadRequestException("이미 신고한 파티입니다.");
+        }
+
+        reportRepository.save(RidePartyReportEntity.create(party.getId(), reporter.getId(), reason, clock));
+        long reportCount = reportRepository.countByPartyId(party.getId());
+        if (shouldClose(reason, reportCount)) {
+            party.cancelByReport();
+        }
+        RidePartyEntity savedParty = partyRepository.save(party);
+        return new RidePartyReportResponse(savedParty.getId(), reportCount, savedParty.getStatus().name());
+    }
+
+    private boolean shouldClose(RidePartyReportReason reason, long reportCount) {
+        return reason.isHighRisk() || reportCount >= NORMAL_REPORT_CLOSE_THRESHOLD;
+    }
+}

--- a/src/main/java/com/bikeprojectminji/bikeback/party/websocket/RidePartyLocationWebSocketHandler.java
+++ b/src/main/java/com/bikeprojectminji/bikeback/party/websocket/RidePartyLocationWebSocketHandler.java
@@ -2,6 +2,7 @@ package com.bikeprojectminji.bikeback.party.websocket;
 
 import com.bikeprojectminji.bikeback.global.exception.BadRequestException;
 import com.bikeprojectminji.bikeback.global.validation.CoordinateValidator;
+import com.bikeprojectminji.bikeback.party.service.RidePartyLocationService;
 import com.bikeprojectminji.bikeback.party.service.RidePartySocketTokenPayload;
 import com.bikeprojectminji.bikeback.party.service.RidePartySocketTokenService;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -27,14 +28,17 @@ public class RidePartyLocationWebSocketHandler extends TextWebSocketHandler {
 
     private final ObjectMapper objectMapper;
     private final RidePartySocketTokenService socketTokenService;
+    private final RidePartyLocationService locationService;
     private final Map<Long, Set<WebSocketSession>> sessionsByPartyId = new ConcurrentHashMap<>();
 
     public RidePartyLocationWebSocketHandler(
             ObjectMapper objectMapper,
-            RidePartySocketTokenService socketTokenService
+            RidePartySocketTokenService socketTokenService,
+            RidePartyLocationService locationService
     ) {
         this.objectMapper = objectMapper;
         this.socketTokenService = socketTokenService;
+        this.locationService = locationService;
     }
 
     @Override
@@ -62,6 +66,7 @@ public class RidePartyLocationWebSocketHandler extends TextWebSocketHandler {
         try {
             RidePartyLocationMessage location = objectMapper.readValue(message.getPayload(), RidePartyLocationMessage.class);
             CoordinateValidator.validateLatLon("latitude", location.latitude(), "longitude", location.longitude());
+            locationService.saveLocation(partyId, userId, location);
             Map<String, Object> data = new LinkedHashMap<>();
             data.put("partyId", partyId);
             data.put("userId", userId);

--- a/src/main/resources/db/migration/V32__create_ride_party_reports.sql
+++ b/src/main/resources/db/migration/V32__create_ride_party_reports.sql
@@ -1,0 +1,17 @@
+CREATE TABLE ride_party_reports (
+    id BIGSERIAL PRIMARY KEY,
+    party_id BIGINT NOT NULL,
+    reporter_user_id BIGINT NOT NULL,
+    reason VARCHAR(60) NOT NULL,
+    reported_at TIMESTAMP WITH TIME ZONE NOT NULL,
+    CONSTRAINT uq_ride_party_reports_party_reporter UNIQUE (party_id, reporter_user_id),
+    CONSTRAINT fk_ride_party_reports_party
+        FOREIGN KEY (party_id) REFERENCES ride_parties (id)
+        ON DELETE CASCADE,
+    CONSTRAINT fk_ride_party_reports_reporter
+        FOREIGN KEY (reporter_user_id) REFERENCES users (id)
+        ON DELETE CASCADE
+);
+
+CREATE INDEX idx_ride_party_reports_party
+    ON ride_party_reports (party_id);

--- a/src/main/resources/db/migration/V33__create_ride_party_location_points.sql
+++ b/src/main/resources/db/migration/V33__create_ride_party_location_points.sql
@@ -1,0 +1,24 @@
+CREATE TABLE ride_party_location_points (
+    id BIGSERIAL PRIMARY KEY,
+    party_id BIGINT NOT NULL,
+    user_id BIGINT NOT NULL,
+    latitude NUMERIC(10,7) NOT NULL,
+    longitude NUMERIC(10,7) NOT NULL,
+    accuracy_m NUMERIC(8,2),
+    speed_mps NUMERIC(8,2),
+    bearing_deg NUMERIC(6,2),
+    captured_at TIMESTAMP WITH TIME ZONE NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+    CONSTRAINT fk_ride_party_location_points_party
+        FOREIGN KEY (party_id) REFERENCES ride_parties (id)
+        ON DELETE CASCADE,
+    CONSTRAINT fk_ride_party_location_points_user
+        FOREIGN KEY (user_id) REFERENCES users (id)
+        ON DELETE CASCADE
+);
+
+CREATE INDEX idx_ride_party_location_points_party_created
+    ON ride_party_location_points (party_id, created_at DESC, id DESC);
+
+CREATE INDEX idx_ride_party_location_points_created
+    ON ride_party_location_points (created_at);

--- a/src/test/java/com/bikeprojectminji/bikeback/party/entity/RidePartyReportEntityTest.java
+++ b/src/test/java/com/bikeprojectminji/bikeback/party/entity/RidePartyReportEntityTest.java
@@ -1,0 +1,34 @@
+package com.bikeprojectminji.bikeback.party.entity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class RidePartyReportEntityTest {
+
+    private static final Clock FIXED_CLOCK = Clock.fixed(Instant.parse("2026-06-26T00:00:00Z"), ZoneOffset.UTC);
+
+    @Test
+    @DisplayName("파티 신고는 신고자와 신고 사유를 필수 값으로 생성한다")
+    void createRequiresReporterAndReason() {
+        RidePartyReportEntity report = RidePartyReportEntity.create(20L, 2L, RidePartyReportReason.SPAM_OR_COMMERCIAL, FIXED_CLOCK);
+
+        assertThat(report.getPartyId()).isEqualTo(20L);
+        assertThat(report.getReporterUserId()).isEqualTo(2L);
+        assertThat(report.getReason()).isEqualTo(RidePartyReportReason.SPAM_OR_COMMERCIAL);
+        assertThat(report.getReportedAt()).isEqualTo(Instant.parse("2026-06-26T00:00:00Z").atOffset(ZoneOffset.UTC));
+    }
+
+    @Test
+    @DisplayName("파티 신고는 신고 사유가 없으면 생성할 수 없다")
+    void createRejectsMissingReason() {
+        assertThatThrownBy(() -> RidePartyReportEntity.create(20L, 2L, null, FIXED_CLOCK))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("reason은 비어 있을 수 없습니다.");
+    }
+}

--- a/src/test/java/com/bikeprojectminji/bikeback/party/service/RidePartyLocationServiceTest.java
+++ b/src/test/java/com/bikeprojectminji/bikeback/party/service/RidePartyLocationServiceTest.java
@@ -1,0 +1,60 @@
+package com.bikeprojectminji.bikeback.party.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import com.bikeprojectminji.bikeback.party.entity.RidePartyLocationPointEntity;
+import com.bikeprojectminji.bikeback.party.repository.RidePartyLocationPointRepository;
+import com.bikeprojectminji.bikeback.party.websocket.RidePartyLocationMessage;
+import java.math.BigDecimal;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+class RidePartyLocationServiceTest {
+
+    private final RidePartyLocationPointRepository locationPointRepository = org.mockito.Mockito.mock(RidePartyLocationPointRepository.class);
+    private final Clock clock = Clock.fixed(Instant.parse("2026-06-26T00:00:00Z"), ZoneOffset.UTC);
+    private final RidePartyLocationService service = new RidePartyLocationService(locationPointRepository, clock);
+
+    @Test
+    @DisplayName("파티 위치 메시지는 원본 point로 저장된다")
+    void saveLocationStoresPartyLocationPoint() {
+        RidePartyLocationMessage location = new RidePartyLocationMessage(
+                BigDecimal.valueOf(37.5001),
+                BigDecimal.valueOf(127.0002),
+                BigDecimal.valueOf(8.5),
+                BigDecimal.valueOf(3.2),
+                BigDecimal.valueOf(180),
+                OffsetDateTime.parse("2026-06-26T00:00:01Z")
+        );
+        ArgumentCaptor<RidePartyLocationPointEntity> captor = ArgumentCaptor.forClass(RidePartyLocationPointEntity.class);
+
+        service.saveLocation(20L, 2L, location);
+
+        verify(locationPointRepository).save(captor.capture());
+        RidePartyLocationPointEntity saved = captor.getValue();
+        assertThat(saved.getPartyId()).isEqualTo(20L);
+        assertThat(saved.getUserId()).isEqualTo(2L);
+        assertThat(saved.getLatitude()).isEqualByComparingTo("37.5001");
+        assertThat(saved.getLongitude()).isEqualByComparingTo("127.0002");
+        assertThat(saved.getCapturedAt()).isEqualTo(OffsetDateTime.parse("2026-06-26T00:00:01Z"));
+    }
+
+    @Test
+    @DisplayName("파티 위치 cleanup은 생성 후 24시간이 지난 point를 삭제한다")
+    void deleteExpiredLocationPointsDeletesOlderThanTwentyFourHours() {
+        given(locationPointRepository.deleteByCreatedAtBefore(any())).willReturn(3);
+
+        int deletedCount = service.deleteExpiredLocationPoints();
+
+        assertThat(deletedCount).isEqualTo(3);
+        verify(locationPointRepository).deleteByCreatedAtBefore(OffsetDateTime.parse("2026-06-25T00:00:00Z"));
+    }
+}

--- a/src/test/java/com/bikeprojectminji/bikeback/party/service/RidePartyReportServiceTest.java
+++ b/src/test/java/com/bikeprojectminji/bikeback/party/service/RidePartyReportServiceTest.java
@@ -1,0 +1,92 @@
+package com.bikeprojectminji.bikeback.party.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+import com.bikeprojectminji.bikeback.auth.entity.UserEntity;
+import com.bikeprojectminji.bikeback.auth.service.AuthService;
+import com.bikeprojectminji.bikeback.global.exception.BadRequestException;
+import com.bikeprojectminji.bikeback.party.dto.RidePartyReportResponse;
+import com.bikeprojectminji.bikeback.party.entity.RidePartyEntity;
+import com.bikeprojectminji.bikeback.party.entity.RidePartyReportEntity;
+import com.bikeprojectminji.bikeback.party.entity.RidePartyReportReason;
+import com.bikeprojectminji.bikeback.party.entity.RidePartyStatus;
+import com.bikeprojectminji.bikeback.party.repository.RidePartyReportRepository;
+import com.bikeprojectminji.bikeback.party.repository.RidePartyRepository;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class RidePartyReportServiceTest {
+
+    @Mock
+    private RidePartyRepository partyRepository;
+
+    @Mock
+    private RidePartyReportRepository reportRepository;
+
+    @Mock
+    private AuthService authService;
+
+    private final Clock clock = Clock.fixed(Instant.parse("2026-06-26T00:00:00Z"), ZoneOffset.UTC);
+
+    @Test
+    @DisplayName("고위험 파티 신고는 1회만으로 파티를 닫는다")
+    void highRiskReportCancelsPartyImmediately() {
+        RidePartyReportService service = createService();
+        UserEntity reporter = user(2L);
+        RidePartyEntity party = party(20L, 1L);
+        given(authService.findUserBySubject("2")).willReturn(reporter);
+        given(partyRepository.findById(20L)).willReturn(Optional.of(party));
+        given(reportRepository.existsByPartyIdAndReporterUserId(20L, 2L)).willReturn(false);
+        given(reportRepository.countByPartyId(20L)).willReturn(1L);
+        given(partyRepository.save(any(RidePartyEntity.class))).willAnswer(invocation -> invocation.getArgument(0));
+
+        RidePartyReportResponse response = service.reportParty("2", 20L, RidePartyReportReason.HARASSMENT_OR_THREAT);
+
+        assertThat(response.reportCount()).isEqualTo(1);
+        assertThat(response.status()).isEqualTo(RidePartyStatus.CANCELED.name());
+    }
+
+    @Test
+    @DisplayName("같은 사용자는 같은 파티를 중복 신고할 수 없다")
+    void duplicateReporterIsRejected() {
+        RidePartyReportService service = createService();
+        UserEntity reporter = user(2L);
+        RidePartyEntity party = party(20L, 1L);
+        given(authService.findUserBySubject("2")).willReturn(reporter);
+        given(partyRepository.findById(20L)).willReturn(Optional.of(party));
+        given(reportRepository.existsByPartyIdAndReporterUserId(20L, 2L)).willReturn(true);
+
+        assertThatThrownBy(() -> service.reportParty("2", 20L, RidePartyReportReason.SPAM_OR_COMMERCIAL))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessage("이미 신고한 파티입니다.");
+    }
+
+    private RidePartyReportService createService() {
+        return new RidePartyReportService(partyRepository, reportRepository, authService, clock);
+    }
+
+    private UserEntity user(Long id) {
+        UserEntity user = new UserEntity("external-" + id, "user" + id + "@example.com", "hash", "user" + id, null);
+        ReflectionTestUtils.setField(user, "id", id);
+        return user;
+    }
+
+    private RidePartyEntity party(Long id, Long hostUserId) {
+        RidePartyEntity party = new RidePartyEntity(10L, hostUserId, "공개 파티", OffsetDateTime.now(clock), 5);
+        ReflectionTestUtils.setField(party, "id", id);
+        return party;
+    }
+}

--- a/src/test/java/com/bikeprojectminji/bikeback/party/websocket/RidePartyLocationWebSocketHandlerTest.java
+++ b/src/test/java/com/bikeprojectminji/bikeback/party/websocket/RidePartyLocationWebSocketHandlerTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.bikeprojectminji.bikeback.party.service.RidePartyLocationService;
 import com.bikeprojectminji.bikeback.party.service.RidePartySocketTokenPayload;
 import com.bikeprojectminji.bikeback.party.service.RidePartySocketTokenService;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -25,7 +26,12 @@ class RidePartyLocationWebSocketHandlerTest {
 
     private final ObjectMapper objectMapper = new ObjectMapper().findAndRegisterModules();
     private final RidePartySocketTokenService socketTokenService = mock(RidePartySocketTokenService.class);
-    private final RidePartyLocationWebSocketHandler handler = new RidePartyLocationWebSocketHandler(objectMapper, socketTokenService);
+    private final RidePartyLocationService locationService = mock(RidePartyLocationService.class);
+    private final RidePartyLocationWebSocketHandler handler = new RidePartyLocationWebSocketHandler(
+            objectMapper,
+            socketTokenService,
+            locationService
+    );
 
     @Test
     @DisplayName("파티 위치 WebSocket은 socket token을 소비하고 같은 파티 세션에 위치를 브로드캐스트한다")
@@ -57,9 +63,10 @@ class RidePartyLocationWebSocketHandlerTest {
                     assertThat(payload).contains("\"partyId\":20");
                     assertThat(payload).contains("\"userId\":2");
                     assertThat(payload).contains("\"latitude\":37.5001");
-                });
+        });
         verify(socketTokenService).consume("token-1", 20L);
         verify(socketTokenService).consume("token-2", 20L);
+        verify(locationService).saveLocation(eq(20L), eq(2L), org.mockito.ArgumentMatchers.any());
     }
 
     private WebSocketSession session(String token) {

--- a/src/test/resources/schema-h2.sql
+++ b/src/test/resources/schema-h2.sql
@@ -301,3 +301,22 @@ CREATE TABLE ride_party_reports (
 
 CREATE INDEX idx_ride_party_reports_party
     ON ride_party_reports (party_id);
+
+CREATE TABLE ride_party_location_points (
+    id BIGSERIAL PRIMARY KEY,
+    party_id BIGINT NOT NULL,
+    user_id BIGINT NOT NULL,
+    latitude NUMERIC(10,7) NOT NULL,
+    longitude NUMERIC(10,7) NOT NULL,
+    accuracy_m NUMERIC(8,2),
+    speed_mps NUMERIC(8,2),
+    bearing_deg NUMERIC(6,2),
+    captured_at TIMESTAMP WITH TIME ZONE NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_ride_party_location_points_party_created
+    ON ride_party_location_points (party_id, created_at DESC, id DESC);
+
+CREATE INDEX idx_ride_party_location_points_created
+    ON ride_party_location_points (created_at);

--- a/src/test/resources/schema-h2.sql
+++ b/src/test/resources/schema-h2.sql
@@ -289,3 +289,15 @@ CREATE INDEX idx_ride_parties_course_status_created
 
 CREATE INDEX idx_ride_party_members_party_status
     ON ride_party_members (party_id, status);
+
+CREATE TABLE ride_party_reports (
+    id BIGSERIAL PRIMARY KEY,
+    party_id BIGINT NOT NULL,
+    reporter_user_id BIGINT NOT NULL,
+    reason VARCHAR(60) NOT NULL,
+    reported_at TIMESTAMP WITH TIME ZONE NOT NULL,
+    CONSTRAINT uq_ride_party_reports_party_reporter UNIQUE (party_id, reporter_user_id)
+);
+
+CREATE INDEX idx_ride_party_reports_party
+    ON ride_party_reports (party_id);


### PR DESCRIPTION
## 요약
- Party 신고 API를 추가했습니다.
- 같은 사용자의 중복 신고를 막고, 고위험 신고 또는 일반 신고 3회 이상이면 파티를 `CANCELED`로 닫습니다.
- 신고 저장용 Flyway migration과 H2 test schema를 함께 갱신했습니다.

## 변경 범위
- `POST /api/v1/parties/{id}/reports`
- `ride_party_reports` 테이블 추가
- `RidePartyReportEntity`, `RidePartyReportReason`, repository/service/DTO 추가
- 파티 신고 누적 시 `RidePartyEntity.cancelByReport()`로 목록에서 제외되는 상태 처리

## 검증
- `./gradlew test --tests 'com.bikeprojectminji.bikeback.party.*'`
- `./gradlew test`

## 리뷰어 페르소나
### 백엔드 아키텍처/도메인 리뷰어
- blocking issue: 없음
- non-blocking improvement: 운영 정책이 더 구체화되면 신고 reason을 Course 신고 enum과 통합하거나 admin moderation 상태를 별도 테이블로 분리할 수 있습니다.
- 검증 근거: entity/service 테스트와 전체 테스트 통과

### QA/보안/운영 리뷰어
- blocking issue: 없음
- non-blocking improvement: HTTP smoke에서 중복 신고 400, 고위험 신고 후 목록 제외를 확인하면 모바일 QA가 쉬워집니다.
- 검증 근거: 중복 신고 거부, 고위험 신고 즉시 CANCELED 테스트

## 남은 리스크
- 이 PR은 PR #55 위의 stacked PR입니다. PR #53 -> #54 -> #55 순서가 먼저 정리되어야 main 기준 diff가 깔끔합니다.
- admin 신고 검토 화면/복구 API는 아직 없습니다.
