### PR TITLE
[codex] 운영 1차 관측성 및 finalization worker 준비

### DIFF
--- a/docs/인프라/k6_백엔드_부하테스트_가이드.md
+++ b/docs/인프라/k6_백엔드_부하테스트_가이드.md
@@ -228,6 +228,7 @@ k6 run ops/loadtest/k6/bike-api.js
 - `AUTH_EMAIL`, `AUTH_PASSWORD`, `AUTH_DISPLAY_NAME`: `AUTH_AUTO_REGISTER=true`일 때 사용할 테스트 계정 값. `AUTH_EMAIL`을 비우면 `TEST_ID` 기반 이메일을 자동 생성
 - `TEST_ID`: Grafana/Prometheus/요약 파일을 같은 실행 단위로 묶을 이름
 - `SUMMARY_DIR`: `handleSummary()`가 JSON 요약을 저장할 디렉터리
+- `SLOW_REQUEST_SAMPLE_MS`: 이 값 이상 걸린 요청은 stdout에 `type=slow_request_sample` JSON line으로 남긴다. 각 샘플에는 k6가 보낸 `request_id`, `trace_id`, 응답의 `X-Request-Id`, `X-Trace-Id`, endpoint, status, duration이 포함된다.
 - `K6_PROMETHEUS_RW_SERVER_URL`: Grafana/Prometheus에 k6 시계열을 직접 보내는 Prometheus remote write endpoint
 - `P95_MS`, `ERROR_RATE_MAX`: 기본 품질 게이트 조정값
 
@@ -270,7 +271,10 @@ baseline / stress에서는 아래 비중으로 총 VU를 나눕니다.
 - 느린 쿼리
 - Redis hit/miss 또는 연결 지연
 - weather provider 지연과 fallback 흔적
-- request_id 기준 access log / app log 추적 가능 여부
+- provider latency/failure metric: `bike_provider_call_total`, `bike_provider_latency`
+- route cache metric: `bike_course_route_cache_*`, `bike_course_route_snapshot_load_duration`
+- finalization job metric: `bike_ride_finalization_job_count`, `bike_ride_finalization_job_duration`, `bike_ride_finalization_job_retry_total`
+- request_id / trace_id 기준 access log / app log / k6 slow sample 연결 가능 여부
 
 ## 10. 주의
 
@@ -294,4 +298,5 @@ baseline / stress에서는 아래 비중으로 총 VU를 나눕니다.
 
 - 기본 stdout 요약과 함께 `handleSummary()`가 JSON 요약을 저장합니다.
 - 경로 기본값: `ops/loadtest/results/<TEST_ID>-summary.json`
+- 느린 요청 샘플은 stdout에 JSON line으로 출력되므로, 실제 실행에서는 `tee ops/loadtest/results/<TEST_ID>-stdout.log`처럼 stdout도 함께 보관합니다.
 - 이 파일을 기준으로 실행 창구, k6 결과, Grafana 해석을 한 보고서로 묶을 수 있습니다.

--- a/ops/loadtest/k6.env.example
+++ b/ops/loadtest/k6.env.example
@@ -5,6 +5,7 @@ BASE_URL=http://localhost:8080
 SCENARIO=smoke
 TEST_ID=bike-smoke-local
 SUMMARY_DIR=ops/loadtest/results
+SLOW_REQUEST_SAMPLE_MS=1000
 
 # 활성 페르소나: home,profile,preRide,inRide,write,health
 PERSONAS=home,profile,preRide,inRide,write,health

