### PR TITLE
feat: expose provider fallback observability

### DIFF
--- a/src/main/java/com/bikeprojectminji/bikeback/address/dto/AddressSearchResponse.java
+++ b/src/main/java/com/bikeprojectminji/bikeback/address/dto/AddressSearchResponse.java
@@ -8,7 +8,22 @@ public record AddressSearchResponse(
         int size,
         int totalCount,
         String provider,
+        String primaryProvider,
+        boolean fallbackUsed,
+        String fallbackReason,
         String message,
         List<AddressCandidateResponse> candidates
 ) {
+
+    public AddressSearchResponse(
+            String status,
+            int page,
+            int size,
+            int totalCount,
+            String provider,
+            String message,
+            List<AddressCandidateResponse> candidates
+    ) {
+        this(status, page, size, totalCount, provider, provider, false, null, message, candidates);
+    }
 }

--- a/src/main/java/com/bikeprojectminji/bikeback/address/service/AddressSearchService.java
+++ b/src/main/java/com/bikeprojectminji/bikeback/address/service/AddressSearchService.java
@@ -9,10 +9,14 @@ import io.micrometer.core.instrument.Metrics;
 import java.time.Duration;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
 @Service
 public class AddressSearchService {
+
+    private static final Logger log = LoggerFactory.getLogger(AddressSearchService.class);
 
     private static final int DEFAULT_PAGE = 1;
     private static final int DEFAULT_SIZE = 5;
@@ -35,15 +39,19 @@ public class AddressSearchService {
     @MeasuredOperation("address.search")
     public AddressSearchResponse search(String rawQuery, Integer page, Integer size) {
         AddressSearchQuery query = normalizeQuery(rawQuery, page, size);
-        AddressSearchProviderResult providerResult = searchWithFallback(query);
-        return toResponse(query, providerResult);
+        AddressSearchOutcome outcome = searchWithFallback(query);
+        return toResponse(query, outcome);
     }
 
-    private AddressSearchProviderResult searchWithFallback(AddressSearchQuery query) {
+    private AddressSearchOutcome searchWithFallback(AddressSearchQuery query) {
+        AddressSearchProviderResult firstResult = null;
         AddressSearchProviderResult lastResult = null;
         for (AddressSearchClient client : addressSearchClients) {
             long startedAtNanos = System.nanoTime();
             AddressSearchProviderResult result = client.search(query);
+            if (firstResult == null) {
+                firstResult = result;
+            }
             bikeMetricsRecorder.recordProviderCall(
                     result.provider(),
                     "address_search",
@@ -51,14 +59,18 @@ public class AddressSearchService {
                     Duration.ofNanos(System.nanoTime() - startedAtNanos)
             );
             if (result.status() == AddressSearchProviderStatus.SUCCESS) {
-                return result;
+                AddressSearchOutcome outcome = AddressSearchOutcome.from(firstResult, result);
+                logFallbackIfNeeded(outcome);
+                return outcome;
             }
             lastResult = result;
         }
         if (lastResult != null) {
-            return lastResult;
+            AddressSearchOutcome outcome = AddressSearchOutcome.from(firstResult, lastResult);
+            logFallbackIfNeeded(outcome);
+            return outcome;
         }
-        return AddressSearchProviderResult.providerFailure("NONE");
+        return AddressSearchOutcome.from(null, AddressSearchProviderResult.providerFailure("NONE"));
     }
 
     private AddressSearchQuery normalizeQuery(String rawQuery, Integer page, Integer size) {
@@ -80,7 +92,8 @@ public class AddressSearchService {
         return new AddressSearchQuery(normalizedQuery, normalizedPage, normalizedSize);
     }
 
-    private AddressSearchResponse toResponse(AddressSearchQuery query, AddressSearchProviderResult providerResult) {
+    private AddressSearchResponse toResponse(AddressSearchQuery query, AddressSearchOutcome outcome) {
+        AddressSearchProviderResult providerResult = outcome.result();
         List<AddressCandidateResponse> candidates = providerResult.candidates().stream()
                 .limit(query.size())
                 .map(AddressCandidate::toResponse)
@@ -92,6 +105,9 @@ public class AddressSearchService {
                 query.size(),
                 candidates.size(),
                 providerResult.provider(),
+                outcome.primaryProvider(),
+                outcome.fallbackUsed(),
+                outcome.fallbackReason(),
                 messageFor(status),
                 candidates
         );
@@ -122,5 +138,38 @@ public class AddressSearchService {
             case "PROVIDER_FAILURE" -> "주소 검색 provider를 사용할 수 없습니다.";
             default -> "주소 검색 상태를 확인하세요.";
         };
+    }
+
+    private void logFallbackIfNeeded(AddressSearchOutcome outcome) {
+        if (!outcome.fallbackUsed()) {
+            return;
+        }
+        log.warn(
+                "address_search_provider_fallback primary_provider={} fallback_provider={} fallback_reason={}",
+                outcome.primaryProvider(),
+                outcome.result().provider(),
+                outcome.fallbackReason()
+        );
+    }
+
+    private record AddressSearchOutcome(
+            AddressSearchProviderResult result,
+            String primaryProvider,
+            boolean fallbackUsed,
+            String fallbackReason
+    ) {
+
+        private static AddressSearchOutcome from(
+                AddressSearchProviderResult firstResult,
+                AddressSearchProviderResult result
+        ) {
+            String primaryProvider = firstResult == null ? result.provider() : firstResult.provider();
+            boolean fallbackUsed = firstResult != null
+                    && !firstResult.provider().equals(result.provider());
+            String fallbackReason = fallbackUsed
+                    ? firstResult.provider() + "_" + firstResult.status().name()
+                    : null;
+            return new AddressSearchOutcome(result, primaryProvider, fallbackUsed, fallbackReason);
+        }
     }
 }

--- a/src/main/java/com/bikeprojectminji/bikeback/airoute/dto/AiRoutePlanResponse.java
+++ b/src/main/java/com/bikeprojectminji/bikeback/airoute/dto/AiRoutePlanResponse.java
@@ -20,7 +20,8 @@ public record AiRoutePlanResponse(
         List<ProviderEvidenceBadgeResponse> evidenceBadges,
         boolean aiGenerated,
         AiRouteElevationSummaryResponse elevationSummary,
-        AiRouteRoutingMetadataResponse routingMetadata
+        AiRouteRoutingMetadataResponse routingMetadata,
+        AiRouteWorkerMetadataResponse aiWorkerMetadata
 ) {
 
     public AiRoutePlanResponse(
@@ -54,6 +55,7 @@ public record AiRoutePlanResponse(
                 explanation,
                 evidenceBadges,
                 aiGenerated,
+                null,
                 null,
                 null
         );
@@ -92,7 +94,69 @@ public record AiRoutePlanResponse(
                 evidenceBadges,
                 aiGenerated,
                 elevationSummary,
+                null,
                 null
+        );
+    }
+
+    public AiRoutePlanResponse(
+            String planId,
+            String status,
+            String summary,
+            String confidence,
+            WeatherData weather,
+            WindData wind,
+            List<AiRoutePointResponse> routePoints,
+            List<AiRouteRiskResponse> risks,
+            List<String> actions,
+            int recommendationScore,
+            RecommendationScoreResponse scoreBreakdown,
+            RecommendationExplanationResponse explanation,
+            List<ProviderEvidenceBadgeResponse> evidenceBadges,
+            boolean aiGenerated,
+            AiRouteElevationSummaryResponse elevationSummary,
+            AiRouteRoutingMetadataResponse routingMetadata
+    ) {
+        this(
+                planId,
+                status,
+                summary,
+                confidence,
+                weather,
+                wind,
+                routePoints,
+                risks,
+                actions,
+                recommendationScore,
+                scoreBreakdown,
+                explanation,
+                evidenceBadges,
+                aiGenerated,
+                elevationSummary,
+                routingMetadata,
+                null
+        );
+    }
+
+    public AiRoutePlanResponse withAiWorkerMetadata(AiRouteWorkerMetadataResponse metadata) {
+        return new AiRoutePlanResponse(
+                planId,
+                status,
+                summary,
+                confidence,
+                weather,
+                wind,
+                routePoints,
+                risks,
+                actions,
+                recommendationScore,
+                scoreBreakdown,
+                explanation,
+                evidenceBadges,
+                aiGenerated,
+                elevationSummary,
+                routingMetadata,
+                metadata
         );
     }
 }

--- a/src/main/java/com/bikeprojectminji/bikeback/airoute/dto/AiRouteWorkerMetadataResponse.java
+++ b/src/main/java/com/bikeprojectminji/bikeback/airoute/dto/AiRouteWorkerMetadataResponse.java
@@ -1,0 +1,8 @@
+package com.bikeprojectminji.bikeback.airoute.dto;
+
+public record AiRouteWorkerMetadataResponse(
+        String provider,
+        boolean fallbackUsed,
+        String fallbackReason
+) {
+}

--- a/src/main/java/com/bikeprojectminji/bikeback/airoute/service/AiRoutePlannerService.java
+++ b/src/main/java/com/bikeprojectminji/bikeback/airoute/service/AiRoutePlannerService.java
@@ -3,6 +3,7 @@ package com.bikeprojectminji.bikeback.airoute.service;
 import com.bikeprojectminji.bikeback.airoute.dto.AiRoutePlanRequest;
 import com.bikeprojectminji.bikeback.airoute.dto.AiRoutePlanResponse;
 import com.bikeprojectminji.bikeback.airoute.dto.AiRouteTextPlanRequest;
+import com.bikeprojectminji.bikeback.airoute.dto.AiRouteWorkerMetadataResponse;
 import com.bikeprojectminji.bikeback.global.exception.BadRequestException;
 import com.bikeprojectminji.bikeback.global.metrics.MeasuredOperation;
 import com.bikeprojectminji.bikeback.routing.service.BicycleRoutePlan;
@@ -58,7 +59,8 @@ public class AiRoutePlannerService {
         AiRoutePlanResponse basePlan = composeRouteCandidatePlan(resolvedRequest, context)
                 .orElseGet(() -> aiRoutePlanComposer.composeFallback(resolvedRequest, context));
         return aiRouteWorkerClient.plan(resolvedRequest, context, basePlan)
-                .orElse(basePlan);
+                .map(this::withWorkerSuccessMetadata)
+                .orElseGet(() -> withWorkerFallbackMetadata(basePlan));
     }
 
     @MeasuredOperation("ai_route.plan_from_text")
@@ -132,6 +134,22 @@ public class AiRoutePlannerService {
                 context,
                 routePlan.candidates().get(0),
                 routePlan
+        ));
+    }
+
+    private AiRoutePlanResponse withWorkerSuccessMetadata(AiRoutePlanResponse plan) {
+        return plan.withAiWorkerMetadata(new AiRouteWorkerMetadataResponse(
+                aiRouteWorkerClient.provider(),
+                false,
+                null
+        ));
+    }
+
+    private AiRoutePlanResponse withWorkerFallbackMetadata(AiRoutePlanResponse plan) {
+        return plan.withAiWorkerMetadata(new AiRouteWorkerMetadataResponse(
+                aiRouteWorkerClient.provider(),
+                true,
+                aiRouteWorkerClient.fallbackReasonWhenEmpty()
         ));
     }
 

--- a/src/main/java/com/bikeprojectminji/bikeback/airoute/service/AiRouteWorkerClient.java
+++ b/src/main/java/com/bikeprojectminji/bikeback/airoute/service/AiRouteWorkerClient.java
@@ -6,6 +6,14 @@ import java.util.Optional;
 
 public interface AiRouteWorkerClient {
 
+    default String provider() {
+        return "AI_ROUTE_WORKER";
+    }
+
+    default String fallbackReasonWhenEmpty() {
+        return "AI_WORKER_UNAVAILABLE";
+    }
+
     Optional<AiRoutePlanResponse> plan(
             AiRoutePlanRequest request,
             AiRouteConditionContext context,

--- a/src/main/java/com/bikeprojectminji/bikeback/airoute/service/DisabledAiRouteWorkerClient.java
+++ b/src/main/java/com/bikeprojectminji/bikeback/airoute/service/DisabledAiRouteWorkerClient.java
@@ -9,6 +9,11 @@ import org.springframework.stereotype.Component;
 public class DisabledAiRouteWorkerClient implements AiRouteWorkerClient {
 
     @Override
+    public String provider() {
+        return "DISABLED_AI_ROUTE_WORKER";
+    }
+
+    @Override
     public Optional<AiRoutePlanResponse> plan(
             AiRoutePlanRequest request,
             AiRouteConditionContext context,

--- a/src/main/java/com/bikeprojectminji/bikeback/airoute/service/HttpAiRouteWorkerClient.java
+++ b/src/main/java/com/bikeprojectminji/bikeback/airoute/service/HttpAiRouteWorkerClient.java
@@ -54,6 +54,11 @@ public class HttpAiRouteWorkerClient implements AiRouteWorkerClient {
     }
 
     @Override
+    public String provider() {
+        return "HTTP_AI_ROUTE_WORKER";
+    }
+
+    @Override
     public Optional<AiRoutePlanResponse> plan(
             AiRoutePlanRequest request,
             AiRouteConditionContext context,

--- a/src/test/java/com/bikeprojectminji/bikeback/address/controller/AddressSearchControllerTest.java
+++ b/src/test/java/com/bikeprojectminji/bikeback/address/controller/AddressSearchControllerTest.java
@@ -50,6 +50,9 @@ class AddressSearchControllerTest {
                         3,
                         2,
                         "FAKE",
+                        "FAKE",
+                        false,
+                        null,
                         "주소 후보가 여러 개입니다.",
                         List.of(
                                 new AddressCandidateResponse(
@@ -76,6 +79,9 @@ class AddressSearchControllerTest {
                 .andExpect(jsonPath("$.data.size").value(3))
                 .andExpect(jsonPath("$.data.totalCount").value(2))
                 .andExpect(jsonPath("$.data.provider").value("FAKE"))
+                .andExpect(jsonPath("$.data.primaryProvider").value("FAKE"))
+                .andExpect(jsonPath("$.data.fallbackUsed").value(false))
+                .andExpect(jsonPath("$.data.fallbackReason").doesNotExist())
                 .andExpect(jsonPath("$.data.candidates[0].label").value("북악스카이웨이 팔각정"))
                 .andExpect(jsonPath("$.data.candidates[0].lat").value(37.6026))
                 .andExpect(jsonPath("$.data.candidates[0].lon").value(126.9803))

--- a/src/test/java/com/bikeprojectminji/bikeback/address/service/AddressSearchServiceIntegrationTest.java
+++ b/src/test/java/com/bikeprojectminji/bikeback/address/service/AddressSearchServiceIntegrationTest.java
@@ -99,6 +99,9 @@ class AddressSearchServiceIntegrationTest {
 
         assertThat(response.status()).isEqualTo("SUCCESS");
         assertThat(response.provider()).isEqualTo("NOMINATIM");
+        assertThat(response.primaryProvider()).isEqualTo("KAKAO_LOCAL");
+        assertThat(response.fallbackUsed()).isTrue();
+        assertThat(response.fallbackReason()).isEqualTo("KAKAO_LOCAL_PROVIDER_FAILURE");
         assertThat(response.candidates()).hasSize(1);
     }
 

--- a/src/test/java/com/bikeprojectminji/bikeback/airoute/service/AiRoutePlannerServiceIntegrationTest.java
+++ b/src/test/java/com/bikeprojectminji/bikeback/airoute/service/AiRoutePlannerServiceIntegrationTest.java
@@ -77,6 +77,8 @@ class AiRoutePlannerServiceIntegrationTest {
         assertThat(routingClient.lastRequest().destinationLon()).isEqualByComparingTo("126.9667");
         assertThat(response.routePoints()).hasSize(2);
         assertThat(response.summary()).contains("현재 위치 기반 추천 코스");
+        assertThat(response.aiWorkerMetadata().fallbackUsed()).isTrue();
+        assertThat(response.aiWorkerMetadata().fallbackReason()).isEqualTo("AI_WORKER_UNAVAILABLE");
     }
 
     @Test


### PR DESCRIPTION
## Summary
- expose address search provider fallback metadata: provider, primaryProvider, fallbackUsed, fallbackReason
- expose AI route worker metadata: provider, fallbackUsed, fallbackReason
- log address provider fallback events so Kakao -> fallback routing can be explained from logs and response evidence

## Verification
- ./gradlew --no-daemon test --tests com.bikeprojectminji.bikeback.address.service.AddressSearchServiceIntegrationTest --tests com.bikeprojectminji.bikeback.address.controller.AddressSearchControllerTest --tests com.bikeprojectminji.bikeback.airoute.service.AiRoutePlannerServiceIntegrationTest
- Runtime evidence: ops/smoke/results/provider_observability_20260627_083720.json

## Evidence
- Address Kakao override fallback response: primaryProvider=KAKAO_LOCAL, provider=NOMINATIM, fallbackUsed=true, fallbackReason=KAKAO_LOCAL_PROVIDER_FAILURE
- AI route worker disabled response: provider=DISABLED_AI_ROUTE_WORKER, fallbackUsed=true, fallbackReason=AI_WORKER_UNAVAILABLE
- GraphHopper routing response: provider=GRAPHHOPPER, fallbackUsed=false

## Reviewers
- Backend architecture/domain: confirm API metadata shape and backward-compatible constructors
- QA/security/operations: confirm fallback evidence is enough for AWS provider failure drills

## Note
- This is stacked on #61 / fix/flyway-v16-immutable-v35 because local DB boot depends on the immutable Flyway repair.