### PR TITLE
test: add concurrency consistency smoke runner

### DIFF
--- a/docs/검토/동시성_정합성_검증_보고_2026-06-27.md
+++ b/docs/검토/동시성_정합성_검증_보고_2026-06-27.md
@@ -1,0 +1,133 @@
+# 동시성 정합성 검증 보고 - 2026-06-27
+
+## 요약
+
+낮은 부하에서 같은 요청을 10개씩 동시에 보내 데이터 중복, job 중복, 파티 멤버 중복, WebSocket socket token 재사용을 확인했다.
+
+데이터베이스 unique 제약과 row lock 덕분에 중복 데이터는 막혔다. 다만 일부 API는 중복 요청이 들어왔을 때 사용자에게 400/409/503 같은 계약된 응답을 주지 못하고 500을 반환했다. 운영 관점에서는 데이터는 지켰지만 사용자 경험과 장애 알림 품질은 아직 부족하다.
+
+## 실행 환경
+
+- Backend: local `bootRun`
+- DB: `bike-back-postgres`
+- Redis: `bike-back-redis`
+- GraphHopper: `bike-back-graphhopper`
+- Evidence: `ops/smoke/results/concurrency_consistency_20260627_175130.json`
+- Runner: `ops/smoke/concurrency_consistency.py`
+
+## 시나리오 결과
+
+| 시나리오 | 결과 | 데이터 정합성 | 사용자/API 응답 |
+|---|---:|---:|---:|
+| 같은 `clientRideId` 주행 저장 10회 동시 요청 | 실패 | 통과 | 실패 |
+| 같은 ride record finalization regenerate 10회 동시 요청 | 통과 | 통과 | 통과 |
+| 같은 자유주행 기록으로 코스 생성 10회 동시 요청 | 실패 | 통과 | 실패 |
+| 같은 멤버의 party join/leave 10회 동시 요청 | 통과 | 통과 | 통과 |
+| Party WebSocket socket token 연결 | 실패 | 미확인 | 실패 |
+
+## 발견한 문제
+
+### 1. 자유주행 저장 idempotency 응답 실패
+
+같은 `ownerUserId + clientRideId`로 10회 동시 저장을 보냈을 때 DB에는 `ride_records` 1건과 `ride_finalization_jobs` 1건만 남았다. 데이터 중복은 막혔다.
+
+하지만 HTTP 응답은 `200` 1건, `500` 9건이었다. 로그 원인은 `uq_ride_records_owner_client_ride_id` unique constraint 위반이 `DataIntegrityViolationException`으로 올라와 `GlobalExceptionHandler`의 unexpected error로 처리된 것이다.
+
+운영 영향:
+- 사용자는 이미 저장된 기록인데도 “서버 내부 오류”를 본다.
+- 모바일 앱은 재시도 판단을 하기 어렵다.
+- 500 알람이 실제 장애처럼 쌓인다.
+
+### 2. 코스 생성 idempotency 응답 실패
+
+같은 `ownerUserId + sourceRideRecordId`로 코스 생성을 10회 동시에 보냈을 때 DB에는 코스 1건만 남았다. 중복 코스는 막혔다.
+
+하지만 HTTP 응답은 `200` 1건, `500` 9건이었다. 원인은 `uq_courses_owner_source_ride_record` unique constraint 위반이 계약된 4xx로 변환되지 않는 것이다.
+
+운영 영향:
+- 사용자는 “이미 저장된 코스” 상황을 서버 장애로 본다.
+- 프론트는 기존 코스 화면으로 이동할지, 재시도할지 판단할 수 없다.
+- 정상적인 중복 요청이 500 지표를 오염시킨다.
+
+### 3. Party WebSocket socket token 인증 경로 충돌
+
+`POST /api/v1/parties/{partyId}/socket-token`은 성공했지만, `GET /ws/v1/parties/{partyId}/locations` 연결은 첫 시도부터 `401`이었다.
+
+응답 헤더에는 `Malformed token`이 기록됐다. 즉 party socket token이 WebSocket handler까지 도달하기 전에 Spring Security JWT 필터가 Bearer 값을 JWT로 해석하고 차단한다.
+
+운영 영향:
+- 파티 위치 공유 WebSocket은 현재 실제 앱에서 연결되지 않을 가능성이 높다.
+- socket token 일회성 소비 정책은 handler에 구현되어 있지만, security chain과 경로 계약이 맞지 않아 검증 단계까지 가지 못한다.
+
+## 정상 확인 항목
+
+### finalization regenerate
+
+같은 ride record에 regenerate를 10회 동시에 보냈고 `ride_finalization_jobs`는 1건만 유지됐다.
+
+응답은 `200` 9건, `503` 1건이었다. `503`은 DB backpressure 계약 응답으로 확인됐다. job 중복 처리 없이 `SUCCEEDED`, `attemptCount=2`로 수렴했다.
+
+### party join/leave
+
+같은 멤버가 같은 party에 join 10회, leave 10회를 동시에 보냈다.
+
+join 후 member row는 host/member 2건, joined row는 2건이었다. leave 후 member row는 2건 그대로이고 joined row는 host 1건만 남았다. 중복 row 없이 정상 수렴했다.
+
+## 해결 선택지
+
+### A. DB unique violation을 도메인 응답으로 변환
+
+`DataIntegrityViolationException`의 constraint name을 보고 `409 Conflict` 또는 idempotent `200`으로 변환한다.
+
+장점:
+- 변경 범위가 작다.
+- 현재 DB 제약을 그대로 활용한다.
+- 운영 500 오염을 빠르게 줄인다.
+
+단점:
+- constraint name에 서비스 로직이 의존한다.
+- 응답을 `409`로 할지 기존 리소스를 찾아 `200`으로 줄지 API 정책 결정이 필요하다.
+
+추천:
+- 자유주행 저장은 같은 `clientRideId`면 기존 기록을 찾아 `200`으로 돌려주는 편이 모바일 재시도에 유리하다.
+- 코스 생성은 이미 저장된 코스 정보를 `200`으로 돌려주거나, 명확한 `409`와 기존 courseId를 data에 담는 정책 중 하나를 정해야 한다.
+
+### B. 서비스 계층에서 pessimistic lock 또는 advisory lock 사용
+
+`ownerUserId + clientRideId`, `ownerUserId + sourceRideRecordId` 단위로 저장 전 lock을 잡는다.
+
+장점:
+- 중복 예외 자체를 줄인다.
+- 서비스 흐름이 명확하다.
+
+단점:
+- lock 설계가 추가되고 DB 의존성이 커진다.
+- 부하 상황에서 대기 시간이 늘 수 있다.
+
+### C. API 계약을 “중복 요청은 409”로 단순화
+
+동시 중복 요청은 데이터가 이미 있으면 항상 `409 Conflict`로 반환한다.
+
+장점:
+- 구현이 쉽고 명확하다.
+- 프론트가 중복 클릭/재시도를 분리하기 쉽다.
+
+단점:
+- 모바일 네트워크 재시도에서 같은 요청이 실패처럼 보일 수 있다.
+- 사용자가 저장 완료 화면을 보지 못했을 때 복구 UX가 필요하다.
+
+## 추천 결정
+
+1차 운영 준비 기준으로는 A를 추천한다.
+
+- 자유주행 저장: `clientRideId`는 모바일 idempotency key로 봐야 하므로, 같은 요청은 기존 `rideRecordId`를 반환하는 `200`이 적절하다.
+- 코스 생성: 같은 `sourceRideRecordId`는 “이미 코스화됨” 상태이므로 기존 `courseId`를 반환하는 `200` 또는 `409 + existingCourseId` 중 하나를 API 명세에 고정해야 한다. 프론트 단순성까지 보면 기존 courseId를 반환하는 `200`이 더 낫다.
+- WebSocket: `/ws/v1/parties/**`는 JWT 인증이 아니라 party socket token 인증 경로로 분리해야 한다. SecurityConfig에서 해당 경로를 WebSocket handler 인증으로 넘기거나, socket token 전달 위치를 JWT와 충돌하지 않는 query/header로 바꾸는 ADR이 필요하다.
+
+## 다음 결정 필요
+
+아래 3개는 사용자 결정 후 코드 수정으로 들어가야 한다.
+
+1. 자유주행 같은 `clientRideId` 동시 요청 응답을 `200 existing`으로 할지 `409 duplicate`로 할지 결정.
+2. 코스 생성 같은 `sourceRideRecordId` 동시 요청 응답을 `200 existing course`로 할지 `409 duplicate`로 할지 결정.
+3. Party WebSocket socket token 전달 방식을 `Authorization: Bearer socketToken`으로 유지하면서 security permit 처리할지, `?socketToken=` 쿼리로 바꿀지 결정.