--- a/ops/loadtest/k6/bike-api.js
+++ b/ops/loadtest/k6/bike-api.js
@@ -7,6 +7,7 @@ var ACTIVE_PERSONAS = parsePersonaFilter(__ENV.PERSONAS || 'home,profile,preRide
 var TEST_ID = __ENV.TEST_ID || 'bike-' + SCENARIO;
 var SUMMARY_DIR = (__ENV.SUMMARY_DIR || 'ops/loadtest/results').replace(/\/$/, '');
 var ENABLE_WEATHER_READ = ((__ENV.ENABLE_WEATHER_READ || 'true') + '').toLowerCase() !== 'false';
+var SLOW_REQUEST_SAMPLE_MS = intEnv('SLOW_REQUEST_SAMPLE_MS', 1000);
 
 if (!BASE_URL) {
   throw new Error('BASE_URL 환경변수는 필수입니다. 예: BASE_URL=http://localhost:8080');
@@ -48,6 +49,62 @@ function baseRequestTags(extra) {
     result[key] = extra[key];
   });
   return result;
+}
+
+function generateCorrelationId() {
+  return [
+    TEST_ID.replace(/[^a-zA-Z0-9._:-]/g, '-'),
+    'vu' + (__VU || 0),
+    'iter' + (__ITER || 0),
+    Math.random().toString(16).slice(2, 10),
+  ].join('-');
+}
+
+function responseHeader(response, name) {
+  if (!response || !response.headers) {
+    return '';
+  }
+  var expected = name.toLowerCase();
+  var keys = Object.keys(response.headers);
+  for (var i = 0; i < keys.length; i += 1) {
+    if (keys[i].toLowerCase() === expected) {
+      return response.headers[keys[i]];
+    }
+  }
+  return '';
+}
+
+function withCorrelationHeaders(headers, requestId, traceId) {
+  var merged = {};
+  Object.keys(headers || {}).forEach(function(key) {
+    merged[key] = headers[key];
+  });
+  merged['X-Request-Id'] = requestId;
+  merged['X-Trace-Id'] = traceId;
+  return merged;
+}
+
+function logSlowRequest(response, method, path, endpoint, requestId, traceId) {
+  var durationMs = response && response.timings ? response.timings.duration : 0;
+  if (durationMs < SLOW_REQUEST_SAMPLE_MS) {
+    return;
+  }
+  console.warn(JSON.stringify({
+    type: 'slow_request_sample',
+    test_id: TEST_ID,
+    scenario: SCENARIO,
+    vu: __VU || 0,
+    iter: __ITER || 0,
+    method: method,
+    path: path,
+    endpoint: endpoint || 'unknown',
+    status: response ? response.status : 0,
+    duration_ms: durationMs,
+    request_id: requestId,
+    response_request_id: responseHeader(response, 'X-Request-Id'),
+    trace_id: traceId,
+    response_trace_id: responseHeader(response, 'X-Trace-Id'),
+  }));
 }
 
 function weightedVus(total, weightPercent) {
@@ -196,25 +253,33 @@ function getJson(path, tags, params) {
   params = params || {};
   var auth = authHeaders(params.authToken);
   var paramHeaders = params.headers || {};
+  var requestId = generateCorrelationId();
+  var traceId = generateCorrelationId();
   var mergedHeaders = { Accept: 'application/json' };
   Object.keys(auth).forEach(function(key) { mergedHeaders[key] = auth[key]; });
   Object.keys(paramHeaders).forEach(function(key) { mergedHeaders[key] = paramHeaders[key]; });
   var merged = {
     tags: baseRequestTags(tags),
-    headers: mergedHeaders,
+    headers: withCorrelationHeaders(mergedHeaders, requestId, traceId),
   };
-  return http.get(BASE_URL + path, merged);
+  var response = http.get(BASE_URL + path, merged);
+  logSlowRequest(response, 'GET', path, tags.endpoint, requestId, traceId);
+  return response;
 }
 
 function postJson(path, body, tags, authToken) {
   tags = tags || {};
   var auth = authHeaders(authToken);
+  var requestId = generateCorrelationId();
+  var traceId = generateCorrelationId();
   var mergedHeaders = { 'Content-Type': 'application/json', Accept: 'application/json' };
   Object.keys(auth).forEach(function(key) { mergedHeaders[key] = auth[key]; });
-  return http.post(BASE_URL + path, JSON.stringify(body), {
+  var response = http.post(BASE_URL + path, JSON.stringify(body), {
     tags: baseRequestTags(tags),
-    headers: mergedHeaders,
+    headers: withCorrelationHeaders(mergedHeaders, requestId, traceId),
   });
+  logSlowRequest(response, 'POST', path, tags.endpoint, requestId, traceId);
+  return response;
 }
 
 function commonChecks(response, expectedStatus) {
@@ -269,9 +334,11 @@ function extractAccessToken(response) {
 }
 
 function postSetupJson(path, body, endpoint) {
+  var requestId = generateCorrelationId();
+  var traceId = generateCorrelationId();
   return http.post(BASE_URL + path, JSON.stringify(body), {
     tags: baseRequestTags({ flow: 'setup', endpoint: endpoint }),
-    headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+    headers: withCorrelationHeaders({ 'Content-Type': 'application/json', Accept: 'application/json' }, requestId, traceId),
     responseCallback: http.expectedStatuses(200, 400, 401, 409),
   });
 }
@@ -575,6 +642,8 @@ function textSummary(data, options) {
   }
   lines.push(indent + 'scenario_profile: ' + SCENARIO);
   lines.push(indent + 'testid: ' + TEST_ID);
+  lines.push(indent + 'slow_request_sample_ms: ' + SLOW_REQUEST_SAMPLE_MS);
+  lines.push(indent + 'slow_request_samples: stdout JSON lines type=slow_request_sample');
   lines.push(indent + 'iterations: ' + iterations);
   lines.push(indent + 'http_req_failed(rate): ' + failedRate);
   lines.push(indent + 'http_req_duration(p95): ' + p95 + ' ms');

--- a/src/main/java/com/bikeprojectminji/bikeback/address/service/AddressSearchService.java
+++ b/src/main/java/com/bikeprojectminji/bikeback/address/service/AddressSearchService.java
@@ -3,7 +3,11 @@ package com.bikeprojectminji.bikeback.address.service;
 import com.bikeprojectminji.bikeback.address.dto.AddressCandidateResponse;
 import com.bikeprojectminji.bikeback.address.dto.AddressSearchResponse;
 import com.bikeprojectminji.bikeback.global.exception.BadRequestException;
+import com.bikeprojectminji.bikeback.global.metrics.BikeMetricsRecorder;
+import io.micrometer.core.instrument.Metrics;
+import java.time.Duration;
 import java.util.List;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -15,9 +19,16 @@ public class AddressSearchService {
     private static final int MAX_QUERY_LENGTH = 120;
 
     private final List<AddressSearchClient> addressSearchClients;
+    private final BikeMetricsRecorder bikeMetricsRecorder;
 
     public AddressSearchService(List<AddressSearchClient> addressSearchClients) {
+        this(addressSearchClients, new BikeMetricsRecorder(Metrics.globalRegistry));
+    }
+
+    @Autowired
+    public AddressSearchService(List<AddressSearchClient> addressSearchClients, BikeMetricsRecorder bikeMetricsRecorder) {
         this.addressSearchClients = List.copyOf(addressSearchClients);
+        this.bikeMetricsRecorder = bikeMetricsRecorder;
     }
 
     public AddressSearchResponse search(String rawQuery, Integer page, Integer size) {
@@ -29,7 +40,14 @@ public class AddressSearchService {
     private AddressSearchProviderResult searchWithFallback(AddressSearchQuery query) {
         AddressSearchProviderResult lastResult = null;
         for (AddressSearchClient client : addressSearchClients) {
+            long startedAtNanos = System.nanoTime();
             AddressSearchProviderResult result = client.search(query);
+            bikeMetricsRecorder.recordProviderCall(
+                    result.provider(),
+                    "address_search",
+                    result.status().name(),
+                    Duration.ofNanos(System.nanoTime() - startedAtNanos)
+            );
             if (result.status() == AddressSearchProviderStatus.SUCCESS) {
                 return result;
             }

--- a/src/main/java/com/bikeprojectminji/bikeback/airoute/service/HttpAiRouteWorkerClient.java
+++ b/src/main/java/com/bikeprojectminji/bikeback/airoute/service/HttpAiRouteWorkerClient.java
@@ -6,10 +6,12 @@ import com.bikeprojectminji.bikeback.airoute.dto.AiRouteElevationSummaryResponse
 import com.bikeprojectminji.bikeback.airoute.dto.ProviderEvidenceBadgeResponse;
 import com.bikeprojectminji.bikeback.airoute.dto.RecommendationScoreResponse;
 import com.bikeprojectminji.bikeback.weather.dto.CurrentWeatherResponse;
+import com.bikeprojectminji.bikeback.global.metrics.BikeMetricsRecorder;
 import java.math.BigDecimal;
 import java.time.Duration;
 import java.util.List;
 import java.util.Optional;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
@@ -30,8 +32,17 @@ public class HttpAiRouteWorkerClient implements AiRouteWorkerClient {
     private static final Logger log = LoggerFactory.getLogger(HttpAiRouteWorkerClient.class);
 
     private final RestClient restClient;
+    private final BikeMetricsRecorder bikeMetricsRecorder;
 
-    public HttpAiRouteWorkerClient(@Value("${ai-route.worker.base-url}") String baseUrl) {
+    public HttpAiRouteWorkerClient(String baseUrl) {
+        this(baseUrl, new BikeMetricsRecorder(io.micrometer.core.instrument.Metrics.globalRegistry));
+    }
+
+    @Autowired
+    public HttpAiRouteWorkerClient(
+            @Value("${ai-route.worker.base-url}") String baseUrl,
+            BikeMetricsRecorder bikeMetricsRecorder
+    ) {
         SimpleClientHttpRequestFactory requestFactory = new SimpleClientHttpRequestFactory();
         requestFactory.setConnectTimeout(Duration.ofSeconds(3));
         requestFactory.setReadTimeout(Duration.ofSeconds(8));
@@ -39,6 +50,7 @@ public class HttpAiRouteWorkerClient implements AiRouteWorkerClient {
                 .baseUrl(baseUrl)
                 .requestFactory(requestFactory)
                 .build();
+        this.bikeMetricsRecorder = bikeMetricsRecorder;
     }
 
     @Override
@@ -47,6 +59,8 @@ public class HttpAiRouteWorkerClient implements AiRouteWorkerClient {
             AiRouteConditionContext context,
             AiRoutePlanResponse fallbackPlan
     ) {
+        long startedAtNanos = System.nanoTime();
+        String outcome = "success";
         try {
             AiRoutePlanResponse response = restClient.post()
                     .uri("/v1/ai-routes/plan")
@@ -56,6 +70,7 @@ public class HttpAiRouteWorkerClient implements AiRouteWorkerClient {
                     .body(AiRoutePlanResponse.class);
             return Optional.ofNullable(response);
         } catch (HttpStatusCodeException exception) {
+            outcome = "http_" + exception.getStatusCode().value();
             // AI worker는 보조 설명 생성자다. 장애 시 fallback은 유지하되 운영자가 원인을 볼 수 있게 남긴다.
             log.warn(
                     "ai_route_worker_failed reason=http_status status={} endpoint=/v1/ai-routes/plan",
@@ -63,12 +78,20 @@ public class HttpAiRouteWorkerClient implements AiRouteWorkerClient {
             );
             return Optional.empty();
         } catch (RestClientException exception) {
+            outcome = "rest_client_exception";
             // 네트워크/타임아웃도 사용자 응답은 backend fallback으로 보호하고, 로그에서만 추적한다.
             log.warn(
                     "ai_route_worker_failed reason=rest_client_exception exception={} endpoint=/v1/ai-routes/plan",
                     exception.getClass().getSimpleName()
             );
             return Optional.empty();
+        } finally {
+            bikeMetricsRecorder.recordProviderCall(
+                    "AI_ROUTE_WORKER",
+                    "plan",
+                    outcome,
+                    Duration.ofNanos(System.nanoTime() - startedAtNanos)
+            );
         }
     }
 

--- a/src/main/java/com/bikeprojectminji/bikeback/course/service/CourseRouteSnapshotService.java
+++ b/src/main/java/com/bikeprojectminji/bikeback/course/service/CourseRouteSnapshotService.java
@@ -70,21 +70,29 @@ public class CourseRouteSnapshotService {
     }
 
     private CourseRouteSnapshot loadSnapshot(Long courseId, String consumer) {
+        long startedAtNanos = System.nanoTime();
         bikeMetricsRecorder.recordCourseRouteSnapshotLoad(consumer);
-        List<CourseRoutePointEntity> routePoints = List.copyOf(courseRoutePointRepository.findByCourseIdOrderByPointOrderAsc(courseId));
-        List<CourseRoutePointResponse> responsePoints = routePoints.stream()
-                .map(routePoint -> new CourseRoutePointResponse(
-                        routePoint.getPointOrder(),
-                        routePoint.getLatitude(),
-                        routePoint.getLongitude()
-                ))
-                .toList();
-        return new CourseRouteSnapshot(
-                courseId,
-                routePoints,
-                responsePoints,
-                new RouteProjectionIndex(routePoints)
-        );
+        try {
+            List<CourseRoutePointEntity> routePoints = List.copyOf(courseRoutePointRepository.findByCourseIdOrderByPointOrderAsc(courseId));
+            List<CourseRoutePointResponse> responsePoints = routePoints.stream()
+                    .map(routePoint -> new CourseRoutePointResponse(
+                            routePoint.getPointOrder(),
+                            routePoint.getLatitude(),
+                            routePoint.getLongitude()
+                    ))
+                    .toList();
+            return new CourseRouteSnapshot(
+                    courseId,
+                    routePoints,
+                    responsePoints,
+                    new RouteProjectionIndex(routePoints)
+            );
+        } finally {
+            bikeMetricsRecorder.recordCourseRouteSnapshotLoadDuration(
+                    consumer,
+                    Duration.ofNanos(System.nanoTime() - startedAtNanos)
+            );
+        }
     }
 
     private record CachedCourseRouteSnapshot(CourseRouteSnapshot snapshot, Instant expiresAt) {

--- a/src/main/java/com/bikeprojectminji/bikeback/global/logging/HttpRequestLoggingFilter.java
+++ b/src/main/java/com/bikeprojectminji/bikeback/global/logging/HttpRequestLoggingFilter.java
@@ -21,9 +21,12 @@ public class HttpRequestLoggingFilter extends OncePerRequestFilter {
             throws ServletException, IOException {
         long startedAt = System.currentTimeMillis();
         String requestId = RequestLogContext.resolveRequestId(request.getHeader(RequestLogContext.REQUEST_ID_HEADER));
+        String traceId = RequestLogContext.resolveTraceId(request.getHeader(RequestLogContext.TRACE_ID_HEADER));
         request.setAttribute(RequestLogContext.REQUEST_ID_ATTRIBUTE, requestId);
+        request.setAttribute(RequestLogContext.TRACE_ID_ATTRIBUTE, traceId);
         response.setHeader(RequestLogContext.REQUEST_ID_HEADER, requestId);
-        RequestLogContext.bind(requestId);
+        response.setHeader(RequestLogContext.TRACE_ID_HEADER, traceId);
+        RequestLogContext.bind(requestId, traceId);
         ContentCachingResponseWrapper responseWrapper = new ContentCachingResponseWrapper(response);
 
         try {
@@ -32,11 +35,11 @@ public class HttpRequestLoggingFilter extends OncePerRequestFilter {
             long durationMs = System.currentTimeMillis() - startedAt;
             int status = responseWrapper.getStatus();
             if (status >= 500) {
-                log.error("http_request outcome=failure request_id={} method={} path={} status={} duration_ms={} remote_addr={}",
-                        requestId, request.getMethod(), request.getRequestURI(), status, durationMs, request.getRemoteAddr());
+                log.error("http_request outcome=failure request_id={} trace_id={} method={} path={} status={} duration_ms={} remote_addr={}",
+                        requestId, traceId, request.getMethod(), request.getRequestURI(), status, durationMs, request.getRemoteAddr());
             } else {
-                log.info("http_request outcome=success request_id={} method={} path={} status={} duration_ms={} remote_addr={}",
-                        requestId, request.getMethod(), request.getRequestURI(), status, durationMs, request.getRemoteAddr());
+                log.info("http_request outcome=success request_id={} trace_id={} method={} path={} status={} duration_ms={} remote_addr={}",
+                        requestId, traceId, request.getMethod(), request.getRequestURI(), status, durationMs, request.getRemoteAddr());
             }
             responseWrapper.copyBodyToResponse();
             RequestLogContext.clear();

--- a/src/main/java/com/bikeprojectminji/bikeback/global/logging/RequestLogContext.java
+++ b/src/main/java/com/bikeprojectminji/bikeback/global/logging/RequestLogContext.java
@@ -5,30 +5,55 @@ import org.slf4j.MDC;
 
 public final class RequestLogContext {
 
+    private static final int MAX_CORRELATION_ID_LENGTH = 80;
+    private static final String CORRELATION_ID_PATTERN = "^[A-Za-z0-9._:-]{1,80}$";
+
     public static final String REQUEST_ID_HEADER = "X-Request-Id";
+    public static final String TRACE_ID_HEADER = "X-Trace-Id";
     public static final String REQUEST_ID_ATTRIBUTE = "requestId";
+    public static final String TRACE_ID_ATTRIBUTE = "traceId";
     public static final String REQUEST_ID_MDC_KEY = "requestId";
+    public static final String TRACE_ID_MDC_KEY = "traceId";
 
     private RequestLogContext() {
     }
 
     public static String resolveRequestId(String headerValue) {
+        return resolveCorrelationId(headerValue);
+    }
+
+    public static String resolveTraceId(String headerValue) {
+        return resolveCorrelationId(headerValue);
+    }
+
+    private static String resolveCorrelationId(String headerValue) {
         if (headerValue == null || headerValue.isBlank()) {
             return UUID.randomUUID().toString();
         }
-        return headerValue;
+        String trimmed = headerValue.trim();
+        if (trimmed.length() > MAX_CORRELATION_ID_LENGTH || !trimmed.matches(CORRELATION_ID_PATTERN)) {
+            return UUID.randomUUID().toString();
+        }
+        return trimmed;
     }
 
-    public static void bind(String requestId) {
+    public static void bind(String requestId, String traceId) {
         MDC.put(REQUEST_ID_MDC_KEY, requestId);
+        MDC.put(TRACE_ID_MDC_KEY, traceId);
     }
 
     public static void clear() {
         MDC.remove(REQUEST_ID_MDC_KEY);
+        MDC.remove(TRACE_ID_MDC_KEY);
     }
 
     public static String currentRequestId() {
         String value = MDC.get(REQUEST_ID_MDC_KEY);
+        return value == null ? "unknown" : value;
+    }
+
+    public static String currentTraceId() {
+        String value = MDC.get(TRACE_ID_MDC_KEY);
         return value == null ? "unknown" : value;
     }
 }

--- a/src/main/java/com/bikeprojectminji/bikeback/global/metrics/BikeMetricsRecorder.java
+++ b/src/main/java/com/bikeprojectminji/bikeback/global/metrics/BikeMetricsRecorder.java
@@ -1,10 +1,13 @@
 package com.bikeprojectminji.bikeback.global.metrics;
 
 import io.micrometer.core.instrument.MeterRegistry;
+import java.time.Duration;
 import org.springframework.stereotype.Component;
 
 @Component
 public class BikeMetricsRecorder {
+
+    private static final int MAX_TAG_VALUE_LENGTH = 60;
 
     private final MeterRegistry meterRegistry;
 
@@ -72,6 +75,31 @@ public class BikeMetricsRecorder {
         meterRegistry.counter("bike_ride_record_finalization_failed_total").increment();
     }
 
+    public void recordRideFinalizationJobAcquired() {
+        meterRegistry.counter("bike_ride_finalization_job_acquired_total").increment();
+    }
+
+    public void recordRideFinalizationJobRetry(String errorCode) {
+        meterRegistry.counter(
+                "bike_ride_finalization_job_retry_total",
+                "error_code", normalize(errorCode)
+        ).increment();
+    }
+
+    public void recordRideFinalizationJobTerminalFailure(String errorCode) {
+        meterRegistry.counter(
+                "bike_ride_finalization_job_terminal_failure_total",
+                "error_code", normalize(errorCode)
+        ).increment();
+    }
+
+    public void recordRideFinalizationJobDuration(String outcome, Duration duration) {
+        meterRegistry.timer(
+                "bike_ride_finalization_job_duration",
+                "outcome", normalize(outcome)
+        ).record(duration);
+    }
+
     public void recordCourseRouteCacheHit(String consumer) {
         meterRegistry.counter("bike_course_route_cache_hit_total", "consumer", normalize(consumer)).increment();
     }
@@ -88,6 +116,13 @@ public class BikeMetricsRecorder {
         meterRegistry.counter("bike_course_route_snapshot_load_total", "consumer", normalize(consumer)).increment();
     }
 
+    public void recordCourseRouteSnapshotLoadDuration(String consumer, Duration duration) {
+        meterRegistry.timer(
+                "bike_course_route_snapshot_load_duration",
+                "consumer", normalize(consumer)
+        ).record(duration);
+    }
+
     public void recordCourseRouteCacheEviction(String reason) {
         meterRegistry.counter("bike_course_route_cache_eviction_total", "reason", normalize(reason)).increment();
     }
@@ -100,10 +135,32 @@ public class BikeMetricsRecorder {
         ).increment();
     }
 
+    public void recordProviderCall(String provider, String operation, String outcome, Duration duration) {
+        meterRegistry.counter(
+                "bike_provider_call_total",
+                "provider", normalize(provider),
+                "operation", normalize(operation),
+                "outcome", normalize(outcome)
+        ).increment();
+        meterRegistry.timer(
+                "bike_provider_latency",
+                "provider", normalize(provider),
+                "operation", normalize(operation),
+                "outcome", normalize(outcome)
+        ).record(duration);
+    }
+
     private String normalize(String value) {
         if (value == null || value.isBlank()) {
             return "unknown";
         }
-        return value.trim().toLowerCase().replace(' ', '_');
+        String normalized = value.trim()
+                .toLowerCase()
+                .replace(' ', '_')
+                .replaceAll("[^a-z0-9_.:-]", "_");
+        if (normalized.length() > MAX_TAG_VALUE_LENGTH) {
+            return normalized.substring(0, MAX_TAG_VALUE_LENGTH);
+        }
+        return normalized;
     }
 }

--- a/src/main/java/com/bikeprojectminji/bikeback/ride/entity/RideFinalizationJobEntity.java
+++ b/src/main/java/com/bikeprojectminji/bikeback/ride/entity/RideFinalizationJobEntity.java
@@ -1,0 +1,163 @@
+package com.bikeprojectminji.bikeback.ride.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.OffsetDateTime;
+
+@Entity
+@Table(name = "ride_finalization_jobs")
+public class RideFinalizationJobEntity {
+
+    private static final int DEFAULT_MAX_ATTEMPTS = 3;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "ride_record_id", nullable = false, unique = true)
+    private Long rideRecordId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 32)
+    private RideFinalizationJobStatus status;
+
+    @Column(name = "attempt_count", nullable = false)
+    private Integer attemptCount;
+
+    @Column(name = "max_attempts", nullable = false)
+    private Integer maxAttempts;
+
+    @Column(name = "next_run_at", nullable = false)
+    private OffsetDateTime nextRunAt;
+
+    @Column(name = "locked_by", length = 120)
+    private String lockedBy;
+
+    @Column(name = "locked_until")
+    private OffsetDateTime lockedUntil;
+
+    @Column(name = "last_error_code", length = 80)
+    private String lastErrorCode;
+
+    @Column(name = "last_error_message")
+    private String lastErrorMessage;
+
+    @Column(name = "created_at", nullable = false, insertable = false, updatable = false)
+    private OffsetDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private OffsetDateTime updatedAt;
+
+    protected RideFinalizationJobEntity() {
+    }
+
+    public RideFinalizationJobEntity(Long rideRecordId, OffsetDateTime now) {
+        this.rideRecordId = rideRecordId;
+        this.status = RideFinalizationJobStatus.PENDING;
+        this.attemptCount = 0;
+        this.maxAttempts = DEFAULT_MAX_ATTEMPTS;
+        this.nextRunAt = now;
+        this.updatedAt = now;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Long getRideRecordId() {
+        return rideRecordId;
+    }
+
+    public RideFinalizationJobStatus getStatus() {
+        return status;
+    }
+
+    public Integer getAttemptCount() {
+        return attemptCount;
+    }
+
+    public Integer getMaxAttempts() {
+        return maxAttempts;
+    }
+
+    public OffsetDateTime getNextRunAt() {
+        return nextRunAt;
+    }
+
+    public String getLockedBy() {
+        return lockedBy;
+    }
+
+    public OffsetDateTime getLockedUntil() {
+        return lockedUntil;
+    }
+
+    public String getLastErrorCode() {
+        return lastErrorCode;
+    }
+
+    public String getLastErrorMessage() {
+        return lastErrorMessage;
+    }
+
+    public void enqueue(OffsetDateTime now) {
+        this.status = RideFinalizationJobStatus.PENDING;
+        this.nextRunAt = now;
+        this.lockedBy = null;
+        this.lockedUntil = null;
+        this.lastErrorCode = null;
+        this.lastErrorMessage = null;
+        this.updatedAt = now;
+    }
+
+    public void markRunning(String workerId, OffsetDateTime now, OffsetDateTime lockedUntil) {
+        this.status = RideFinalizationJobStatus.RUNNING;
+        this.attemptCount = this.attemptCount + 1;
+        this.lockedBy = workerId;
+        this.lockedUntil = lockedUntil;
+        this.updatedAt = now;
+    }
+
+    public void markSucceeded(OffsetDateTime now) {
+        this.status = RideFinalizationJobStatus.SUCCEEDED;
+        this.lockedBy = null;
+        this.lockedUntil = null;
+        this.updatedAt = now;
+    }
+
+    public void markRetryWait(OffsetDateTime now, OffsetDateTime nextRunAt, String errorCode, String errorMessage) {
+        this.status = RideFinalizationJobStatus.RETRY_WAIT;
+        this.nextRunAt = nextRunAt;
+        this.lockedBy = null;
+        this.lockedUntil = null;
+        this.lastErrorCode = errorCode;
+        this.lastErrorMessage = errorMessage;
+        this.updatedAt = now;
+    }
+
+    public void markFailed(OffsetDateTime now, String errorCode, String errorMessage) {
+        this.status = RideFinalizationJobStatus.FAILED;
+        this.lockedBy = null;
+        this.lockedUntil = null;
+        this.lastErrorCode = errorCode;
+        this.lastErrorMessage = errorMessage;
+        this.updatedAt = now;
+    }
+
+    public boolean attemptsExhausted() {
+        return attemptCount >= maxAttempts;
+    }
+
+    public boolean isOwnedRunningLease(String workerId, int expectedAttemptCount) {
+        return status == RideFinalizationJobStatus.RUNNING
+                && attemptCount == expectedAttemptCount
+                && lockedBy != null
+                && lockedBy.equals(workerId);
+    }
+}

--- a/src/main/java/com/bikeprojectminji/bikeback/ride/entity/RideFinalizationJobStatus.java
+++ b/src/main/java/com/bikeprojectminji/bikeback/ride/entity/RideFinalizationJobStatus.java
@@ -1,0 +1,9 @@
+package com.bikeprojectminji.bikeback.ride.entity;
+
+public enum RideFinalizationJobStatus {
+    PENDING,
+    RUNNING,
+    SUCCEEDED,
+    FAILED,
+    RETRY_WAIT
+}

--- a/src/main/java/com/bikeprojectminji/bikeback/ride/policy/service/RidePolicyService.java
+++ b/src/main/java/com/bikeprojectminji/bikeback/ride/policy/service/RidePolicyService.java
@@ -225,6 +225,9 @@ public class RidePolicyService {
         if (request == null || request.phase() == null || request.location() == null) {
             throw new BadRequestException("phase와 location은 필수입니다.");
         }
+        if (!"PRE_START".equals(request.phase()) && !"ACTIVE".equals(request.phase())) {
+            throw new BadRequestException("phase는 PRE_START 또는 ACTIVE여야 합니다.");
+        }
         validateLocation(request.location());
         if (request.trace() != null) {
             for (RideLocationRequest tracePoint : request.trace()) {

--- a/src/main/java/com/bikeprojectminji/bikeback/ride/repository/RideFinalizationJobRepository.java
+++ b/src/main/java/com/bikeprojectminji/bikeback/ride/repository/RideFinalizationJobRepository.java
@@ -1,0 +1,42 @@
+package com.bikeprojectminji.bikeback.ride.repository;
+
+import com.bikeprojectminji.bikeback.ride.entity.RideFinalizationJobEntity;
+import com.bikeprojectminji.bikeback.ride.entity.RideFinalizationJobStatus;
+import jakarta.persistence.LockModeType;
+import java.time.OffsetDateTime;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+
+public interface RideFinalizationJobRepository extends JpaRepository<RideFinalizationJobEntity, Long> {
+
+    Optional<RideFinalizationJobEntity> findByRideRecordId(Long rideRecordId);
+
+    long countByStatus(RideFinalizationJobStatus status);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("""
+            select j from RideFinalizationJobEntity j
+            where j.status in :statuses
+              and j.nextRunAt <= :now
+            order by j.nextRunAt asc, j.id asc
+            """)
+    List<RideFinalizationJobEntity> findRunnableJobs(
+            Collection<RideFinalizationJobStatus> statuses,
+            OffsetDateTime now,
+            Pageable pageable
+    );
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("""
+            select j from RideFinalizationJobEntity j
+            where j.status = com.bikeprojectminji.bikeback.ride.entity.RideFinalizationJobStatus.RUNNING
+              and j.lockedUntil < :now
+            order by j.lockedUntil asc, j.id asc
+            """)
+    List<RideFinalizationJobEntity> findExpiredRunningJobs(OffsetDateTime now, Pageable pageable);
+}

--- a/src/main/java/com/bikeprojectminji/bikeback/ride/service/RideFinalizationJobLease.java
+++ b/src/main/java/com/bikeprojectminji/bikeback/ride/service/RideFinalizationJobLease.java
@@ -1,0 +1,8 @@
+package com.bikeprojectminji.bikeback.ride.service;
+
+public record RideFinalizationJobLease(
+        Long jobId,
+        Long rideRecordId,
+        int attemptCount
+) {
+}

--- a/src/main/java/com/bikeprojectminji/bikeback/ride/service/RideFinalizationJobMetricsBinder.java
+++ b/src/main/java/com/bikeprojectminji/bikeback/ride/service/RideFinalizationJobMetricsBinder.java
@@ -1,0 +1,26 @@
+package com.bikeprojectminji.bikeback.ride.service;
+
+import com.bikeprojectminji.bikeback.ride.entity.RideFinalizationJobStatus;
+import com.bikeprojectminji.bikeback.ride.repository.RideFinalizationJobRepository;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import org.springframework.stereotype.Component;
+
+@Component
+public class RideFinalizationJobMetricsBinder {
+
+    public RideFinalizationJobMetricsBinder(
+            MeterRegistry meterRegistry,
+            RideFinalizationJobRepository rideFinalizationJobRepository
+    ) {
+        for (RideFinalizationJobStatus status : RideFinalizationJobStatus.values()) {
+            Gauge.builder(
+                            "bike_ride_finalization_job_count",
+                            rideFinalizationJobRepository,
+                            repository -> repository.countByStatus(status)
+                    )
+                    .tag("status", status.name().toLowerCase())
+                    .register(meterRegistry);
+        }
+    }
+}

--- a/src/main/java/com/bikeprojectminji/bikeback/ride/service/RideFinalizationJobService.java
+++ b/src/main/java/com/bikeprojectminji/bikeback/ride/service/RideFinalizationJobService.java
@@ -1,0 +1,139 @@
+package com.bikeprojectminji.bikeback.ride.service;
+
+import com.bikeprojectminji.bikeback.global.metrics.BikeMetricsRecorder;
+import com.bikeprojectminji.bikeback.ride.entity.RideFinalizationJobEntity;
+import com.bikeprojectminji.bikeback.ride.entity.RideFinalizationJobStatus;
+import com.bikeprojectminji.bikeback.ride.repository.RideFinalizationJobRepository;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class RideFinalizationJobService {
+
+    private static final List<RideFinalizationJobStatus> RUNNABLE_STATUSES = List.of(
+            RideFinalizationJobStatus.PENDING,
+            RideFinalizationJobStatus.RETRY_WAIT
+    );
+
+    private final RideFinalizationJobRepository rideFinalizationJobRepository;
+    private final BikeMetricsRecorder bikeMetricsRecorder;
+    private final Clock clock;
+    private final Duration leaseDuration;
+    private final Duration retryBaseDelay;
+
+    public RideFinalizationJobService(
+            RideFinalizationJobRepository rideFinalizationJobRepository,
+            BikeMetricsRecorder bikeMetricsRecorder,
+            Clock clock,
+            @Value("${ride.finalization.worker.lease-sec:60}") long leaseSec,
+            @Value("${ride.finalization.worker.retry-base-delay-sec:5}") long retryBaseDelaySec
+    ) {
+        this.rideFinalizationJobRepository = rideFinalizationJobRepository;
+        this.bikeMetricsRecorder = bikeMetricsRecorder;
+        this.clock = clock;
+        this.leaseDuration = Duration.ofSeconds(leaseSec);
+        this.retryBaseDelay = Duration.ofSeconds(retryBaseDelaySec);
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void enqueue(Long rideRecordId) {
+        OffsetDateTime now = OffsetDateTime.now(clock);
+        RideFinalizationJobEntity job = rideFinalizationJobRepository.findByRideRecordId(rideRecordId)
+                .orElseGet(() -> new RideFinalizationJobEntity(rideRecordId, now));
+        job.enqueue(now);
+        rideFinalizationJobRepository.save(job);
+    }
+
+    @Transactional
+    public Optional<RideFinalizationJobLease> acquireNext(String workerId) {
+        OffsetDateTime now = OffsetDateTime.now(clock);
+        List<RideFinalizationJobEntity> runnableJobs = rideFinalizationJobRepository.findRunnableJobs(
+                RUNNABLE_STATUSES,
+                now,
+                PageRequest.of(0, 1)
+        );
+        if (runnableJobs.isEmpty()) {
+            runnableJobs = rideFinalizationJobRepository.findExpiredRunningJobs(now, PageRequest.of(0, 1));
+        }
+        if (runnableJobs.isEmpty()) {
+            return Optional.empty();
+        }
+
+        RideFinalizationJobEntity job = runnableJobs.get(0);
+        job.markRunning(workerId, now, now.plus(leaseDuration));
+        rideFinalizationJobRepository.save(job);
+        bikeMetricsRecorder.recordRideFinalizationJobAcquired();
+        return Optional.of(new RideFinalizationJobLease(job.getId(), job.getRideRecordId(), job.getAttemptCount()));
+    }
+
+    @Transactional
+    public boolean markSucceeded(Long jobId, String workerId, int attemptCount, Duration duration) {
+        RideFinalizationJobEntity job = rideFinalizationJobRepository.findById(jobId).orElseThrow();
+        if (!job.isOwnedRunningLease(workerId, attemptCount)) {
+            return false;
+        }
+        job.markSucceeded(OffsetDateTime.now(clock));
+        rideFinalizationJobRepository.save(job);
+        bikeMetricsRecorder.recordRideFinalizationJobDuration("succeeded", duration);
+        return true;
+    }
+
+    @Transactional
+    public boolean markFailedOrRetry(
+            Long jobId,
+            String workerId,
+            int attemptCount,
+            String errorCode,
+            String errorMessage,
+            Duration duration
+    ) {
+        OffsetDateTime now = OffsetDateTime.now(clock);
+        RideFinalizationJobEntity job = rideFinalizationJobRepository.findById(jobId).orElseThrow();
+        if (!job.isOwnedRunningLease(workerId, attemptCount)) {
+            return false;
+        }
+        String sanitizedErrorCode = sanitizeErrorCode(errorCode);
+        String sanitizedMessage = sanitizeErrorMessage(errorMessage);
+        if (job.attemptsExhausted()) {
+            job.markFailed(now, sanitizedErrorCode, sanitizedMessage);
+            rideFinalizationJobRepository.save(job);
+            bikeMetricsRecorder.recordRideRecordFinalizationFailure();
+            bikeMetricsRecorder.recordRideFinalizationJobTerminalFailure(sanitizedErrorCode);
+            bikeMetricsRecorder.recordRideFinalizationJobDuration("failed", duration);
+            return true;
+        }
+
+        OffsetDateTime nextRunAt = now.plus(retryBaseDelay.multipliedBy(Math.max(1, job.getAttemptCount())));
+        job.markRetryWait(now, nextRunAt, sanitizedErrorCode, sanitizedMessage);
+        rideFinalizationJobRepository.save(job);
+        bikeMetricsRecorder.recordRideFinalizationJobRetry(sanitizedErrorCode);
+        bikeMetricsRecorder.recordRideFinalizationJobDuration("retry_wait", duration);
+        return false;
+    }
+
+    private String sanitizeErrorCode(String errorCode) {
+        if (errorCode == null || errorCode.isBlank()) {
+            return "unknown";
+        }
+        return errorCode.trim().toLowerCase().replaceAll("[^a-z0-9_.:-]", "_");
+    }
+
+    private String sanitizeErrorMessage(String errorMessage) {
+        if (errorMessage == null || errorMessage.isBlank()) {
+            return "unknown";
+        }
+        String singleLine = errorMessage.replace('\n', ' ').replace('\r', ' ').trim();
+        if (singleLine.length() > 300) {
+            return singleLine.substring(0, 300);
+        }
+        return singleLine;
+    }
+}

--- a/src/main/java/com/bikeprojectminji/bikeback/ride/service/RideFinalizationJobWorker.java
+++ b/src/main/java/com/bikeprojectminji/bikeback/ride/service/RideFinalizationJobWorker.java
@@ -1,0 +1,124 @@
+package com.bikeprojectminji.bikeback.ride.service;
+
+import com.bikeprojectminji.bikeback.global.logging.RequestLogContext;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.OffsetDateTime;
+import java.util.Optional;
+import java.util.UUID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+@Service
+public class RideFinalizationJobWorker {
+
+    private static final Logger log = LoggerFactory.getLogger(RideFinalizationJobWorker.class);
+
+    private final RideFinalizationJobService rideFinalizationJobService;
+    private final RideRecordFinalizationWriter rideRecordFinalizationWriter;
+    private final RideRecordFinalizationFailureService rideRecordFinalizationFailureService;
+    private final Clock clock;
+    private final String appRole;
+    private final String workerId;
+    private final int batchSize;
+
+    public RideFinalizationJobWorker(
+            RideFinalizationJobService rideFinalizationJobService,
+            RideRecordFinalizationWriter rideRecordFinalizationWriter,
+            RideRecordFinalizationFailureService rideRecordFinalizationFailureService,
+            Clock clock,
+            @Value("${bike.app-role:all}") String appRole,
+            @Value("${ride.finalization.worker.id:}") String configuredWorkerId,
+            @Value("${ride.finalization.worker.batch-size:5}") int batchSize
+    ) {
+        this.rideFinalizationJobService = rideFinalizationJobService;
+        this.rideRecordFinalizationWriter = rideRecordFinalizationWriter;
+        this.rideRecordFinalizationFailureService = rideRecordFinalizationFailureService;
+        this.clock = clock;
+        this.appRole = appRole == null ? "all" : appRole.trim().toLowerCase();
+        this.workerId = configuredWorkerId == null || configuredWorkerId.isBlank()
+                ? "worker-" + UUID.randomUUID()
+                : configuredWorkerId.trim();
+        this.batchSize = Math.max(1, batchSize);
+    }
+
+    @Scheduled(fixedDelayString = "${ride.finalization.worker.poll-delay-ms:500}")
+    public void processDueJobs() {
+        if (!workerEnabled()) {
+            return;
+        }
+        for (int i = 0; i < batchSize; i++) {
+            Optional<RideFinalizationJobLease> lease = rideFinalizationJobService.acquireNext(workerId);
+            if (lease.isEmpty()) {
+                return;
+            }
+            process(lease.get());
+        }
+    }
+
+    private boolean workerEnabled() {
+        return "all".equals(appRole) || "worker".equals(appRole);
+    }
+
+    private void process(RideFinalizationJobLease lease) {
+        String requestId = "finalization-job-" + lease.jobId();
+        RequestLogContext.bind(requestId, requestId);
+        OffsetDateTime startedAt = OffsetDateTime.now(clock);
+        try {
+            rideRecordFinalizationWriter.replaceProcessedPoints(lease.rideRecordId());
+            boolean marked = rideFinalizationJobService.markSucceeded(
+                    lease.jobId(),
+                    workerId,
+                    lease.attemptCount(),
+                    Duration.between(startedAt, OffsetDateTime.now(clock))
+            );
+            if (!marked) {
+                log.warn(
+                        "ride_finalization_job_stale_completion request_id={} trace_id={} job_id={} ride_record_id={} attempt={}",
+                        RequestLogContext.currentRequestId(),
+                        RequestLogContext.currentTraceId(),
+                        lease.jobId(),
+                        lease.rideRecordId(),
+                        lease.attemptCount()
+                );
+                return;
+            }
+            log.info(
+                    "ride_finalization_job_succeeded request_id={} trace_id={} job_id={} ride_record_id={} attempt={}",
+                    RequestLogContext.currentRequestId(),
+                    RequestLogContext.currentTraceId(),
+                    lease.jobId(),
+                    lease.rideRecordId(),
+                    lease.attemptCount()
+            );
+        } catch (Exception exception) {
+            Duration duration = Duration.between(startedAt, OffsetDateTime.now(clock));
+            boolean terminal = rideFinalizationJobService.markFailedOrRetry(
+                    lease.jobId(),
+                    workerId,
+                    lease.attemptCount(),
+                    exception.getClass().getSimpleName(),
+                    exception.getMessage(),
+                    duration
+            );
+            if (terminal) {
+                rideRecordFinalizationFailureService.markFailed(lease.rideRecordId(), exception.getMessage());
+            }
+            log.warn(
+                    "ride_finalization_job_failed request_id={} trace_id={} job_id={} ride_record_id={} attempt={} terminal={} error_code={}",
+                    RequestLogContext.currentRequestId(),
+                    RequestLogContext.currentTraceId(),
+                    lease.jobId(),
+                    lease.rideRecordId(),
+                    lease.attemptCount(),
+                    terminal,
+                    exception.getClass().getSimpleName()
+            );
+        } finally {
+            RequestLogContext.clear();
+        }
+    }
+}

--- a/src/main/java/com/bikeprojectminji/bikeback/ride/service/RideRecordFinalizationService.java
+++ b/src/main/java/com/bikeprojectminji/bikeback/ride/service/RideRecordFinalizationService.java
@@ -7,7 +7,6 @@ import com.bikeprojectminji.bikeback.ride.repository.RideRecordPointRepository;
 import com.bikeprojectminji.bikeback.ride.repository.RideRecordProcessedPointRepository;
 import com.bikeprojectminji.bikeback.ride.repository.RideRecordRepository;
 import java.time.OffsetDateTime;
-import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -17,23 +16,22 @@ public class RideRecordFinalizationService {
     private final RideRecordRepository rideRecordRepository;
     private final RideRecordPointRepository rideRecordPointRepository;
     private final RideRecordProcessedPointRepository rideRecordProcessedPointRepository;
-    private final RideRecordFinalizationProcessor rideRecordFinalizationProcessor;
+    private final RideFinalizationJobService rideFinalizationJobService;
 
     public RideRecordFinalizationService(
             RideRecordRepository rideRecordRepository,
             RideRecordPointRepository rideRecordPointRepository,
             RideRecordProcessedPointRepository rideRecordProcessedPointRepository,
-            RideRecordFinalizationProcessor rideRecordFinalizationProcessor
+            RideFinalizationJobService rideFinalizationJobService
     ) {
         this.rideRecordRepository = rideRecordRepository;
         this.rideRecordPointRepository = rideRecordPointRepository;
         this.rideRecordProcessedPointRepository = rideRecordProcessedPointRepository;
-        this.rideRecordFinalizationProcessor = rideRecordFinalizationProcessor;
+        this.rideFinalizationJobService = rideFinalizationJobService;
     }
 
-    @Async
     public void requestFinalization(Long rideRecordId) {
-        rideRecordFinalizationProcessor.finalizeRideRecord(rideRecordId);
+        rideFinalizationJobService.enqueue(rideRecordId);
     }
 
     @Transactional

--- a/src/main/java/com/bikeprojectminji/bikeback/ride/service/RideRecordService.java
+++ b/src/main/java/com/bikeprojectminji/bikeback/ride/service/RideRecordService.java
@@ -209,7 +209,7 @@ public class RideRecordService {
             throw new BadRequestException("trace가 없는 자유 주행 기록은 재처리할 수 없습니다.");
         }
         rideRecordFinalizationService.markForRegeneration(rideRecord);
-        rideRecordFinalizationService.requestFinalization(rideRecordId);
+        registerFinalizationAfterCommit(rideRecordId);
         return rideRecordFinalizationService.getStatus(rideRecord);
     }
 

--- a/src/main/java/com/bikeprojectminji/bikeback/routing/infrastructure/GraphHopperBicycleRoutingClient.java
+++ b/src/main/java/com/bikeprojectminji/bikeback/routing/infrastructure/GraphHopperBicycleRoutingClient.java
@@ -92,6 +92,8 @@ public class GraphHopperBicycleRoutingClient implements BicycleRoutingClient {
     }
 
     private BicycleRoutingProviderResult routeOnce(String baseUrl, BicycleRouteRequest request) {
+        long startedAtNanos = System.nanoTime();
+        String outcome = "success";
         try {
             GraphHopperRouteResponse response = restClient.get()
                     .uri(ignored -> {
@@ -118,6 +120,7 @@ public class GraphHopperBicycleRoutingClient implements BicycleRoutingClient {
                     .retrieve()
                     .body(GraphHopperRouteResponse.class);
             if (response == null || response.paths() == null || response.paths().isEmpty()) {
+                outcome = "empty_response";
                 return providerFailure("empty_response");
             }
             List<BicycleRouteCandidate> candidates = response.paths().stream()
@@ -126,13 +129,25 @@ public class GraphHopperBicycleRoutingClient implements BicycleRoutingClient {
                     .filter(candidate -> !candidate.polyline().isEmpty())
                     .toList();
             if (candidates.isEmpty()) {
+                outcome = "invalid_response";
                 return providerFailure("invalid_response");
             }
             return BicycleRoutingProviderResult.success(PROVIDER, candidates);
         } catch (HttpStatusCodeException exception) {
-            return providerFailure(reasonForStatus(exception.getStatusCode().value()));
+            outcome = reasonForStatus(exception.getStatusCode().value());
+            return providerFailure(outcome);
         } catch (RestClientException | IllegalArgumentException exception) {
-            return providerFailure(exception instanceof IllegalArgumentException ? "illegal_argument" : "rest_client_exception");
+            outcome = exception instanceof IllegalArgumentException ? "illegal_argument" : "rest_client_exception";
+            return providerFailure(outcome);
+        } finally {
+            if (bikeMetricsRecorder != null) {
+                bikeMetricsRecorder.recordProviderCall(
+                        PROVIDER,
+                        "route",
+                        outcome,
+                        Duration.ofNanos(System.nanoTime() - startedAtNanos)
+                );
+            }
         }
     }
 

--- a/src/main/java/com/bikeprojectminji/bikeback/routing/infrastructure/KakaoMobilityBicycleRoutingClient.java
+++ b/src/main/java/com/bikeprojectminji/bikeback/routing/infrastructure/KakaoMobilityBicycleRoutingClient.java
@@ -57,6 +57,8 @@ public class KakaoMobilityBicycleRoutingClient implements BicycleRoutingClient {
         if (restApiKey == null || restApiKey.isBlank()) {
             return providerFailure("missing_api_key");
         }
+        long startedAtNanos = System.nanoTime();
+        String outcome = "success";
         try {
             KakaoBicycleDirectionsResponse response = restClient.get()
                     .uri(uriBuilder -> uriBuilder
@@ -69,6 +71,7 @@ public class KakaoMobilityBicycleRoutingClient implements BicycleRoutingClient {
                     .retrieve()
                     .body(KakaoBicycleDirectionsResponse.class);
             if (response == null || response.routes() == null || response.routes().isEmpty()) {
+                outcome = "empty_response";
                 return providerFailure("empty_response");
             }
             return BicycleRoutingProviderResult.success(PROVIDER, response.routes().stream()
@@ -76,9 +79,20 @@ public class KakaoMobilityBicycleRoutingClient implements BicycleRoutingClient {
                     .map(route -> route.toCandidate(request.preference()))
                     .toList());
         } catch (HttpStatusCodeException exception) {
-            return providerFailure(reasonForStatus(exception.getStatusCode()));
+            outcome = reasonForStatus(exception.getStatusCode());
+            return providerFailure(outcome);
         } catch (RestClientException exception) {
+            outcome = "rest_client_exception";
             return providerFailure("rest_client_exception");
+        } finally {
+            if (bikeMetricsRecorder != null) {
+                bikeMetricsRecorder.recordProviderCall(
+                        PROVIDER,
+                        "route",
+                        outcome,
+                        Duration.ofNanos(System.nanoTime() - startedAtNanos)
+                );
+            }
         }
     }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -107,6 +107,7 @@ ai-route:
     allowed-origins: ${AI_ROUTE_WEBSOCKET_ALLOWED_ORIGINS:}
 
 bike:
+  app-role: ${BIKE_APP_ROLE:all}
   rate-limit:
     store: ${BIKE_RATE_LIMIT_STORE:redis}
   async:

--- a/src/main/resources/db/migration/V34__create_ride_finalization_jobs.sql
+++ b/src/main/resources/db/migration/V34__create_ride_finalization_jobs.sql
@@ -1,0 +1,45 @@
+CREATE TABLE IF NOT EXISTS ride_finalization_jobs (
+    id BIGSERIAL PRIMARY KEY,
+    ride_record_id BIGINT NOT NULL,
+    status VARCHAR(32) NOT NULL,
+    attempt_count INTEGER NOT NULL DEFAULT 0,
+    max_attempts INTEGER NOT NULL DEFAULT 3,
+    next_run_at TIMESTAMPTZ NOT NULL,
+    locked_by VARCHAR(120),
+    locked_until TIMESTAMPTZ,
+    last_error_code VARCHAR(80),
+    last_error_message TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    CONSTRAINT uq_ride_finalization_jobs_ride_record UNIQUE (ride_record_id),
+    CONSTRAINT fk_ride_finalization_jobs_ride_record
+        FOREIGN KEY (ride_record_id) REFERENCES ride_records (id)
+        ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_ride_finalization_jobs_runnable
+    ON ride_finalization_jobs (status, next_run_at, id);
+
+CREATE INDEX IF NOT EXISTS idx_ride_finalization_jobs_expired_running
+    ON ride_finalization_jobs (status, locked_until, id);
+
+INSERT INTO ride_finalization_jobs (
+    ride_record_id,
+    status,
+    attempt_count,
+    max_attempts,
+    next_run_at,
+    created_at,
+    updated_at
+)
+SELECT
+    r.id,
+    'PENDING',
+    0,
+    3,
+    now(),
+    now(),
+    now()
+FROM ride_records r
+WHERE r.finalization_status = 'FINALIZING'
+ON CONFLICT (ride_record_id) DO NOTHING;

--- a/src/test/java/com/bikeprojectminji/bikeback/address/service/AddressSearchServiceIntegrationTest.java
+++ b/src/test/java/com/bikeprojectminji/bikeback/address/service/AddressSearchServiceIntegrationTest.java
@@ -5,6 +5,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.bikeprojectminji.bikeback.address.dto.AddressSearchResponse;
 import com.bikeprojectminji.bikeback.global.exception.BadRequestException;
+import com.bikeprojectminji.bikeback.global.metrics.BikeMetricsRecorder;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.math.BigDecimal;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
@@ -133,6 +135,11 @@ class AddressSearchServiceIntegrationTest {
         @Bean
         ScenarioAddressSearchClient scenarioAddressSearchClient() {
             return new ScenarioAddressSearchClient();
+        }
+
+        @Bean
+        BikeMetricsRecorder bikeMetricsRecorder() {
+            return new BikeMetricsRecorder(new SimpleMeterRegistry());
         }
 
     }

--- a/src/test/java/com/bikeprojectminji/bikeback/global/metrics/BikeMetricsRecorderTest.java
+++ b/src/test/java/com/bikeprojectminji/bikeback/global/metrics/BikeMetricsRecorderTest.java
@@ -27,12 +27,18 @@ class BikeMetricsRecorderTest {
         recorder.recordFeaturedCoursesFallback("missing_location_parameters");
         recorder.recordRidePolicyUndetermined("ACTIVE", "stale_location");
         recorder.recordRideRecordFinalizationFailure();
+        recorder.recordRideFinalizationJobAcquired();
+        recorder.recordRideFinalizationJobRetry("IllegalStateException");
+        recorder.recordRideFinalizationJobTerminalFailure("IllegalStateException");
+        recorder.recordRideFinalizationJobDuration("succeeded", java.time.Duration.ofMillis(125));
         recorder.recordCourseRouteCacheHit("ride_policy");
         recorder.recordCourseRouteCacheMiss("ride_policy");
         recorder.recordCourseRouteCacheBypass("course_download");
         recorder.recordCourseRouteSnapshotLoad("route_points");
+        recorder.recordCourseRouteSnapshotLoadDuration("route_points", java.time.Duration.ofMillis(10));
         recorder.recordCourseRouteCacheEviction("route_points_updated");
         recorder.recordRoutingProviderFailure("GraphHopper", "http_429");
+        recorder.recordProviderCall("GraphHopper", "route", "success", java.time.Duration.ofMillis(35));
 
         assertThat(meterRegistry.get("bike_weather_fallback_total").counter().count()).isEqualTo(1.0);
         assertThat(meterRegistry.get("bike_weather_stale_served_total").counter().count()).isEqualTo(1.0);
@@ -54,15 +60,41 @@ class BikeMetricsRecorderTest {
                 .counter()
                 .count()).isEqualTo(1.0);
         assertThat(meterRegistry.get("bike_ride_record_finalization_failed_total").counter().count()).isEqualTo(1.0);
+        assertThat(meterRegistry.get("bike_ride_finalization_job_acquired_total").counter().count()).isEqualTo(1.0);
+        assertThat(meterRegistry.get("bike_ride_finalization_job_retry_total")
+                .tag("error_code", "illegalstateexception")
+                .counter()
+                .count()).isEqualTo(1.0);
+        assertThat(meterRegistry.get("bike_ride_finalization_job_terminal_failure_total")
+                .tag("error_code", "illegalstateexception")
+                .counter()
+                .count()).isEqualTo(1.0);
+        assertThat(meterRegistry.get("bike_ride_finalization_job_duration")
+                .tag("outcome", "succeeded")
+                .timer()
+                .count()).isEqualTo(1);
         assertThat(meterRegistry.get("bike_course_route_cache_hit_total").tag("consumer", "ride_policy").counter().count()).isEqualTo(1.0);
         assertThat(meterRegistry.get("bike_course_route_cache_miss_total").tag("consumer", "ride_policy").counter().count()).isEqualTo(1.0);
         assertThat(meterRegistry.get("bike_course_route_cache_bypass_total").tag("consumer", "course_download").counter().count()).isEqualTo(1.0);
         assertThat(meterRegistry.get("bike_course_route_snapshot_load_total").tag("consumer", "route_points").counter().count()).isEqualTo(1.0);
+        assertThat(meterRegistry.get("bike_course_route_snapshot_load_duration").tag("consumer", "route_points").timer().count()).isEqualTo(1);
         assertThat(meterRegistry.get("bike_course_route_cache_eviction_total").tag("reason", "route_points_updated").counter().count()).isEqualTo(1.0);
         assertThat(meterRegistry.get("bike_routing_provider_failure_total")
                 .tag("provider", "graphhopper")
                 .tag("reason", "http_429")
                 .counter()
                 .count()).isEqualTo(1.0);
+        assertThat(meterRegistry.get("bike_provider_call_total")
+                .tag("provider", "graphhopper")
+                .tag("operation", "route")
+                .tag("outcome", "success")
+                .counter()
+                .count()).isEqualTo(1.0);
+        assertThat(meterRegistry.get("bike_provider_latency")
+                .tag("provider", "graphhopper")
+                .tag("operation", "route")
+                .tag("outcome", "success")
+                .timer()
+                .count()).isEqualTo(1);
     }
 }

--- a/src/test/java/com/bikeprojectminji/bikeback/global/metrics/PrometheusMetricsIntegrationTest.java
+++ b/src/test/java/com/bikeprojectminji/bikeback/global/metrics/PrometheusMetricsIntegrationTest.java
@@ -22,8 +22,12 @@ class PrometheusMetricsIntegrationTest {
         bikeMetricsRecorder.recordWeatherRefreshSkipped("already_in_progress");
         bikeMetricsRecorder.recordRidePolicyUndetermined("PRE_START", "low_accuracy");
         bikeMetricsRecorder.recordRideRecordFinalizationFailure();
+        bikeMetricsRecorder.recordRideFinalizationJobAcquired();
+        bikeMetricsRecorder.recordRideFinalizationJobRetry("IllegalStateException");
+        bikeMetricsRecorder.recordRideFinalizationJobDuration("succeeded", java.time.Duration.ofMillis(125));
         bikeMetricsRecorder.recordCourseRouteCacheHit("ride_policy");
         bikeMetricsRecorder.recordCourseRouteSnapshotLoad("ride_policy");
+        bikeMetricsRecorder.recordProviderCall("GraphHopper", "route", "success", java.time.Duration.ofMillis(35));
 
         String scrape = prometheusMeterRegistry.scrape();
 
@@ -34,7 +38,12 @@ class PrometheusMetricsIntegrationTest {
         assertThat(scrape).contains("bike_weather_refresh_skipped_total");
         assertThat(scrape).contains("bike_ride_policy_undetermined_total");
         assertThat(scrape).contains("bike_ride_record_finalization_failed_total");
+        assertThat(scrape).contains("bike_ride_finalization_job_acquired_total");
+        assertThat(scrape).contains("bike_ride_finalization_job_retry_total");
+        assertThat(scrape).contains("bike_ride_finalization_job_duration");
         assertThat(scrape).contains("bike_course_route_cache_hit_total");
         assertThat(scrape).contains("bike_course_route_snapshot_load_total");
+        assertThat(scrape).contains("bike_provider_call_total");
+        assertThat(scrape).contains("bike_provider_latency");
     }
 }

--- a/src/test/java/com/bikeprojectminji/bikeback/ride/entity/RideFinalizationJobEntityTest.java
+++ b/src/test/java/com/bikeprojectminji/bikeback/ride/entity/RideFinalizationJobEntityTest.java
@@ -1,0 +1,27 @@
+package com.bikeprojectminji.bikeback.ride.entity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.OffsetDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class RideFinalizationJobEntityTest {
+
+    @Test
+    @DisplayName("RUNNING lease 소유자는 worker id와 attempt count가 모두 일치해야 한다")
+    void runningLeaseRequiresWorkerIdAndAttemptCount() {
+        OffsetDateTime now = OffsetDateTime.parse("2026-06-26T08:00:00Z");
+        RideFinalizationJobEntity job = new RideFinalizationJobEntity(10L, now);
+
+        job.markRunning("worker-a", now, now.plusMinutes(1));
+
+        assertThat(job.isOwnedRunningLease("worker-a", 1)).isTrue();
+        assertThat(job.isOwnedRunningLease("worker-b", 1)).isFalse();
+        assertThat(job.isOwnedRunningLease("worker-a", 2)).isFalse();
+
+        job.enqueue(now.plusSeconds(10));
+
+        assertThat(job.isOwnedRunningLease("worker-a", 1)).isFalse();
+    }
+}

--- a/src/test/java/com/bikeprojectminji/bikeback/ride/service/RideFinalizationJobWorkerTest.java
+++ b/src/test/java/com/bikeprojectminji/bikeback/ride/service/RideFinalizationJobWorkerTest.java
@@ -1,0 +1,80 @@
+package com.bikeprojectminji.bikeback.ride.service;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class RideFinalizationJobWorkerTest {
+
+    private static final Clock CLOCK = Clock.fixed(Instant.parse("2026-06-26T08:00:00Z"), ZoneOffset.UTC);
+
+    @Mock
+    private RideFinalizationJobService rideFinalizationJobService;
+
+    @Mock
+    private RideRecordFinalizationWriter rideRecordFinalizationWriter;
+
+    @Mock
+    private RideRecordFinalizationFailureService rideRecordFinalizationFailureService;
+
+    @Test
+    @DisplayName("app role이 api이면 finalization worker는 job을 가져오지 않는다")
+    void apiRoleDoesNotProcessJobs() {
+        RideFinalizationJobWorker worker = new RideFinalizationJobWorker(
+                rideFinalizationJobService,
+                rideRecordFinalizationWriter,
+                rideRecordFinalizationFailureService,
+                CLOCK,
+                "api",
+                "test-worker",
+                1
+        );
+
+        worker.processDueJobs();
+
+        then(rideFinalizationJobService).shouldHaveNoInteractions();
+    }
+
+    @Test
+    @DisplayName("terminal 실패가 아니면 ride record를 FAILED로 전이하지 않고 retry job만 남긴다")
+    void retryableFailureDoesNotMarkRideRecordFailed() {
+        RideFinalizationJobWorker worker = new RideFinalizationJobWorker(
+                rideFinalizationJobService,
+                rideRecordFinalizationWriter,
+                rideRecordFinalizationFailureService,
+                CLOCK,
+                "worker",
+                "test-worker",
+                1
+        );
+        RideFinalizationJobLease lease = new RideFinalizationJobLease(11L, 22L, 1);
+        given(rideFinalizationJobService.acquireNext("test-worker")).willReturn(Optional.of(lease));
+        RuntimeException failure = new RuntimeException("canonicalization failed");
+        org.mockito.Mockito.doThrow(failure).when(rideRecordFinalizationWriter).replaceProcessedPoints(22L);
+        given(rideFinalizationJobService.markFailedOrRetry(
+                org.mockito.ArgumentMatchers.eq(11L),
+                org.mockito.ArgumentMatchers.eq("test-worker"),
+                org.mockito.ArgumentMatchers.eq(1),
+                org.mockito.ArgumentMatchers.anyString(),
+                org.mockito.ArgumentMatchers.anyString(),
+                org.mockito.ArgumentMatchers.any()
+        ))
+                .willReturn(false);
+
+        worker.processDueJobs();
+
+        verify(rideRecordFinalizationFailureService, never()).markFailed(22L, "canonicalization failed");
+    }
+}

--- a/src/test/java/com/bikeprojectminji/bikeback/ride/service/RideRecordFinalizationIntegrationTest.java
+++ b/src/test/java/com/bikeprojectminji/bikeback/ride/service/RideRecordFinalizationIntegrationTest.java
@@ -38,7 +38,7 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-@SpringBootTest
+@SpringBootTest(properties = "bike.app-role=all")
 @ActiveProfiles("test")
 class RideRecordFinalizationIntegrationTest {
 
@@ -56,6 +56,9 @@ class RideRecordFinalizationIntegrationTest {
 
     @Autowired
     private RideRecordRepository rideRecordRepository;
+
+    @Autowired
+    private RideFinalizationJobWorker rideFinalizationJobWorker;
 
     @Autowired
     private CourseRepository courseRepository;
@@ -217,6 +220,7 @@ class RideRecordFinalizationIntegrationTest {
 
     private RideRecordFinalizationStatusResponse awaitReady(Long rideRecordId) throws Exception {
         for (int i = 0; i < 20; i++) {
+            rideFinalizationJobWorker.processDueJobs();
             RideRecordFinalizationStatusResponse status = rideRecordService.getRideRecordStatus("1", rideRecordId);
             if (!"FINALIZING".equals(status.status())) {
                 return status;

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -24,5 +24,6 @@ auth:
     token-validity-sec: 900
 
 bike:
+  app-role: api
   rate-limit:
     store: memory

--- a/src/test/resources/schema-h2.sql
+++ b/src/test/resources/schema-h2.sql
@@ -166,6 +166,25 @@ CREATE TABLE ride_record_processed_points (
         ON DELETE CASCADE
 );
 
+CREATE TABLE ride_finalization_jobs (
+    id BIGSERIAL PRIMARY KEY,
+    ride_record_id BIGINT NOT NULL,
+    status VARCHAR(32) NOT NULL,
+    attempt_count INTEGER NOT NULL DEFAULT 0,
+    max_attempts INTEGER NOT NULL DEFAULT 3,
+    next_run_at TIMESTAMP WITH TIME ZONE NOT NULL,
+    locked_by VARCHAR(120),
+    locked_until TIMESTAMP WITH TIME ZONE,
+    last_error_code VARCHAR(80),
+    last_error_message TEXT,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+    CONSTRAINT uq_ride_finalization_jobs_ride_record UNIQUE (ride_record_id),
+    CONSTRAINT fk_ride_finalization_jobs_ride_record
+        FOREIGN KEY (ride_record_id) REFERENCES ride_records (id)
+        ON DELETE CASCADE
+);
+
 CREATE TABLE client_events (
     id BIGSERIAL PRIMARY KEY,
     event_name VARCHAR(100) NOT NULL,
@@ -190,6 +209,12 @@ CREATE UNIQUE INDEX uq_courses_owner_source_ride_record
 
 CREATE INDEX idx_ride_records_owner_status_ended_at
     ON ride_records (owner_user_id, finalization_status, ended_at);
+
+CREATE INDEX idx_ride_finalization_jobs_runnable
+    ON ride_finalization_jobs (status, next_run_at, id);
+
+CREATE INDEX idx_ride_finalization_jobs_expired_running
+    ON ride_finalization_jobs (status, locked_until, id);
 
 CREATE INDEX idx_courses_owner_created_at
     ON courses (owner_user_id, created_at);


### PR DESCRIPTION
## 변경 요약
- HTTP 요청마다 `X-Request-Id`, `X-Trace-Id`를 응답/로그에 연결하고 외부 입력 correlation id를 sanitize했습니다.
- k6 `bike-api.js`가 요청별 request/trace id를 생성하고, `SLOW_REQUEST_SAMPLE_MS` 이상 느린 요청을 stdout JSON line evidence로 남기도록 확장했습니다.
- provider latency/failure, route snapshot load duration, finalization job count/duration/retry/failure metric을 추가했습니다.
- ride finalization을 `@Async` 직접 처리에서 `ride_finalization_jobs` DB job table + worker polling 구조로 전환했습니다.
- `BIKE_APP_ROLE=api|worker|all` 실행 역할 설정을 추가했습니다.
- 기존 `FINALIZING` ride record를 신규 job table로 backfill하는 Flyway migration을 추가했습니다.

## 주요 파일
- `src/main/java/com/bikeprojectminji/bikeback/global/logging/*`
- `src/main/java/com/bikeprojectminji/bikeback/global/metrics/BikeMetricsRecorder.java`
- `src/main/java/com/bikeprojectminji/bikeback/ride/entity/RideFinalizationJobEntity.java`
- `src/main/java/com/bikeprojectminji/bikeback/ride/service/RideFinalizationJobService.java`
- `src/main/java/com/bikeprojectminji/bikeback/ride/service/RideFinalizationJobWorker.java`
- `src/main/resources/db/migration/V34__create_ride_finalization_jobs.sql`
- `ops/loadtest/k6/bike-api.js`
- `docs/인프라/k6_백엔드_부하테스트_가이드.md`

## 검증
- `./gradlew test --tests 'com.bikeprojectminji.bikeback.ride.entity.RideFinalizationJobEntityTest' --tests 'com.bikeprojectminji.bikeback.ride.service.RideFinalizationJobWorkerTest' --tests 'com.bikeprojectminji.bikeback.ride.service.*Finalization*' --tests 'com.bikeprojectminji.bikeback.ride.policy.service.RidePolicyServiceTest' --tests 'com.bikeprojectminji.bikeback.global.metrics.*'` 통과
- `./gradlew test` 통과
- `k6 inspect -e BASE_URL=http://localhost:8080 ops/loadtest/k6/bike-api.js` 통과
- `git diff --check` 통과

## 리뷰 페르소나
### 백엔드 아키텍처/도메인 리뷰어
- blocking: 기존 `FINALIZING` record backfill 누락, legacy finalization failure metric 회귀 가능성 지적
- 반영: `V34` migration에 backfill 추가, terminal failure 시 legacy `bike_ride_record_finalization_failed_total`도 유지

### QA/보안/운영 리뷰어
- blocking: stale lease worker가 job 상태를 덮어쓸 수 있음, 공개 ride-policy phase tag cardinality 가능성 지적
- 반영: job 완료/실패 갱신 시 `lockedBy` + `attemptCount` + `RUNNING` 검증, metric 기록 전 `phase` allowlist 검증 추가

## 아직 실행하지 못한 검증
- Local HTTP smoke/k6 run: 이 세션의 `bootRun --spring.profiles.active=test`는 testRuntime H2가 bootRun classpath에 없어 datasource URL을 구성하지 못했습니다. 실제 Postgres/Redis env 또는 compose 기동 후 재실행 필요합니다.
- AWS single instance / ALB single target / ALB 2 targets: 대상 인프라 endpoint, 배포 권한, 운영 scrape 접근 정보가 이 세션에 없어 미실행입니다.

## 남은 리스크
- DB polling worker는 1차 구조입니다. 다중 worker 고부하에서는 PostgreSQL native `FOR UPDATE SKIP LOCKED` 전환을 검토할 수 있습니다.
- k6 slow sample stdout에는 query path가 포함되므로 evidence 공개 범위를 제한해야 합니다.
- Prometheus app metrics scrape는 기존 보안 정책상 인증/네트워크 모델 확정 전까지 내부 병목 분석 완료 근거로 볼 수 없습니다.
