### PR TITLE
fix: keep Flyway V16 immutable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,7 @@ ops/aws/alb-acm-route53/terraform.tfvars.discovered
 
 # Local verification artifacts
 smoke-check-file-summary.json
+ops/smoke/results/
 
 # Load test generated artifacts
 ops/loadtest/results/

--- a/src/main/resources/db/migration/V16__release_defect_fix_constraints.sql
+++ b/src/main/resources/db/migration/V16__release_defect_fix_constraints.sql
@@ -14,24 +14,6 @@ CREATE UNIQUE INDEX IF NOT EXISTS uq_ride_record_processed_points_record_order
 CREATE UNIQUE INDEX IF NOT EXISTS uq_course_route_points_course_order
     ON course_route_points (course_id, point_order);
 
-WITH duplicate_source_courses AS (
-    SELECT id,
-           ROW_NUMBER() OVER (
-               PARTITION BY owner_user_id, source_ride_record_id
-               ORDER BY id
-           ) AS duplicate_rank
-    FROM courses
-    WHERE owner_user_id IS NOT NULL
-      AND source_ride_record_id IS NOT NULL
-)
-UPDATE courses
-SET source_ride_record_id = NULL
-WHERE id IN (
-    SELECT id
-    FROM duplicate_source_courses
-    WHERE duplicate_rank > 1
-);
-
 CREATE UNIQUE INDEX IF NOT EXISTS uq_courses_owner_source_ride_record
     ON courses (owner_user_id, source_ride_record_id)
     WHERE source_ride_record_id IS NOT NULL;

--- a/src/main/resources/db/migration/V35__detach_duplicate_source_courses_after_v16.sql
+++ b/src/main/resources/db/migration/V35__detach_duplicate_source_courses_after_v16.sql
@@ -1,0 +1,17 @@
+WITH duplicate_source_courses AS (
+    SELECT id,
+           ROW_NUMBER() OVER (
+               PARTITION BY owner_user_id, source_ride_record_id
+               ORDER BY id
+           ) AS duplicate_rank
+    FROM courses
+    WHERE owner_user_id IS NOT NULL
+      AND source_ride_record_id IS NOT NULL
+)
+UPDATE courses
+SET source_ride_record_id = NULL
+WHERE id IN (
+    SELECT id
+    FROM duplicate_source_courses
+    WHERE duplicate_rank > 1
+);


### PR DESCRIPTION
## Summary
- Restore `V16__release_defect_fix_constraints.sql` to the already-applied immutable contents.
- Move duplicate `source_ride_record_id` cleanup into new `V35__detach_duplicate_source_courses_after_v16.sql`.
- Ignore generated smoke evidence under `ops/smoke/results/`.

## Verification
- Existing local DB boot: `./gradlew --no-daemon bootRun` validated 35 migrations, applied V35, and `/health` returned 200 with request/trace headers.
- Fresh temporary DB boot: `./gradlew --no-daemon bootRun` applied migrations 1..35 and `/health` returned 200.
- `./gradlew --no-daemon compileTestJava` passed.
- Targeted health/actuator tests passed: `./gradlew --no-daemon test --tests com.bikeprojectminji.bikeback.global.health.HealthControllerTest --tests com.bikeprojectminji.bikeback.global.health.ActuatorPrometheusSecurityIntegrationTest --stacktrace`.

## Known Risk
- Full `./gradlew --no-daemon test --stacktrace` did not complete within 300s in this environment; no failing assertion was captured.

## Review Personas
- Backend architecture/domain reviewer: verify Flyway immutability and migration ordering.
- QA/security/operations reviewer: verify existing DB and fresh DB boot evidence, and ensure no smoke artifacts are committed.