### PR TITLE
[codex] Party 위치 보존 정책 구현

### DIFF
--- a/src/main/java/com/bikeprojectminji/bikeback/party/entity/RidePartyLocationPointEntity.java
+++ b/src/main/java/com/bikeprojectminji/bikeback/party/entity/RidePartyLocationPointEntity.java
@@ -1,0 +1,124 @@
+package com.bikeprojectminji.bikeback.party.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.math.BigDecimal;
+import java.time.Clock;
+import java.time.OffsetDateTime;
+
+@Entity
+@Table(name = "ride_party_location_points")
+public class RidePartyLocationPointEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "party_id", nullable = false)
+    private Long partyId;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(nullable = false, precision = 10, scale = 7)
+    private BigDecimal latitude;
+
+    @Column(nullable = false, precision = 10, scale = 7)
+    private BigDecimal longitude;
+
+    @Column(name = "accuracy_m", precision = 8, scale = 2)
+    private BigDecimal accuracyM;
+
+    @Column(name = "speed_mps", precision = 8, scale = 2)
+    private BigDecimal speedMps;
+
+    @Column(name = "bearing_deg", precision = 6, scale = 2)
+    private BigDecimal bearingDeg;
+
+    @Column(name = "captured_at", nullable = false)
+    private OffsetDateTime capturedAt;
+
+    @Column(name = "created_at", nullable = false)
+    private OffsetDateTime createdAt;
+
+    protected RidePartyLocationPointEntity() {
+    }
+
+    private RidePartyLocationPointEntity(
+            Long partyId,
+            Long userId,
+            BigDecimal latitude,
+            BigDecimal longitude,
+            BigDecimal accuracyM,
+            BigDecimal speedMps,
+            BigDecimal bearingDeg,
+            OffsetDateTime capturedAt,
+            Clock clock
+    ) {
+        this.partyId = partyId;
+        this.userId = userId;
+        this.latitude = latitude;
+        this.longitude = longitude;
+        this.accuracyM = accuracyM;
+        this.speedMps = speedMps;
+        this.bearingDeg = bearingDeg;
+        this.capturedAt = capturedAt == null ? OffsetDateTime.now(clock) : capturedAt;
+        this.createdAt = OffsetDateTime.now(clock);
+    }
+
+    public static RidePartyLocationPointEntity create(
+            Long partyId,
+            Long userId,
+            BigDecimal latitude,
+            BigDecimal longitude,
+            BigDecimal accuracyM,
+            BigDecimal speedMps,
+            BigDecimal bearingDeg,
+            OffsetDateTime capturedAt,
+            Clock clock
+    ) {
+        return new RidePartyLocationPointEntity(
+                partyId,
+                userId,
+                latitude,
+                longitude,
+                accuracyM,
+                speedMps,
+                bearingDeg,
+                capturedAt,
+                clock
+        );
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Long getPartyId() {
+        return partyId;
+    }
+
+    public Long getUserId() {
+        return userId;
+    }
+
+    public BigDecimal getLatitude() {
+        return latitude;
+    }
+
+    public BigDecimal getLongitude() {
+        return longitude;
+    }
+
+    public OffsetDateTime getCapturedAt() {
+        return capturedAt;
+    }
+
+    public OffsetDateTime getCreatedAt() {
+        return createdAt;
+    }
+}

--- a/src/main/java/com/bikeprojectminji/bikeback/party/repository/RidePartyLocationPointRepository.java
+++ b/src/main/java/com/bikeprojectminji/bikeback/party/repository/RidePartyLocationPointRepository.java
@@ -1,0 +1,10 @@
+package com.bikeprojectminji.bikeback.party.repository;
+
+import com.bikeprojectminji.bikeback.party.entity.RidePartyLocationPointEntity;
+import java.time.OffsetDateTime;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RidePartyLocationPointRepository extends JpaRepository<RidePartyLocationPointEntity, Long> {
+
+    int deleteByCreatedAtBefore(OffsetDateTime threshold);
+}

