### PR TITLE
fix: detach duplicate source courses before constraint

### DIFF
--- a/src/main/resources/db/migration/V16__release_defect_fix_constraints.sql
+++ b/src/main/resources/db/migration/V16__release_defect_fix_constraints.sql
@@ -14,6 +14,24 @@ CREATE UNIQUE INDEX IF NOT EXISTS uq_ride_record_processed_points_record_order
 CREATE UNIQUE INDEX IF NOT EXISTS uq_course_route_points_course_order
     ON course_route_points (course_id, point_order);
 
+WITH duplicate_source_courses AS (
+    SELECT id,
+           ROW_NUMBER() OVER (
+               PARTITION BY owner_user_id, source_ride_record_id
+               ORDER BY id
+           ) AS duplicate_rank
+    FROM courses
+    WHERE owner_user_id IS NOT NULL
+      AND source_ride_record_id IS NOT NULL
+)
+UPDATE courses
+SET source_ride_record_id = NULL
+WHERE id IN (
+    SELECT id
+    FROM duplicate_source_courses
+    WHERE duplicate_rank > 1
+);
+
 CREATE UNIQUE INDEX IF NOT EXISTS uq_courses_owner_source_ride_record
     ON courses (owner_user_id, source_ride_record_id)
     WHERE source_ride_record_id IS NOT NULL;


### PR DESCRIPTION
## 변경 요약
- V16 `uq_courses_owner_source_ride_record` 생성 전에 기존 중복 `courses.source_ride_record_id`를 정리합니다.
- 같은 `(owner_user_id, source_ride_record_id)` 그룹에서는 가장 낮은 `courses.id` 1건만 원본 ride record 연결을 유지하고, 나머지는 `source_ride_record_id = NULL`로 분리합니다.
- course row 자체는 삭제하지 않아 route point/report/publication 같은 연결 데이터 손실을 피합니다.

## 검증
- `./gradlew --no-daemon test --console=plain` 성공
- `./gradlew --no-daemon bootJar --console=plain` 성공
- AWS DB PostGIS extension 선생성 후 최신 jar 수동 배포 성공
- AWS Flyway: v15 -> v34 적용 성공
- AWS 중복 확인: `source_ride_record_id IS NOT NULL` 기준 중복 0건
- ALB target group `bike-api-tg`: healthy
- `https://api.gajabike.shop/health`: 200, `X-Request-Id`/`X-Trace-Id` 확인
- k6 weather 제외 smoke 성공
  - summary: `ops/loadtest/results/aws-alb-noweather-20260626-223534-summary.json`
  - `http_req_failed(rate): 0`
  - `checks(rate): 1`
  - `http_req_duration(p95): 151.213363 ms`

## 리뷰 관점
### 백엔드 아키텍처/도메인 리뷰어
- blocking issue: 없음
- non-blocking improvement: 장기적으로 운영 DB 보정성 migration은 별도 data migration 규칙 문서화 권장
- 검증 근거: 도메인 정책 `COURSE-P-003`과 서비스 중복 거부 로직에 맞춰 유니크 제약 유지

### QA/보안/운영 리뷰어
- blocking issue: 없음
- non-blocking improvement: `/actuator/prometheus`는 현재 인증 401이라 이번 smoke에서 직접 scrape evidence는 미수집
- 검증 근거: AWS 배포, ALB health, k6 smoke, request_id/trace_id 앱 로그 연결 확인

## 남은 리스크
- V16 파일을 수정했으므로 이미 V16 이상을 적용한 장기 실행 환경이 있다면 Flyway checksum mismatch가 날 수 있습니다. 현재 AWS 대상 DB는 v15에서 적용되어 정상 통과했습니다.
- 중복 row는 삭제하지 않고 source link만 분리했으므로, UI/API에서 해당 course는 계속 남습니다.