--- a/ops/smoke/concurrency_consistency.py
+++ b/ops/smoke/concurrency_consistency.py
@@ -1,0 +1,697 @@
+#!/usr/bin/env python3
+"""BIKE 낮은 부하 동시성/정합성 검증 evidence runner.
+
+민감한 access token은 evidence 파일에 저장하지 않는다.
+실패가 있어도 가능한 시나리오를 계속 실행하고 마지막에 요약으로 보고한다.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import concurrent.futures
+import json
+import os
+import socket
+import ssl
+import subprocess
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+from uuid import uuid4
+
+
+BASE_URL = os.environ.get("BIKE_CONCURRENCY_BASE_URL", "http://127.0.0.1:8080").rstrip("/")
+DB_CONTAINER = os.environ.get("BIKE_CONCURRENCY_DB_CONTAINER", "bike-back-postgres")
+DB_NAME = os.environ.get("BIKE_CONCURRENCY_DB_NAME", "bike")
+DB_USER = os.environ.get("BIKE_CONCURRENCY_DB_USER", "bike")
+OUTPUT_PATH = Path(os.environ.get(
+    "BIKE_CONCURRENCY_OUTPUT",
+    "ops/smoke/results/concurrency_consistency.json",
+))
+REQUEST_COUNT = int(os.environ.get("BIKE_CONCURRENCY_REQUEST_COUNT", "10"))
+
+
+class SmokeFailure(Exception):
+    pass
+
+
+@dataclass(frozen=True)
+class User:
+    user_id: int
+    access_token: str
+
+
+def now_iso() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def later_iso(seconds: int) -> str:
+    return (datetime.now(timezone.utc).replace(microsecond=0) + timedelta(seconds=seconds)).isoformat().replace("+00:00", "Z")
+
+
+def request(
+        method: str,
+        path: str,
+        payload: dict[str, Any] | None = None,
+        token: str | None = None,
+        request_id: str | None = None,
+        timeout_sec: float = 30.0,
+) -> dict[str, Any]:
+    headers = {"Accept": "application/json"}
+    if request_id:
+        headers["X-Request-Id"] = request_id
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    data = None
+    if payload is not None:
+        headers["Content-Type"] = "application/json"
+        data = json.dumps(payload, ensure_ascii=False).encode()
+
+    http_request = urllib.request.Request(
+        BASE_URL + path,
+        data=data,
+        headers=headers,
+        method=method,
+    )
+    started = time.perf_counter()
+    try:
+        with urllib.request.urlopen(http_request, timeout=timeout_sec) as response:
+            body_bytes = response.read()
+            return http_result(method, path, response.status, response.headers, body_bytes, started)
+    except urllib.error.HTTPError as error:
+        body_bytes = error.read()
+        return http_result(method, path, error.code, error.headers, body_bytes, started)
+    except urllib.error.URLError as error:
+        return {
+            "method": method,
+            "path": path,
+            "status": 0,
+            "durationMs": round((time.perf_counter() - started) * 1000, 2),
+            "error": str(error),
+        }
+
+
+def http_result(method: str, path: str, status: int, headers: Any, body_bytes: bytes, started: float) -> dict[str, Any]:
+    return {
+        "method": method,
+        "path": path,
+        "status": status,
+        "durationMs": round((time.perf_counter() - started) * 1000, 2),
+        "bodyBytes": len(body_bytes),
+        "headers": sanitize_headers(dict(headers)),
+        "body": parse_json(body_bytes.decode(errors="replace")),
+    }
+
+
+def parse_json(value: str) -> Any:
+    if not value:
+        return None
+    try:
+        return json.loads(value)
+    except json.JSONDecodeError:
+        return value
+
+
+def sanitize_headers(headers: dict[str, str]) -> dict[str, str]:
+    allowed = {"X-Request-Id", "X-Trace-Id", "Content-Type"}
+    return {key: value for key, value in headers.items() if key in allowed}
+
+
+def api_data(result: dict[str, Any]) -> dict[str, Any]:
+    body = result.get("body")
+    if not isinstance(body, dict) or not isinstance(body.get("data"), dict):
+        raise SmokeFailure(f"{result.get('method')} {result.get('path')} 응답에 data object가 없습니다.")
+    return body["data"]
+
+
+def register_user(label: str) -> User:
+    email = f"concurrency-{label}-{int(time.time())}-{uuid4().hex[:8]}@example.com"
+    result = request("POST", "/api/v1/auth/register", {
+        "email": email,
+        "password": "Password123!",
+        "displayName": f"Concurrency{label}",
+    }, request_id=f"conc-register-{label}")
+    require_status(result, 200, f"register {label}")
+    data = api_data(result)
+    token = data.get("accessToken")
+    user_id = data.get("userId")
+    if not isinstance(token, str) or not isinstance(user_id, int):
+        raise SmokeFailure(f"register {label} 응답에 userId/accessToken이 없습니다.")
+    return User(user_id=user_id, access_token=token)
+
+
+def require_status(result: dict[str, Any], expected: int, label: str) -> None:
+    if result.get("status") != expected:
+        raise SmokeFailure(f"{label} status={result.get('status')}, expected={expected}, body={result.get('body')}")
+
+
+def route_payload(client_ride_id: str) -> dict[str, Any]:
+    started = datetime.now(timezone.utc).replace(microsecond=0)
+    points = [
+        (37.481247, 126.952739),
+        (37.482090, 126.956101),
+        (37.483518, 126.960721),
+        (37.484912, 126.965133),
+    ]
+    route_points = []
+    for index, (lat, lon) in enumerate(points, start=1):
+        route_points.append({
+            "pointOrder": index,
+            "latitude": lat,
+            "longitude": lon,
+            "capturedAt": (started + timedelta(seconds=index * 30)).isoformat().replace("+00:00", "Z"),
+            "accuracyM": 5,
+            "speedMps": 4.5,
+        })
+    ended = started + timedelta(seconds=len(points) * 30)
+    return {
+        "clientRideId": client_ride_id,
+        "startedAt": started.isoformat().replace("+00:00", "Z"),
+        "endedAt": ended.isoformat().replace("+00:00", "Z"),
+        "summary": {
+            "distanceM": 1200,
+            "durationSec": 120,
+        },
+        "routePoints": route_points,
+    }
+
+
+def run_parallel(label: str, count: int, fn: Any) -> list[dict[str, Any]]:
+    with concurrent.futures.ThreadPoolExecutor(max_workers=count, thread_name_prefix=label) as executor:
+        futures = [executor.submit(fn, index) for index in range(count)]
+        return [future.result() for future in concurrent.futures.as_completed(futures)]
+
+
+def ids_from_results(results: list[dict[str, Any]], field: str) -> list[int]:
+    ids: list[int] = []
+    for result in results:
+        body = result.get("body")
+        if isinstance(body, dict) and isinstance(body.get("data"), dict):
+            value = body["data"].get(field)
+            if isinstance(value, int):
+                ids.append(value)
+    return sorted(set(ids))
+
+
+def sql_scalar(query: str) -> str:
+    return subprocess.check_output(
+        ["docker", "exec", DB_CONTAINER, "psql", "-U", DB_USER, "-d", DB_NAME, "-tAc", query],
+        text=True,
+    ).strip()
+
+
+def sql_json(query: str) -> Any:
+    raw = sql_scalar(query)
+    if not raw:
+        return None
+    return json.loads(raw)
+
+
+def sql_literal(value: str) -> str:
+    return "'" + value.replace("'", "''") + "'"
+
+
+def summarize_http(results: list[dict[str, Any]]) -> dict[str, Any]:
+    status_counts: dict[str, int] = {}
+    request_ids: list[str] = []
+    trace_ids: list[str] = []
+    error_samples: list[Any] = []
+    durations = sorted(result.get("durationMs", 0) for result in results)
+    for result in results:
+        status_counts[str(result.get("status"))] = status_counts.get(str(result.get("status")), 0) + 1
+        headers = result.get("headers") or {}
+        if headers.get("X-Request-Id"):
+            request_ids.append(headers["X-Request-Id"])
+        if headers.get("X-Trace-Id"):
+            trace_ids.append(headers["X-Trace-Id"])
+        if result.get("status", 0) >= 400 or result.get("status") == 0:
+            error_samples.append({
+                "status": result.get("status"),
+                "body": result.get("body"),
+                "headers": headers,
+                "error": result.get("error"),
+            })
+    return {
+        "statusCounts": status_counts,
+        "durationMs": {
+            "min": durations[0] if durations else None,
+            "max": durations[-1] if durations else None,
+        },
+        "requestIdSamples": request_ids[:5],
+        "traceIdSamples": trace_ids[:5],
+        "errorSamples": error_samples[:5],
+    }
+
+
+def has_unexpected_5xx(results: list[dict[str, Any]]) -> bool:
+    return any(
+        isinstance(result.get("status"), int)
+        and result["status"] >= 500
+        and result["status"] != 503
+        for result in results
+    )
+
+
+def scenario_duplicate_client_ride(
+        evidence: dict[str, Any],
+        user: User,
+        evidence_key: str = "duplicateClientRideId",
+) -> int | None:
+    client_ride_id = f"conc-ride-{uuid4().hex}"
+    payload = route_payload(client_ride_id)
+
+    def post(index: int) -> dict[str, Any]:
+        return request(
+            "POST",
+            "/api/v1/ride-records",
+            payload,
+            token=user.access_token,
+            request_id=f"conc-ride-save-{index}-{client_ride_id}",
+        )
+
+    results = run_parallel("ride-save", REQUEST_COUNT, post)
+    ride_ids = ids_from_results(results, "rideRecordId")
+    db = sql_json(f"""
+        select json_build_object(
+            'rideRecordCount', count(*),
+            'rideRecordIds', coalesce(json_agg(id order by id), '[]'::json),
+            'pointCount', coalesce(sum(point_count), 0),
+            'jobCount', coalesce(sum(job_count), 0)
+        )
+        from (
+            select r.id,
+                   (select count(*) from ride_record_points p where p.ride_record_id = r.id) as point_count,
+                   (select count(*) from ride_finalization_jobs j where j.ride_record_id = r.id) as job_count
+            from ride_records r
+            where r.owner_user_id = {user.user_id}
+              and r.client_ride_id = {sql_literal(client_ride_id)}
+        ) s;
+    """)
+    ok = len(ride_ids) <= 1 and db["rideRecordCount"] == 1 and db["jobCount"] == 1 and not has_unexpected_5xx(results)
+    evidence[evidence_key] = {
+        "ok": ok,
+        "clientRideId": client_ride_id,
+        "http": summarize_http(results),
+        "distinctRideRecordIdsFromResponses": ride_ids,
+        "db": db,
+        "expected": "HTTP 5xx 없이 같은 owner/clientRideId는 DB ride_records 1건, finalization job 1건만 남아야 함",
+    }
+    return ride_ids[0] if ride_ids else None
+
+
+def poll_ready(ride_record_id: int, user: User, evidence_key: str, evidence: dict[str, Any]) -> bool:
+    attempts: list[dict[str, Any]] = []
+    deadline = time.time() + 60
+    while time.time() < deadline:
+        result = request(
+            "GET",
+            f"/api/v1/ride-records/{ride_record_id}",
+            token=user.access_token,
+            request_id=f"conc-poll-{ride_record_id}",
+        )
+        data = api_data(result) if result.get("status") == 200 else {}
+        attempts.append({
+            "status": result.get("status"),
+            "data": {
+                "finalizationStatus": data.get("status"),
+                "rawPointCount": data.get("rawPointCount"),
+                "processedPointCount": data.get("processedPointCount"),
+                "finalizationAttempts": data.get("finalizationAttempts"),
+                "linkedCourseId": data.get("linkedCourseId"),
+            },
+            "headers": result.get("headers"),
+        })
+        if data.get("status") == "READY":
+            evidence[evidence_key] = {"ready": True, "attempts": attempts}
+            return True
+        if data.get("status") == "FAILED":
+            evidence[evidence_key] = {"ready": False, "attempts": attempts}
+            return False
+        time.sleep(1)
+    evidence[evidence_key] = {"ready": False, "attempts": attempts}
+    return False
+
+
+def scenario_duplicate_regenerate(evidence: dict[str, Any], user: User, ride_record_id: int) -> None:
+    if not poll_ready(ride_record_id, user, "duplicateRegenerateInitialReady", evidence):
+        evidence["duplicateRegenerate"] = {"ok": False, "skipped": "ride record did not become READY"}
+        return
+
+    def post(index: int) -> dict[str, Any]:
+        return request(
+            "POST",
+            f"/api/v1/ride-records/{ride_record_id}/regenerate",
+            {},
+            token=user.access_token,
+            request_id=f"conc-regenerate-{index}-{ride_record_id}",
+        )
+
+    results = run_parallel("regenerate", REQUEST_COUNT, post)
+    db = sql_json(f"""
+        select json_build_object(
+            'jobCount', count(*),
+            'statuses', coalesce(json_agg(status order by id), '[]'::json),
+            'attemptCounts', coalesce(json_agg(attempt_count order by id), '[]'::json)
+        )
+        from ride_finalization_jobs
+        where ride_record_id = {ride_record_id};
+    """)
+    ok = db["jobCount"] == 1 and not has_unexpected_5xx(results)
+    evidence["duplicateRegenerate"] = {
+        "ok": ok,
+        "rideRecordId": ride_record_id,
+        "http": summarize_http(results),
+        "db": db,
+        "expected": "동시 regenerate 후에도 ride_finalization_jobs는 rideRecord당 1건이어야 함",
+    }
+
+
+def scenario_duplicate_course_create(evidence: dict[str, Any], user: User, ride_record_id: int) -> int | None:
+    if not poll_ready(ride_record_id, user, "duplicateCourseCreateInitialReady", evidence):
+        evidence["duplicateCourseCreate"] = {"ok": False, "skipped": "ride record did not become READY"}
+        return None
+
+    def post(index: int) -> dict[str, Any]:
+        return request(
+            "POST",
+            "/api/v1/courses",
+            {
+                "sourceRideRecordId": ride_record_id,
+                "name": f"Concurrency course {ride_record_id}",
+                "description": "동시성 검증용 코스",
+                "visibility": "PUBLIC",
+            },
+            token=user.access_token,
+            request_id=f"conc-course-create-{index}-{ride_record_id}",
+        )
+
+    results = run_parallel("course-create", REQUEST_COUNT, post)
+    course_ids = ids_from_results(results, "courseId")
+    db = sql_json(f"""
+        select json_build_object(
+            'courseCount', count(*),
+            'courseIds', coalesce(json_agg(id order by id), '[]'::json),
+            'routePointCount', coalesce(sum(point_count), 0)
+        )
+        from (
+            select c.id,
+                   (select count(*) from course_route_points p where p.course_id = c.id) as point_count
+            from courses c
+            where c.owner_user_id = {user.user_id}
+              and c.source_ride_record_id = {ride_record_id}
+        ) s;
+    """)
+    ok = len(course_ids) <= 1 and db["courseCount"] == 1 and not has_unexpected_5xx(results)
+    evidence["duplicateCourseCreate"] = {
+        "ok": ok,
+        "rideRecordId": ride_record_id,
+        "http": summarize_http(results),
+        "distinctCourseIdsFromResponses": course_ids,
+        "db": db,
+        "expected": "같은 sourceRideRecordId는 코스 1건만 생성되고 나머지는 계약된 4xx로 끝나야 함",
+    }
+    return course_ids[0] if course_ids else None
+
+
+def create_ready_course(evidence: dict[str, Any], user: User) -> int:
+    ride_result = request(
+        "POST",
+        "/api/v1/ride-records",
+        route_payload(f"conc-party-source-{uuid4().hex}"),
+        token=user.access_token,
+        request_id="conc-party-source-ride",
+    )
+    require_status(ride_result, 200, "party source ride create")
+    ride_record_id = api_data(ride_result)["rideRecordId"]
+    if not poll_ready(ride_record_id, user, "partySourceRideReady", evidence):
+        raise SmokeFailure("party source ride did not become READY")
+    course_result = request(
+        "POST",
+        "/api/v1/courses",
+        {
+            "sourceRideRecordId": ride_record_id,
+            "name": f"Concurrency party course {ride_record_id}",
+            "description": "파티 동시성 검증용 코스",
+            "visibility": "PUBLIC",
+        },
+        token=user.access_token,
+        request_id="conc-party-source-course",
+    )
+    require_status(course_result, 200, "party source course create")
+    return api_data(course_result)["courseId"]
+
+
+def scenario_party_join_leave(evidence: dict[str, Any], host: User) -> int | None:
+    course_id = create_ready_course(evidence, host)
+    member = register_user("member")
+    party_result = request(
+        "POST",
+        "/api/v1/parties",
+        {
+            "courseId": course_id,
+            "title": "Concurrency party",
+            "scheduledStartAt": later_iso(3600),
+            "capacity": 2,
+        },
+        token=host.access_token,
+        request_id="conc-party-create",
+    )
+    require_status(party_result, 200, "party create")
+    party_id = api_data(party_result)["id"]
+
+    def join(index: int) -> dict[str, Any]:
+        return request(
+            "POST",
+            f"/api/v1/parties/{party_id}/join",
+            {},
+            token=member.access_token,
+            request_id=f"conc-party-join-{index}-{party_id}",
+        )
+
+    join_results = run_parallel("party-join", REQUEST_COUNT, join)
+    joined_db = sql_json(f"""
+        select json_build_object(
+            'memberRows', count(*),
+            'joinedRows', count(*) filter (where status = 'JOINED'),
+            'statuses', coalesce(json_agg(status order by id), '[]'::json)
+        )
+        from ride_party_members
+        where party_id = {party_id};
+    """)
+
+    def leave(index: int) -> dict[str, Any]:
+        return request(
+            "POST",
+            f"/api/v1/parties/{party_id}/leave",
+            {},
+            token=member.access_token,
+            request_id=f"conc-party-leave-{index}-{party_id}",
+        )
+
+    leave_results = run_parallel("party-leave", REQUEST_COUNT, leave)
+    left_db = sql_json(f"""
+        select json_build_object(
+            'memberRows', count(*),
+            'joinedRows', count(*) filter (where status = 'JOINED'),
+            'statuses', coalesce(json_agg(status order by id), '[]'::json)
+        )
+        from ride_party_members
+        where party_id = {party_id};
+    """)
+    ok = (
+        joined_db["memberRows"] == 2
+        and joined_db["joinedRows"] == 2
+        and left_db["memberRows"] == 2
+        and left_db["joinedRows"] == 1
+        and not has_unexpected_5xx(join_results)
+        and not has_unexpected_5xx(leave_results)
+    )
+    evidence["partyJoinLeave"] = {
+        "ok": ok,
+        "partyId": party_id,
+        "courseId": course_id,
+        "joinHttp": summarize_http(join_results),
+        "leaveHttp": summarize_http(leave_results),
+        "dbAfterJoin": joined_db,
+        "dbAfterLeave": left_db,
+        "expected": "같은 member 동시 join/leave 후 중복 member row가 없어야 하고 host 1명만 JOINED로 남아야 함",
+    }
+    return party_id
+
+
+def websocket_handshake(base_url: str, party_id: int, token: str) -> dict[str, Any]:
+    parsed = urllib.parse.urlparse(base_url)
+    secure = parsed.scheme == "https"
+    host = parsed.hostname or "127.0.0.1"
+    port = parsed.port or (443 if secure else 80)
+    key = base64.b64encode(os.urandom(16)).decode()
+    path = f"/ws/v1/parties/{party_id}/locations"
+    request_text = (
+        f"GET {path} HTTP/1.1\r\n"
+        f"Host: {host}:{port}\r\n"
+        "Upgrade: websocket\r\n"
+        "Connection: Upgrade\r\n"
+        f"Sec-WebSocket-Key: {key}\r\n"
+        "Sec-WebSocket-Version: 13\r\n"
+        f"Authorization: Bearer {token}\r\n"
+        "\r\n"
+    )
+    started = time.perf_counter()
+    raw_response = b""
+    frame = b""
+    try:
+        sock: socket.socket = socket.create_connection((host, port), timeout=5)
+        if secure:
+            sock = ssl.create_default_context().wrap_socket(sock, server_hostname=host)
+        with sock:
+            sock.settimeout(5)
+            sock.sendall(request_text.encode())
+            while b"\r\n\r\n" not in raw_response:
+                chunk = sock.recv(4096)
+                if not chunk:
+                    break
+                raw_response += chunk
+            try:
+                frame = sock.recv(256)
+            except socket.timeout:
+                frame = b""
+    except OSError as error:
+        return {
+            "status": 0,
+            "durationMs": round((time.perf_counter() - started) * 1000, 2),
+            "error": str(error),
+        }
+    head = raw_response.split(b"\r\n\r\n", 1)[0].decode(errors="replace")
+    status = 0
+    if head.startswith("HTTP/"):
+        parts = head.split(" ", 2)
+        if len(parts) > 1 and parts[1].isdigit():
+            status = int(parts[1])
+    opcode = frame[0] & 0x0F if frame else None
+    return {
+        "status": status,
+        "durationMs": round((time.perf_counter() - started) * 1000, 2),
+        "responseHead": head.splitlines()[:8],
+        "firstFrameOpcode": opcode,
+        "firstFrameHex": frame.hex()[:80],
+    }
+
+
+def scenario_socket_token_reuse(evidence: dict[str, Any], user: User, party_id: int) -> None:
+    token_result = request(
+        "POST",
+        f"/api/v1/parties/{party_id}/socket-token",
+        {},
+        token=user.access_token,
+        request_id=f"conc-party-socket-token-{party_id}",
+    )
+    require_status(token_result, 200, "party socket token issue")
+    socket_token = api_data(token_result).get("socketToken")
+    if not isinstance(socket_token, str):
+        raise SmokeFailure("socket token issue 응답에 token이 없습니다.")
+    first = websocket_handshake(BASE_URL, party_id, socket_token)
+    second = websocket_handshake(BASE_URL, party_id, socket_token)
+    ok = (
+        first["status"] == 101
+        and first.get("firstFrameOpcode") == 1
+        and (
+            second["status"] in {401, 403}
+            or (second["status"] == 101 and second.get("firstFrameOpcode") == 8)
+        )
+    )
+    evidence["socketTokenReuse"] = {
+        "ok": ok,
+        "partyId": party_id,
+        "firstHandshake": first,
+        "secondHandshake": second,
+        "expected": "첫 연결만 connected frame을 받고, 재사용 연결은 handshake 거부 또는 policy close frame으로 종료되어야 함",
+    }
+
+
+def scenario_guard(evidence: dict[str, Any], key: str, fn: Any) -> Any:
+    try:
+        return fn()
+    except Exception as exception:
+        evidence[key] = {
+            "ok": False,
+            "error": exception.__class__.__name__,
+            "message": str(exception),
+        }
+        return None
+
+
+def build_summary(evidence: dict[str, Any]) -> dict[str, Any]:
+    scenario_keys = [
+        "duplicateClientRideId",
+        "duplicateRegenerate",
+        "duplicateCourseCreate",
+        "partyJoinLeave",
+        "socketTokenReuse",
+    ]
+    return {
+        "ok": all(bool(evidence.get(key, {}).get("ok")) for key in scenario_keys),
+        "scenarios": {
+            key: bool(evidence.get(key, {}).get("ok"))
+            for key in scenario_keys
+        },
+        "evidencePath": str(OUTPUT_PATH),
+    }
+
+
+def main() -> int:
+    global OUTPUT_PATH
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--output", default=str(OUTPUT_PATH))
+    args = parser.parse_args()
+
+    OUTPUT_PATH = Path(args.output)
+
+    evidence: dict[str, Any] = {
+        "startedAt": now_iso(),
+        "baseUrl": BASE_URL,
+        "dbContainer": DB_CONTAINER,
+        "requestCount": REQUEST_COUNT,
+    }
+    health = request("GET", "/health", request_id="conc-health")
+    require_status(health, 200, "health")
+    evidence["health"] = {
+        "status": health["status"],
+        "headers": health.get("headers"),
+    }
+
+    owner = register_user("owner")
+    ride_id = scenario_guard(evidence, "duplicateClientRideId", lambda: scenario_duplicate_client_ride(evidence, owner))
+    if isinstance(ride_id, int):
+        scenario_guard(evidence, "duplicateRegenerate", lambda: scenario_duplicate_regenerate(evidence, owner, ride_id))
+
+    course_owner = register_user("course-owner")
+    course_ride_id = scenario_guard(
+        evidence,
+        "duplicateCourseCreateSetup",
+        lambda: scenario_duplicate_client_ride(evidence, course_owner, "duplicateCourseCreateRideSave"),
+    )
+    if isinstance(course_ride_id, int):
+        scenario_guard(evidence, "duplicateCourseCreate", lambda: scenario_duplicate_course_create(evidence, course_owner, course_ride_id))
+
+    host = register_user("host")
+    party_id = scenario_guard(evidence, "partyJoinLeave", lambda: scenario_party_join_leave(evidence, host))
+    if isinstance(party_id, int):
+        scenario_guard(evidence, "socketTokenReuse", lambda: scenario_socket_token_reuse(evidence, host, party_id))
+
+    evidence["finishedAt"] = now_iso()
+    evidence["summary"] = build_summary(evidence)
+    OUTPUT_PATH.parent.mkdir(parents=True, exist_ok=True)
+    OUTPUT_PATH.write_text(json.dumps(evidence, ensure_ascii=False, indent=2))
+    print(json.dumps(evidence["summary"], ensure_ascii=False, indent=2))
+    return 0 if evidence["summary"]["ok"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add HTTP/DB concurrency consistency runner for local backend evidence
- cover duplicate clientRideId ride save, duplicate regenerate, duplicate course creation, party join/leave, and party WebSocket socket token path
- add Korean review report with observed failures and decision options

## Verification
- python3 -m py_compile ops/smoke/concurrency_consistency.py
- local bootRun health confirmed on :8080/:18081
- BIKE_CONCURRENCY_OUTPUT=ops/smoke/results/concurrency_consistency_20260627_175130.json python3 ops/smoke/concurrency_consistency.py --output ops/smoke/results/concurrency_consistency_20260627_175130.json

## Result
- PASS: duplicate regenerate kept one ride_finalization_jobs row; party join/leave kept member rows consistent
- FAIL: duplicate clientRideId ride save returns 500 on unique constraint race, though DB keeps one ride record/job
- FAIL: duplicate sourceRideRecord course create returns 500 on unique constraint race, though DB keeps one course
- FAIL: party WebSocket socket token is rejected by Spring Security as malformed JWT before handler token auth

## Decision needed before code fix
- ride duplicate response policy: 200 existing vs 409 duplicate
- course duplicate response policy: 200 existing course vs 409 duplicate with existingCourseId
- party WebSocket token transport/security policy: permit handler auth for /ws/v1/parties/** vs move socket token out of Authorization Bearer

## Note
- This is stacked on #62 / ops/provider-fallback-observability.