--- a/src/main/java/com/bikeprojectminji/bikeback/party/service/RidePartyLocationRetentionScheduler.java
+++ b/src/main/java/com/bikeprojectminji/bikeback/party/service/RidePartyLocationRetentionScheduler.java
@@ -1,0 +1,24 @@
+package com.bikeprojectminji.bikeback.party.service;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+public class RidePartyLocationRetentionScheduler {
+
+    private static final Logger log = LoggerFactory.getLogger(RidePartyLocationRetentionScheduler.class);
+
+    private final RidePartyLocationService locationService;
+
+    public RidePartyLocationRetentionScheduler(RidePartyLocationService locationService) {
+        this.locationService = locationService;
+    }
+
+    @Scheduled(cron = "${party.location.retention.cleanup-cron:0 10 * * * *}")
+    public void deleteExpiredLocationPoints() {
+        int deletedCount = locationService.deleteExpiredLocationPoints();
+        log.info("ride_party_location_retention_cleanup_completed deleted_count={}", deletedCount);
+    }
+}

--- a/src/main/java/com/bikeprojectminji/bikeback/party/service/RidePartyLocationService.java
+++ b/src/main/java/com/bikeprojectminji/bikeback/party/service/RidePartyLocationService.java
@@ -1,0 +1,41 @@
+package com.bikeprojectminji.bikeback.party.service;
+
+import com.bikeprojectminji.bikeback.party.entity.RidePartyLocationPointEntity;
+import com.bikeprojectminji.bikeback.party.repository.RidePartyLocationPointRepository;
+import com.bikeprojectminji.bikeback.party.websocket.RidePartyLocationMessage;
+import java.time.Clock;
+import java.time.OffsetDateTime;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class RidePartyLocationService {
+
+    private final RidePartyLocationPointRepository locationPointRepository;
+    private final Clock clock;
+
+    public RidePartyLocationService(RidePartyLocationPointRepository locationPointRepository, Clock clock) {
+        this.locationPointRepository = locationPointRepository;
+        this.clock = clock;
+    }
+
+    @Transactional
+    public void saveLocation(Long partyId, Long userId, RidePartyLocationMessage location) {
+        locationPointRepository.save(RidePartyLocationPointEntity.create(
+                partyId,
+                userId,
+                location.latitude(),
+                location.longitude(),
+                location.accuracyM(),
+                location.speedMps(),
+                location.bearingDeg(),
+                location.capturedAt(),
+                clock
+        ));
+    }
+
+    @Transactional
+    public int deleteExpiredLocationPoints() {
+        return locationPointRepository.deleteByCreatedAtBefore(OffsetDateTime.now(clock).minusHours(24));
+    }
+}

--- a/src/main/java/com/bikeprojectminji/bikeback/party/websocket/RidePartyLocationWebSocketHandler.java
+++ b/src/main/java/com/bikeprojectminji/bikeback/party/websocket/RidePartyLocationWebSocketHandler.java
@@ -2,6 +2,7 @@ package com.bikeprojectminji.bikeback.party.websocket;
 
 import com.bikeprojectminji.bikeback.global.exception.BadRequestException;
 import com.bikeprojectminji.bikeback.global.validation.CoordinateValidator;
