### PR TITLE
feat: add internal operation observability

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+	implementation 'org.springframework.boot:spring-boot-starter-aop'
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-resource-server'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-web'

--- a/ops/observability/ec2/.env.example
+++ b/ops/observability/ec2/.env.example
@@ -3,6 +3,8 @@ GRAFANA_ROOT_URL=https://observability.gajabike.shop
 GRAFANA_ADMIN_USER=admin
 GRAFANA_ADMIN_PASSWORD=change-me
 APP_PRIVATE_HOST=10.0.10.12
+# App EC2 must set MANAGEMENT_PROMETHEUS_PUBLIC_SCRAPE_ENABLED=true.
+# The management port must stay private-security-group only and must not be routed through the public ALB.
 POSTGRES_EXPORTER_DSN=postgresql://bike:change-me@10.0.20.10:5432/bike?sslmode=disable
 REDIS_EXPORTER_ADDR=redis://10.0.10.12:6379
 REDIS_EXPORTER_SKIP_TLS_VERIFICATION=false

--- a/ops/observability/ec2/prometheus/prometheus.yml.template
+++ b/ops/observability/ec2/prometheus/prometheus.yml.template
@@ -13,6 +13,12 @@ scrape_configs:
       - targets:
           - ${APP_PRIVATE_HOST}:9121
 
+  - job_name: bike-back-app
+    metrics_path: /actuator/prometheus
+    static_configs:
+      - targets:
+          - ${APP_PRIVATE_HOST}:18081
+
   - job_name: prometheus
     static_configs:
       - targets:

--- a/ops/observability/ec2/validate-observability-stack.sh
+++ b/ops/observability/ec2/validate-observability-stack.sh
@@ -9,12 +9,13 @@ set -a
 source "$ENV_FILE"
 set +a
 
-printf '[INFO] checking actuator endpoint rejects unauthenticated access\n'
+printf '[INFO] checking private actuator prometheus scrape\n'
 ACTUATOR_STATUS="$(curl -sS -o /tmp/bike-app-prometheus.txt -w '%{http_code}' "http://${APP_PRIVATE_HOST}:18081/actuator/prometheus")"
-if [ "$ACTUATOR_STATUS" != "401" ]; then
-  printf '[ERROR] expected unauthenticated actuator prometheus status 401, got %s\n' "$ACTUATOR_STATUS" >&2
+if [ "$ACTUATOR_STATUS" != "200" ]; then
+  printf '[ERROR] expected private actuator prometheus status 200, got %s\n' "$ACTUATOR_STATUS" >&2
   exit 1
 fi
+grep -q 'http_server_requests_seconds' /tmp/bike-app-prometheus.txt
 
 printf '[INFO] checking prometheus readiness\n'
 curl -fsS http://127.0.0.1:9090/-/ready >/tmp/bike-prometheus-ready.txt

--- a/src/main/java/com/bikeprojectminji/bikeback/address/service/AddressSearchService.java
+++ b/src/main/java/com/bikeprojectminji/bikeback/address/service/AddressSearchService.java
@@ -4,6 +4,7 @@ import com.bikeprojectminji.bikeback.address.dto.AddressCandidateResponse;
 import com.bikeprojectminji.bikeback.address.dto.AddressSearchResponse;
 import com.bikeprojectminji.bikeback.global.exception.BadRequestException;
 import com.bikeprojectminji.bikeback.global.metrics.BikeMetricsRecorder;
+import com.bikeprojectminji.bikeback.global.metrics.MeasuredOperation;
 import io.micrometer.core.instrument.Metrics;
 import java.time.Duration;
 import java.util.List;
@@ -31,6 +32,7 @@ public class AddressSearchService {
         this.bikeMetricsRecorder = bikeMetricsRecorder;
     }
 