+import com.bikeprojectminji.bikeback.party.service.RidePartyLocationService;
 import com.bikeprojectminji.bikeback.party.service.RidePartySocketTokenPayload;
 import com.bikeprojectminji.bikeback.party.service.RidePartySocketTokenService;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -27,14 +28,17 @@ public class RidePartyLocationWebSocketHandler extends TextWebSocketHandler {
 
     private final ObjectMapper objectMapper;
     private final RidePartySocketTokenService socketTokenService;
+    private final RidePartyLocationService locationService;
     private final Map<Long, Set<WebSocketSession>> sessionsByPartyId = new ConcurrentHashMap<>();
 
     public RidePartyLocationWebSocketHandler(
             ObjectMapper objectMapper,
-            RidePartySocketTokenService socketTokenService
+            RidePartySocketTokenService socketTokenService,
+            RidePartyLocationService locationService
     ) {
         this.objectMapper = objectMapper;
         this.socketTokenService = socketTokenService;
+        this.locationService = locationService;
     }
 
     @Override
@@ -62,6 +66,7 @@ public class RidePartyLocationWebSocketHandler extends TextWebSocketHandler {
         try {
             RidePartyLocationMessage location = objectMapper.readValue(message.getPayload(), RidePartyLocationMessage.class);
             CoordinateValidator.validateLatLon("latitude", location.latitude(), "longitude", location.longitude());
+            locationService.saveLocation(partyId, userId, location);
             Map<String, Object> data = new LinkedHashMap<>();
             data.put("partyId", partyId);
             data.put("userId", userId);

--- a/src/main/resources/db/migration/V33__create_ride_party_location_points.sql
+++ b/src/main/resources/db/migration/V33__create_ride_party_location_points.sql
@@ -1,0 +1,24 @@
+CREATE TABLE ride_party_location_points (
+    id BIGSERIAL PRIMARY KEY,
+    party_id BIGINT NOT NULL,
+    user_id BIGINT NOT NULL,
+    latitude NUMERIC(10,7) NOT NULL,
+    longitude NUMERIC(10,7) NOT NULL,
+    accuracy_m NUMERIC(8,2),
+    speed_mps NUMERIC(8,2),
+    bearing_deg NUMERIC(6,2),
+    captured_at TIMESTAMP WITH TIME ZONE NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+    CONSTRAINT fk_ride_party_location_points_party
+        FOREIGN KEY (party_id) REFERENCES ride_parties (id)
+        ON DELETE CASCADE,
+    CONSTRAINT fk_ride_party_location_points_user
+        FOREIGN KEY (user_id) REFERENCES users (id)
+        ON DELETE CASCADE
+);
+
+CREATE INDEX idx_ride_party_location_points_party_created
+    ON ride_party_location_points (party_id, created_at DESC, id DESC);
+
+CREATE INDEX idx_ride_party_location_points_created
+    ON ride_party_location_points (created_at);

--- a/src/test/java/com/bikeprojectminji/bikeback/party/service/RidePartyLocationServiceTest.java
+++ b/src/test/java/com/bikeprojectminji/bikeback/party/service/RidePartyLocationServiceTest.java
@@ -1,0 +1,60 @@
+package com.bikeprojectminji.bikeback.party.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import com.bikeprojectminji.bikeback.party.entity.RidePartyLocationPointEntity;
+import com.bikeprojectminji.bikeback.party.repository.RidePartyLocationPointRepository;
+import com.bikeprojectminji.bikeback.party.websocket.RidePartyLocationMessage;
+import java.math.BigDecimal;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+class RidePartyLocationServiceTest {
+
+    private final RidePartyLocationPointRepository locationPointRepository = org.mockito.Mockito.mock(RidePartyLocationPointRepository.class);
+    private final Clock clock = Clock.fixed(Instant.parse("2026-06-26T00:00:00Z"), ZoneOffset.UTC);
+    private final RidePartyLocationService service = new RidePartyLocationService(locationPointRepository, clock);
+
+    @Test
+    @DisplayName("파티 위치 메시지는 원본 point로 저장된다")
+    void saveLocationStoresPartyLocationPoint() {
+        RidePartyLocationMessage location = new RidePartyLocationMessage(
+                BigDecimal.valueOf(37.5001),
+                BigDecimal.valueOf(127.0002),
+                BigDecimal.valueOf(8.5),
+                BigDecimal.valueOf(3.2),
+                BigDecimal.valueOf(180),
+                OffsetDateTime.parse("2026-06-26T00:00:01Z")
+        );
+        ArgumentCaptor<RidePartyLocationPointEntity> captor = ArgumentCaptor.forClass(RidePartyLocationPointEntity.class);
+
+        service.saveLocation(20L, 2L, location);
+
+        verify(locationPointRepository).save(captor.capture());
+        RidePartyLocationPointEntity saved = captor.getValue();
+        assertThat(saved.getPartyId()).isEqualTo(20L);
+        assertThat(saved.getUserId()).isEqualTo(2L);
+        assertThat(saved.getLatitude()).isEqualByComparingTo("37.5001");
+        assertThat(saved.getLongitude()).isEqualByComparingTo("127.0002");
+        assertThat(saved.getCapturedAt()).isEqualTo(OffsetDateTime.parse("2026-06-26T00:00:01Z"));
+    }
+
+    @Test
+    @DisplayName("파티 위치 cleanup은 생성 후 24시간이 지난 point를 삭제한다")
+    void deleteExpiredLocationPointsDeletesOlderThanTwentyFourHours() {
+        given(locationPointRepository.deleteByCreatedAtBefore(any())).willReturn(3);
+
+        int deletedCount = service.deleteExpiredLocationPoints();
+
+        assertThat(deletedCount).isEqualTo(3);
+        verify(locationPointRepository).deleteByCreatedAtBefore(OffsetDateTime.parse("2026-06-25T00:00:00Z"));
+    }
+}

--- a/src/test/java/com/bikeprojectminji/bikeback/party/websocket/RidePartyLocationWebSocketHandlerTest.java
+++ b/src/test/java/com/bikeprojectminji/bikeback/party/websocket/RidePartyLocationWebSocketHandlerTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.bikeprojectminji.bikeback.party.service.RidePartyLocationService;
 import com.bikeprojectminji.bikeback.party.service.RidePartySocketTokenPayload;
 import com.bikeprojectminji.bikeback.party.service.RidePartySocketTokenService;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -25,7 +26,12 @@ class RidePartyLocationWebSocketHandlerTest {
 
     private final ObjectMapper objectMapper = new ObjectMapper().findAndRegisterModules();
     private final RidePartySocketTokenService socketTokenService = mock(RidePartySocketTokenService.class);
-    private final RidePartyLocationWebSocketHandler handler = new RidePartyLocationWebSocketHandler(objectMapper, socketTokenService);
+    private final RidePartyLocationService locationService = mock(RidePartyLocationService.class);
+    private final RidePartyLocationWebSocketHandler handler = new RidePartyLocationWebSocketHandler(
+            objectMapper,
+            socketTokenService,
+            locationService
+    );
 
     @Test
     @DisplayName("파티 위치 WebSocket은 socket token을 소비하고 같은 파티 세션에 위치를 브로드캐스트한다")
@@ -57,9 +63,10 @@ class RidePartyLocationWebSocketHandlerTest {
                     assertThat(payload).contains("\"partyId\":20");
                     assertThat(payload).contains("\"userId\":2");
                     assertThat(payload).contains("\"latitude\":37.5001");
-                });
+        });
         verify(socketTokenService).consume("token-1", 20L);
         verify(socketTokenService).consume("token-2", 20L);
+        verify(locationService).saveLocation(eq(20L), eq(2L), org.mockito.ArgumentMatchers.any());
     }
 
     private WebSocketSession session(String token) {

--- a/src/test/resources/schema-h2.sql
+++ b/src/test/resources/schema-h2.sql
@@ -301,3 +301,22 @@ CREATE TABLE ride_party_reports (
 
 CREATE INDEX idx_ride_party_reports_party
     ON ride_party_reports (party_id);
+
+CREATE TABLE ride_party_location_points (
+    id BIGSERIAL PRIMARY KEY,
+    party_id BIGINT NOT NULL,
+    user_id BIGINT NOT NULL,
+    latitude NUMERIC(10,7) NOT NULL,
+    longitude NUMERIC(10,7) NOT NULL,
+    accuracy_m NUMERIC(8,2),
+    speed_mps NUMERIC(8,2),
+    bearing_deg NUMERIC(6,2),
+    captured_at TIMESTAMP WITH TIME ZONE NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_ride_party_location_points_party_created
+    ON ride_party_location_points (party_id, created_at DESC, id DESC);
+
+CREATE INDEX idx_ride_party_location_points_created
+    ON ride_party_location_points (created_at);


### PR DESCRIPTION
## 요약
- Party 위치 WebSocket 메시지를 DB 원본 point로 저장합니다.
- 저장된 원본 point는 생성 후 24시간이 지나면 cleanup 대상이 되도록 retention 서비스를 추가했습니다.
- `ride_party_location_points` Flyway migration과 H2 test schema를 함께 갱신했습니다.

## 변경 범위
- `ride_party_location_points` 테이블 추가
- `RidePartyLocationPointEntity`, repository, service, retention scheduler 추가
- `WS /ws/v1/parties/{id}/locations` 수신 시 위치 검증 후 저장 호출
- 위치 저장/24시간 삭제 service 테스트 추가

## 검증
- `./gradlew test --tests 'com.bikeprojectminji.bikeback.party.*'`
- `./gradlew test`

## 리뷰어 페르소나
### 백엔드 아키텍처/도메인 리뷰어
- blocking issue: 없음
- non-blocking improvement: 위치 point 조회 API가 필요해지면 참여자 권한과 최신 point만 노출하는 별도 read model을 추가하는 편이 좋습니다.
- 검증 근거: WebSocket handler 저장 호출 테스트, location service 저장/삭제 테스트, 전체 테스트 통과

### QA/보안/운영 리뷰어
- blocking issue: 없음
- non-blocking improvement: 운영 smoke에서 WebSocket 송신 후 DB 저장 row와 cleanup 수동 실행을 확인하면 배포 증거가 좋아집니다.
- 검증 근거: 좌표 검증 후 저장, 24시간 이전 threshold 삭제 테스트

## 남은 리스크
- 이 PR은 PR #56 위의 stacked PR입니다. PR #53 -> #54 -> #55 -> #56 순서가 먼저 정리되어야 main 기준 diff가 깔끔합니다.
- 실제 Redis socket token + WebSocket client + DB row 확인 smoke는 아직 수행하지 않았습니다.