+    @MeasuredOperation("address.search")
     public AddressSearchResponse search(String rawQuery, Integer page, Integer size) {
         AddressSearchQuery query = normalizeQuery(rawQuery, page, size);
         AddressSearchProviderResult providerResult = searchWithFallback(query);

--- a/src/main/java/com/bikeprojectminji/bikeback/airoute/service/AiRoutePlannerService.java
+++ b/src/main/java/com/bikeprojectminji/bikeback/airoute/service/AiRoutePlannerService.java
@@ -4,6 +4,7 @@ import com.bikeprojectminji.bikeback.airoute.dto.AiRoutePlanRequest;
 import com.bikeprojectminji.bikeback.airoute.dto.AiRoutePlanResponse;
 import com.bikeprojectminji.bikeback.airoute.dto.AiRouteTextPlanRequest;
 import com.bikeprojectminji.bikeback.global.exception.BadRequestException;
+import com.bikeprojectminji.bikeback.global.metrics.MeasuredOperation;
 import com.bikeprojectminji.bikeback.routing.service.BicycleRoutePlan;
 import com.bikeprojectminji.bikeback.routing.service.BicycleRouteRequest;
 import com.bikeprojectminji.bikeback.routing.service.BicycleRoutingService;
@@ -45,6 +46,7 @@ public class AiRoutePlannerService {
         return plan(null, request);
     }
 
+    @MeasuredOperation("ai_route.plan")
     public AiRoutePlanResponse plan(String subject, AiRoutePlanRequest request) {
         validate(request);
         AiRoutePlanRequest resolvedRequest = applyDefaultDestination(applyDefaultRideStyle(subject, request));
@@ -59,6 +61,7 @@ public class AiRoutePlannerService {
                 .orElse(basePlan);
     }
 
+    @MeasuredOperation("ai_route.plan_from_text")
     public AiRoutePlanResponse planFromText(String subject, AiRouteTextPlanRequest request) {
         validateTextRequest(request);
         AiRoutePlanRequest resolvedRequest = textIntentResolver.resolve(request);

--- a/src/main/java/com/bikeprojectminji/bikeback/course/service/CourseQueryService.java
+++ b/src/main/java/com/bikeprojectminji/bikeback/course/service/CourseQueryService.java
@@ -20,6 +20,7 @@ import com.bikeprojectminji.bikeback.global.exception.BadRequestException;
 import com.bikeprojectminji.bikeback.global.exception.NotFoundException;
 import com.bikeprojectminji.bikeback.global.logging.RequestLogContext;
 import com.bikeprojectminji.bikeback.global.metrics.BikeMetricsRecorder;
+import com.bikeprojectminji.bikeback.global.metrics.MeasuredOperation;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.util.Comparator;
@@ -56,6 +57,7 @@ public class CourseQueryService {
         this.courseRouteSnapshotService = courseRouteSnapshotService;
     }
 
+    @MeasuredOperation("course.read.list")
     public CourseListResponse getCourses(Long cursor, Integer limit) {
         int pageSize = resolveLimit(limit);
         List<CourseListRow> queriedCourses = courseRepository.findPublicListPageAfter(cursor, pageSize + 1);
@@ -78,6 +80,7 @@ public class CourseQueryService {
         return new CourseListResponse(items, hasNext, nextCursor);
     }
 
+    @MeasuredOperation("course.read.detail")
     public CourseDetailResponse getCourseDetail(Long courseId, String subject, String shareToken) {
         CourseEntity course = findReadableCourse(courseId, subject, shareToken);
         return new CourseDetailResponse(
@@ -91,12 +94,14 @@ public class CourseQueryService {
         );
     }
 
+    @MeasuredOperation("course.read.route_points")
     public CourseRoutePointsResponse getCourseRoutePoints(Long courseId, String subject, String shareToken) {
         CourseEntity course = findReadableCourse(courseId, subject, shareToken);
         List<CourseRoutePointResponse> points = courseRouteSnapshotService.get(course.getId(), "route_points").responsePoints();
         return new CourseRoutePointsResponse(course.getId(), points);
     }
 
+    @MeasuredOperation("course.search.public")
     public CourseListResponse searchPublicCourses(String query, String sort) {
         validateSearchSort(sort);
         List<CourseEntity> courses = isBlank(query)
@@ -114,6 +119,7 @@ public class CourseQueryService {
         return new CourseListResponse(items, false, null);
     }
 
+    @MeasuredOperation("course.read.featured")
     public FeaturedCourseResponse getFeaturedCourses(BigDecimal lat, BigDecimal lon) {
         boolean distanceMode = lat != null && lon != null;
         if (distanceMode) {
@@ -152,6 +158,7 @@ public class CourseQueryService {
         return new FeaturedCourseResponse(distanceMode ? "distance" : "fallback", items);
     }
 
+    @MeasuredOperation("course.download")
     public CourseDownloadResponse downloadCourse(Long courseId, String subject, String shareToken) {
         CourseEntity course = findReadableCourse(courseId, subject, shareToken);
         List<CourseRoutePointResponse> routePoints = courseRouteSnapshotService.get(course.getId(), "course_download").responsePoints();

--- a/src/main/java/com/bikeprojectminji/bikeback/course/service/CourseRouteSnapshotService.java
+++ b/src/main/java/com/bikeprojectminji/bikeback/course/service/CourseRouteSnapshotService.java
@@ -4,6 +4,7 @@ import com.bikeprojectminji.bikeback.course.dto.CourseRoutePointResponse;
 import com.bikeprojectminji.bikeback.course.entity.CourseRoutePointEntity;
 import com.bikeprojectminji.bikeback.course.repository.CourseRoutePointRepository;
 import com.bikeprojectminji.bikeback.global.metrics.BikeMetricsRecorder;
+import com.bikeprojectminji.bikeback.global.metrics.MeasuredOperation;
 import com.bikeprojectminji.bikeback.ride.policy.service.RouteProjectionIndex;
 import java.time.Clock;
 import java.time.Duration;
@@ -37,6 +38,7 @@ public class CourseRouteSnapshotService {
         this.ttl = Duration.ofSeconds(ttlSec);
     }
 
+    @MeasuredOperation("course.route.snapshot")
     public CourseRouteSnapshot get(Long courseId, String consumer) {
         if (!enabled) {
             bikeMetricsRecorder.recordCourseRouteCacheBypass(consumer);

--- a/src/main/java/com/bikeprojectminji/bikeback/course/service/CourseService.java
+++ b/src/main/java/com/bikeprojectminji/bikeback/course/service/CourseService.java
@@ -21,6 +21,7 @@ import com.bikeprojectminji.bikeback.auth.entity.UserEntity;
 import com.bikeprojectminji.bikeback.global.exception.BadRequestException;
 import com.bikeprojectminji.bikeback.global.exception.ForbiddenException;
 import com.bikeprojectminji.bikeback.global.exception.NotFoundException;
+import com.bikeprojectminji.bikeback.global.metrics.MeasuredOperation;
 import com.bikeprojectminji.bikeback.global.validation.CoordinateValidator;
 import java.math.RoundingMode;
 import com.bikeprojectminji.bikeback.course.repository.CourseRepository;
@@ -73,6 +74,7 @@ public class CourseService {
         this.achievementCompletionDispatcher = achievementCompletionDispatcher;
     }
 
+    @MeasuredOperation("course.write.from_ride_record")
     public CourseWriteResponse createCourseFromRideRecord(String subject, CreateCourseFromRideRecordRequest request) {
         // 코스 생성은 사용자가 소유한 ride record를 읽어 route point를 course route point로 복제하는 방식이다.
         // 즉 ride 기록과 course는 source of truth를 공유하지 않고, 생성 시점에 복사본을 만든다.
@@ -128,6 +130,7 @@ public class CourseService {
         return toCourseWriteResponse(savedCourse);
     }
 
+    @MeasuredOperation("course.write.import_gpx")
     public CourseWriteResponse importGpxCourse(String subject, ImportGpxCourseRequest request) {
         validateImportGpxRequest(request);
         UserEntity user = authService.findUserBySubject(subject);
@@ -159,6 +162,7 @@ public class CourseService {
         return toCourseWriteResponse(savedCourse);
     }
 
+    @MeasuredOperation("course.write.update")
     public CourseWriteResponse updateCourse(String subject, Long courseId, UpdateCourseRequest request) {
         // 코스 수정은 metadata 수정과 route point 교체를 한 트랜잭션으로 처리해
         // 제목/설명/visibility와 경로 포인트가 어긋난 상태를 남기지 않게 한다.
@@ -183,6 +187,7 @@ public class CourseService {
         return toCourseWriteResponse(courseRepository.save(course));
     }
 
+    @MeasuredOperation("course.write.visibility")
     public CourseWriteResponse updateCourseVisibility(String subject, Long courseId, UpdateCourseVisibilityRequest request) {
         if (request == null || request.visibility() == null || request.visibility().isBlank()) {
             throw new BadRequestException("visibility는 비어 있을 수 없습니다.");
@@ -193,6 +198,7 @@ public class CourseService {
         return toCourseWriteResponse(courseRepository.save(course));
     }
 
+    @MeasuredOperation("course.share.info")
     public CourseShareResponse getCourseShareInfo(String subject, Long courseId) {
         // 공유 정보 조회는 PRIVATE 코스를 먼저 차단하고,
         // 공개 가능한 코스에 대해서만 shareToken을 생성 또는 재사용한다.

--- a/src/main/java/com/bikeprojectminji/bikeback/global/config/SecurityConfig.java
+++ b/src/main/java/com/bikeprojectminji/bikeback/global/config/SecurityConfig.java
@@ -39,12 +39,22 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 public class SecurityConfig {
 
     @Bean
-    public SecurityFilterChain securityFilterChain(HttpSecurity http, ObjectMapper objectMapper) throws Exception {
+    public SecurityFilterChain securityFilterChain(
+            HttpSecurity http,
+            ObjectMapper objectMapper,
+            @Value("${management.prometheus.public-scrape-enabled:false}") boolean prometheusPublicScrapeEnabled
+    ) throws Exception {
         http
                 .cors(Customizer.withDefaults())
                 .csrf(csrf -> csrf.disable())
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-                .authorizeHttpRequests(authorize -> authorize
+                .authorizeHttpRequests(authorize -> {
+                    if (prometheusPublicScrapeEnabled) {
+                        authorize.requestMatchers(HttpMethod.GET, "/actuator/prometheus").permitAll();
+                    } else {
+                        authorize.requestMatchers(HttpMethod.GET, "/actuator/prometheus").hasAuthority("ROLE_OPS");
+                    }
+                    authorize
                         .requestMatchers("/api/v1/auth/register").permitAll()
                         .requestMatchers("/api/v1/auth/login").permitAll()
                         .requestMatchers("/api/v1/auth/kakao/login").permitAll()
@@ -90,8 +100,8 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.POST, "/api/v1/courses/*/share").authenticated()
                         .requestMatchers(HttpMethod.PUT, "/api/v1/courses/*").authenticated()
                         .requestMatchers(HttpMethod.PATCH, "/api/v1/courses/*/visibility").authenticated()
-                        .anyRequest().authenticated()
-                )
+                        .anyRequest().authenticated();
+                })
                 .oauth2ResourceServer(oauth2 -> oauth2.jwt(jwt -> jwt.jwtAuthenticationConverter(this::accessTokenAuthentication)))
                 .exceptionHandling(exceptionHandling -> exceptionHandling
                         .authenticationEntryPoint((request, response, exception) -> {

--- a/src/main/java/com/bikeprojectminji/bikeback/global/metrics/BikeMetricsRecorder.java
+++ b/src/main/java/com/bikeprojectminji/bikeback/global/metrics/BikeMetricsRecorder.java
@@ -150,6 +150,14 @@ public class BikeMetricsRecorder {
         ).record(duration);
     }
 
+    public void recordOperationDuration(String operation, String outcome, Duration duration) {
+        meterRegistry.timer(
+                "bike_operation_duration",
+                "operation", normalize(operation),
+                "outcome", normalize(outcome)
+        ).record(duration);
+    }
+
     private String normalize(String value) {
         if (value == null || value.isBlank()) {
             return "unknown";

--- a/src/main/java/com/bikeprojectminji/bikeback/global/metrics/MeasuredOperation.java
+++ b/src/main/java/com/bikeprojectminji/bikeback/global/metrics/MeasuredOperation.java
@@ -1,0 +1,13 @@
+package com.bikeprojectminji.bikeback.global.metrics;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface MeasuredOperation {
+
+    String value();
+}

--- a/src/main/java/com/bikeprojectminji/bikeback/global/metrics/OperationMetricsAspect.java
+++ b/src/main/java/com/bikeprojectminji/bikeback/global/metrics/OperationMetricsAspect.java
@@ -1,0 +1,47 @@
+package com.bikeprojectminji.bikeback.global.metrics;
+
+import com.bikeprojectminji.bikeback.global.logging.RequestLogContext;
+import java.time.Duration;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+@Aspect
+@Component
+public class OperationMetricsAspect {
+
+    private static final Logger log = LoggerFactory.getLogger(OperationMetricsAspect.class);
+
+    private final BikeMetricsRecorder bikeMetricsRecorder;
+
+    public OperationMetricsAspect(BikeMetricsRecorder bikeMetricsRecorder) {
+        this.bikeMetricsRecorder = bikeMetricsRecorder;
+    }
+
+    @Around("@annotation(measuredOperation)")
+    public Object recordOperation(ProceedingJoinPoint joinPoint, MeasuredOperation measuredOperation) throws Throwable {
+        long startedAtNanos = System.nanoTime();
+        String outcome = "success";
+        try {
+            return joinPoint.proceed();
+        } catch (Throwable throwable) {
+            outcome = "failure";
+            throw throwable;
+        } finally {
+            Duration duration = Duration.ofNanos(System.nanoTime() - startedAtNanos);
+            String operation = measuredOperation.value();
+            bikeMetricsRecorder.recordOperationDuration(operation, outcome, duration);
+            log.info(
+                    "operation_duration request_id={} trace_id={} operation={} outcome={} duration_ms={}",
+                    RequestLogContext.currentRequestId(),
+                    RequestLogContext.currentTraceId(),
+                    operation,
+                    outcome,
+                    duration.toMillis()
+            );
+        }
+    }
+}

--- a/src/main/java/com/bikeprojectminji/bikeback/location/service/RecentLocationCacheService.java
+++ b/src/main/java/com/bikeprojectminji/bikeback/location/service/RecentLocationCacheService.java
@@ -7,6 +7,7 @@ import com.bikeprojectminji.bikeback.ride.entity.RideRecordFinalizationStatus;
 import com.bikeprojectminji.bikeback.ride.entity.RideRecordPointEntity;
 import com.bikeprojectminji.bikeback.ride.repository.RideRecordPointRepository;
 import com.bikeprojectminji.bikeback.ride.repository.RideRecordRepository;
+import com.bikeprojectminji.bikeback.global.metrics.MeasuredOperation;
 import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
@@ -42,6 +43,7 @@ public class RecentLocationCacheService {
         this.rideRecordPointRepository = rideRecordPointRepository;
     }
 
+    @MeasuredOperation("location.recent.find")
     public Optional<RecentLocationSnapshot> find(String subject) {
         // subject 기준 최근 위치는 현재 단계에서 1건만 유지하므로, 그대로 Optional로 조회한다.
         Optional<RecentLocationSnapshot> snapshot = recentLocationCacheStore.find(subject);
@@ -88,6 +90,7 @@ public class RecentLocationCacheService {
         return Optional.of(fallback);
     }
 
+    @MeasuredOperation("location.recent.save_completed")
     public void saveCompleted(
             String subject,
             Long rideRecordId,

--- a/src/main/java/com/bikeprojectminji/bikeback/party/service/RidePartyLocationService.java
+++ b/src/main/java/com/bikeprojectminji/bikeback/party/service/RidePartyLocationService.java
@@ -3,6 +3,7 @@ package com.bikeprojectminji.bikeback.party.service;
 import com.bikeprojectminji.bikeback.party.entity.RidePartyLocationPointEntity;
 import com.bikeprojectminji.bikeback.party.repository.RidePartyLocationPointRepository;
 import com.bikeprojectminji.bikeback.party.websocket.RidePartyLocationMessage;
+import com.bikeprojectminji.bikeback.global.metrics.MeasuredOperation;
 import java.time.Clock;
 import java.time.OffsetDateTime;
 import org.springframework.stereotype.Service;
@@ -19,6 +20,7 @@ public class RidePartyLocationService {
         this.clock = clock;
     }
 
+    @MeasuredOperation("party.location.save")
     @Transactional
     public void saveLocation(Long partyId, Long userId, RidePartyLocationMessage location) {
         locationPointRepository.save(RidePartyLocationPointEntity.create(
@@ -34,6 +36,7 @@ public class RidePartyLocationService {
         ));
     }
 
+    @MeasuredOperation("party.location.cleanup")
     @Transactional
     public int deleteExpiredLocationPoints() {
         return locationPointRepository.deleteByCreatedAtBefore(OffsetDateTime.now(clock).minusHours(24));

--- a/src/main/java/com/bikeprojectminji/bikeback/ride/policy/service/RidePolicyService.java
+++ b/src/main/java/com/bikeprojectminji/bikeback/ride/policy/service/RidePolicyService.java
@@ -11,6 +11,7 @@ import com.bikeprojectminji.bikeback.auth.service.AuthService;
 import com.bikeprojectminji.bikeback.global.exception.BadRequestException;
 import com.bikeprojectminji.bikeback.global.exception.NotFoundException;
 import com.bikeprojectminji.bikeback.global.metrics.BikeMetricsRecorder;
+import com.bikeprojectminji.bikeback.global.metrics.MeasuredOperation;
 import com.bikeprojectminji.bikeback.global.validation.CoordinateValidator;
 import com.bikeprojectminji.bikeback.ride.policy.dto.RideLocationRequest;
 import com.bikeprojectminji.bikeback.ride.policy.dto.RidePolicyCompletionResponse;
@@ -74,6 +75,7 @@ public class RidePolicyService {
         return evaluate(courseId, null, null, request);
     }
 
+    @MeasuredOperation("ride.policy.evaluate")
     public RidePolicyEvaluationResponse evaluate(Long courseId, String subject, String shareToken, RidePolicyEvaluationRequest request) {
         validateRequest(request);
 

--- a/src/main/java/com/bikeprojectminji/bikeback/ride/service/RideFinalizationJobService.java
+++ b/src/main/java/com/bikeprojectminji/bikeback/ride/service/RideFinalizationJobService.java
@@ -1,6 +1,7 @@
 package com.bikeprojectminji.bikeback.ride.service;
 
 import com.bikeprojectminji.bikeback.global.metrics.BikeMetricsRecorder;
+import com.bikeprojectminji.bikeback.global.metrics.MeasuredOperation;
 import com.bikeprojectminji.bikeback.ride.entity.RideFinalizationJobEntity;
 import com.bikeprojectminji.bikeback.ride.entity.RideFinalizationJobStatus;
 import com.bikeprojectminji.bikeback.ride.repository.RideFinalizationJobRepository;
@@ -43,6 +44,7 @@ public class RideFinalizationJobService {
         this.retryBaseDelay = Duration.ofSeconds(retryBaseDelaySec);
     }
 
+    @MeasuredOperation("ride.finalization.job.enqueue")
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void enqueue(Long rideRecordId) {
         OffsetDateTime now = OffsetDateTime.now(clock);
@@ -52,6 +54,7 @@ public class RideFinalizationJobService {
         rideFinalizationJobRepository.save(job);
     }
 
+    @MeasuredOperation("ride.finalization.job.acquire")
     @Transactional
     public Optional<RideFinalizationJobLease> acquireNext(String workerId) {
         OffsetDateTime now = OffsetDateTime.now(clock);
@@ -74,6 +77,7 @@ public class RideFinalizationJobService {
         return Optional.of(new RideFinalizationJobLease(job.getId(), job.getRideRecordId(), job.getAttemptCount()));
     }
 
+    @MeasuredOperation("ride.finalization.job.succeed")
     @Transactional
     public boolean markSucceeded(Long jobId, String workerId, int attemptCount, Duration duration) {
         RideFinalizationJobEntity job = rideFinalizationJobRepository.findById(jobId).orElseThrow();
@@ -86,6 +90,7 @@ public class RideFinalizationJobService {
         return true;
     }
 
+    @MeasuredOperation("ride.finalization.job.fail_or_retry")
     @Transactional
     public boolean markFailedOrRetry(
             Long jobId,

--- a/src/main/java/com/bikeprojectminji/bikeback/ride/service/RideRecordService.java
+++ b/src/main/java/com/bikeprojectminji/bikeback/ride/service/RideRecordService.java
@@ -6,6 +6,7 @@ import com.bikeprojectminji.bikeback.course.repository.CourseRepository;
 import com.bikeprojectminji.bikeback.global.exception.BadRequestException;
 import com.bikeprojectminji.bikeback.global.exception.ConflictException;
 import com.bikeprojectminji.bikeback.global.exception.NotFoundException;
+import com.bikeprojectminji.bikeback.global.metrics.MeasuredOperation;
 import com.bikeprojectminji.bikeback.location.service.RecentLocationCacheService;
 import com.bikeprojectminji.bikeback.ride.dto.CreateRideRecordRequest;
 import com.bikeprojectminji.bikeback.ride.dto.CreateRideRecordSummaryRequest;
@@ -59,6 +60,7 @@ public class RideRecordService {
         this.rideRecordFinalizationService = rideRecordFinalizationService;
     }
 
+    @MeasuredOperation("ride.record.save_full")
     @Transactional
     public RideRecordResponse saveRideRecord(String subject, CreateRideRecordRequest request) {
         // 자유 주행 저장은 입력 검증 -> 현재 사용자 식별 -> ride record 저장 -> route point 저장 순서로 진행한다.
@@ -104,6 +106,7 @@ public class RideRecordService {
         return new RideRecordResponse(rideRecordId, user.getId(), routePoints.size(), rideRecord.getFinalizationStatus().name());
     }
 
+    @MeasuredOperation("ride.record.save_summary")
     @Transactional
     public RideRecordResponse saveRideRecordSummary(String subject, CreateRideRecordSummaryRequest request) {
         // 웹 HUD 기본 저장은 요약만 남긴다. trace가 없으면 후처리 대상 raw point가 없어 finalization을 시작하지 않는다.
@@ -136,6 +139,7 @@ public class RideRecordService {
         return new RideRecordResponse(rideRecord.getId(), user.getId(), 0, rideRecord.getFinalizationStatus().name());
     }
 
+    @MeasuredOperation("ride.record.trace_save")
     @Transactional
     public RideRecordResponse saveRideRecordTrace(String subject, Long rideRecordId, RideRecordTraceRequest request) {
         if (request == null) {
@@ -159,6 +163,7 @@ public class RideRecordService {
         return new RideRecordResponse(rideRecordId, user.getId(), routePoints.size(), rideRecord.getFinalizationStatus().name());
     }
 
+    @MeasuredOperation("ride.record.list")
     @Transactional(readOnly = true)
     public RideRecordListResponse listRideRecords(String subject) {
         UserEntity user = authService.findUserBySubject(subject);
@@ -178,6 +183,7 @@ public class RideRecordService {
                 .toList());
     }
 
+    @MeasuredOperation("ride.record.status")
     @Transactional(readOnly = true)
     public RideRecordFinalizationStatusResponse getRideRecordStatus(String subject, Long rideRecordId) {
         UserEntity user = authService.findUserBySubject(subject);
@@ -200,6 +206,7 @@ public class RideRecordService {
         );
     }
 
+    @MeasuredOperation("ride.record.regenerate")
     @Transactional
     public RideRecordFinalizationStatusResponse regenerateRideRecord(String subject, Long rideRecordId) {
         UserEntity user = authService.findUserBySubject(subject);

--- a/src/main/java/com/bikeprojectminji/bikeback/routing/service/BicycleRoutingService.java
+++ b/src/main/java/com/bikeprojectminji/bikeback/routing/service/BicycleRoutingService.java
@@ -1,6 +1,7 @@
 package com.bikeprojectminji.bikeback.routing.service;
 
 import com.bikeprojectminji.bikeback.global.exception.BadRequestException;
+import com.bikeprojectminji.bikeback.global.metrics.MeasuredOperation;
 import java.math.BigDecimal;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -22,6 +23,7 @@ public class BicycleRoutingService {
         this.qualityValidator = qualityValidator;
     }
 
+    @MeasuredOperation("routing.bicycle.route")
     public BicycleRoutePlan route(BicycleRouteRequest request) {
         validate(request);
         for (int index = 0; index < routingClients.size(); index++) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -43,6 +43,7 @@ management:
       exposure:
         include: health,prometheus
   prometheus:
+    public-scrape-enabled: ${MANAGEMENT_PROMETHEUS_PUBLIC_SCRAPE_ENABLED:false}
     metrics:
       export:
         enabled: true

--- a/src/test/java/com/bikeprojectminji/bikeback/global/health/ActuatorPrometheusPublicScrapeIntegrationTest.java
+++ b/src/test/java/com/bikeprojectminji/bikeback/global/health/ActuatorPrometheusPublicScrapeIntegrationTest.java
@@ -1,0 +1,40 @@
+package com.bikeprojectminji.bikeback.global.health;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.test.web.server.LocalManagementPort;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, properties = {
+        "management.server.port=0",
+        "management.endpoints.web.exposure.include=health,prometheus",
+        "management.prometheus.public-scrape-enabled=true"
+})
+@ActiveProfiles("test")
+class ActuatorPrometheusPublicScrapeIntegrationTest {
+
+    @LocalManagementPort
+    private int managementPort;
+
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+    @Test
+    @DisplayName("private scrape 모드에서는 management port의 Prometheus endpoint를 인증 없이 조회할 수 있다")
+    void prometheusEndpointOnManagementPortAllowsPrivateScrapeWhenEnabled() {
+        ResponseEntity<String> response = restTemplate.getForEntity(
+                "http://localhost:" + managementPort + "/actuator/prometheus",
+                String.class
+        );
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).contains("jvm_info");
+    }
+}

--- a/src/test/java/com/bikeprojectminji/bikeback/global/metrics/BikeMetricsRecorderTest.java
+++ b/src/test/java/com/bikeprojectminji/bikeback/global/metrics/BikeMetricsRecorderTest.java
@@ -39,6 +39,7 @@ class BikeMetricsRecorderTest {
         recorder.recordCourseRouteCacheEviction("route_points_updated");
         recorder.recordRoutingProviderFailure("GraphHopper", "http_429");
         recorder.recordProviderCall("GraphHopper", "route", "success", java.time.Duration.ofMillis(35));
+        recorder.recordOperationDuration("ride.policy.evaluate", "success", java.time.Duration.ofMillis(42));
 
         assertThat(meterRegistry.get("bike_weather_fallback_total").counter().count()).isEqualTo(1.0);
         assertThat(meterRegistry.get("bike_weather_stale_served_total").counter().count()).isEqualTo(1.0);
@@ -93,6 +94,11 @@ class BikeMetricsRecorderTest {
         assertThat(meterRegistry.get("bike_provider_latency")
                 .tag("provider", "graphhopper")
                 .tag("operation", "route")
+                .tag("outcome", "success")
+                .timer()
+                .count()).isEqualTo(1);
+        assertThat(meterRegistry.get("bike_operation_duration")
+                .tag("operation", "ride.policy.evaluate")
                 .tag("outcome", "success")
                 .timer()
                 .count()).isEqualTo(1);

--- a/src/test/java/com/bikeprojectminji/bikeback/global/metrics/OperationMetricsAspectTest.java
+++ b/src/test/java/com/bikeprojectminji/bikeback/global/metrics/OperationMetricsAspectTest.java
@@ -1,0 +1,68 @@
+package com.bikeprojectminji.bikeback.global.metrics;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.lang.reflect.Method;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class OperationMetricsAspectTest {
+
+    @Test
+    @DisplayName("성공한 내부 operation은 success outcome timer로 기록된다")
+    void recordOperationRecordsSuccessDuration() throws Throwable {
+        SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
+        OperationMetricsAspect aspect = new OperationMetricsAspect(new BikeMetricsRecorder(meterRegistry));
+        ProceedingJoinPoint joinPoint = mock(ProceedingJoinPoint.class);
+        given(joinPoint.proceed()).willReturn("ok");
+
+        Object result = aspect.recordOperation(joinPoint, measuredOperation("successOperation"));
+
+        assertThat(result).isEqualTo("ok");
+        assertThat(meterRegistry.get("bike_operation_duration")
+                .tag("operation", "test.operation")
+                .tag("outcome", "success")
+                .timer()
+                .count()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("실패한 내부 operation은 예외를 보존하고 failure outcome timer로 기록된다")
+    void recordOperationRecordsFailureDuration() throws Throwable {
+        SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
+        OperationMetricsAspect aspect = new OperationMetricsAspect(new BikeMetricsRecorder(meterRegistry));
+        ProceedingJoinPoint joinPoint = mock(ProceedingJoinPoint.class);
+        IllegalStateException failure = new IllegalStateException("boom");
+        given(joinPoint.proceed()).willThrow(failure);
+
+        assertThatThrownBy(() -> aspect.recordOperation(joinPoint, measuredOperation("failureOperation")))
+                .isSameAs(failure);
+
+        assertThat(meterRegistry.get("bike_operation_duration")
+                .tag("operation", "test.operation")
+                .tag("outcome", "failure")
+                .timer()
+                .count()).isEqualTo(1);
+    }
+
+    private MeasuredOperation measuredOperation(String methodName) throws NoSuchMethodException {
+        Method method = TestOperations.class.getDeclaredMethod(methodName);
+        return method.getAnnotation(MeasuredOperation.class);
+    }
+
+    private static class TestOperations {
+
+        @MeasuredOperation("test.operation")
+        private void successOperation() {
+        }
+
+        @MeasuredOperation("test.operation")
+        private void failureOperation() {
+        }
+    }
+}

--- a/src/test/java/com/bikeprojectminji/bikeback/global/metrics/PrometheusMetricsIntegrationTest.java
+++ b/src/test/java/com/bikeprojectminji/bikeback/global/metrics/PrometheusMetricsIntegrationTest.java
@@ -28,6 +28,7 @@ class PrometheusMetricsIntegrationTest {
         bikeMetricsRecorder.recordCourseRouteCacheHit("ride_policy");
         bikeMetricsRecorder.recordCourseRouteSnapshotLoad("ride_policy");
         bikeMetricsRecorder.recordProviderCall("GraphHopper", "route", "success", java.time.Duration.ofMillis(35));
+        bikeMetricsRecorder.recordOperationDuration("ride.policy.evaluate", "success", java.time.Duration.ofMillis(42));
 
         String scrape = prometheusMeterRegistry.scrape();
 
@@ -45,5 +46,6 @@ class PrometheusMetricsIntegrationTest {
         assertThat(scrape).contains("bike_course_route_snapshot_load_total");
         assertThat(scrape).contains("bike_provider_call_total");
         assertThat(scrape).contains("bike_provider_latency");
+        assertThat(scrape).contains("bike_operation_duration");
     }
 }


### PR DESCRIPTION
## Summary
- Add measured internal operation timing via @MeasuredOperation + AOP and publish bike_operation_duration metrics.
- Annotate core course, ride, routing, AI route, provider, finalization, party, and location operations with low-cardinality operation names.
- Allow private Prometheus scrape on the management port with an explicit env flag and update EC2 observability validation.

## Validation
- Local targeted tests: ./gradlew --no-daemon test --tests '*BikeMetricsRecorderTest' --tests '*PrometheusMetricsIntegrationTest' --tests '*OperationMetricsAspectTest' --tests '*ActuatorPrometheusSecurityIntegrationTest' --tests '*ActuatorPrometheusPublicScrapeIntegrationTest' --console=plain
- Local full tests: ./gradlew --no-daemon test --console=plain
- Local package: ./gradlew --no-daemon bootJar --console=plain
- AWS deploy: app health returned 200 after jar deploy to i-0e5bce97db12b2300.
- ALB health: https://api.gajabike.shop/health returned 200 with x-request-id and x-trace-id headers.
- k6 smoke: ops/loadtest/results/aws-alb-observability-20260627-005844-summary.json, 21 requests, 40/40 checks, http_req_failed rate 0, overall p95 178.217844 ms, course-read p95 173.00500065 ms, ride-policy p95 161.38650009999995 ms.
- Prometheus scrape: private http://127.0.0.1:18081/actuator/prometheus returned 200 and exposed http_server_requests_seconds_count plus bike_operation_duration_seconds_count.
- Request/trace evidence: k6 request_id aws-alb-observability-20260627-005844-vu3-iter0-4fc6b0a2 matched operation_duration logs for course.route.snapshot and course.read.list.

## Review Personas
- Backend architecture/domain reviewer: check operation boundary, annotation placement, cardinality, AOP failure behavior.
- QA/security/operations reviewer: check private scrape exposure, request/trace evidence, k6 and Prometheus reproducibility.

## Risks
- operation_duration logs are INFO-level and may need sampling or threshold logging before higher traffic.
- Prometheus public scrape flag must only be used when the management port is private to the VPC/security group.
- This is not full distributed tracing; it is request_id/trace_id connected operation timing for first production-readiness diagnostics.