### PR TITLE
fix: stabilize duplicate write idempotency

### DIFF
--- a/docs/ADR/ADR_중복요청_Redis_idempotency_lock_운영정책_2026-06-27.md
+++ b/docs/ADR/ADR_중복요청_Redis_idempotency_lock_운영정책_2026-06-27.md
@@ -1,0 +1,228 @@
+# ADR: 중복 요청 Redis idempotency lock 운영 정책
+
+- 날짜: 2026-06-27
+- 상태: accepted
+- 범위: 자유주행 저장, 기록 기반 코스 생성, Redis 장애 fallback, AWS ALB 다중 인스턴스 검증
+- 관련 evidence:
+  - `ops/smoke/results/concurrency_consistency_20260627_192607.json`
+  - `ops/smoke/results/concurrency_consistency_strict_20260627_193509.json`
+  - `ops/smoke/results/concurrency_consistency_numeric_subject_lock_20260627_202815.json`
+  - `DOCS/검토/동시성_정합성_검증_보고_2026-06-27.md`
+
+## 배경
+
+운영 1차 검증 전에 낮은 부하 동시성 smoke를 실행했다. 사용자 결정으로 아래 API 계약을 적용했다.
+
+- 같은 `ownerUserId + clientRideId` 자유주행 저장은 기존 `rideRecordId`를 `200`으로 반환한다.
+- 같은 `ownerUserId + sourceRideRecordId` 기록 기반 코스 생성은 기존 `courseId`를 `200`으로 반환한다.
+- Party WebSocket socket token은 브라우저/모바일 WebSocket에서 쓰기 쉬운 `?socketToken=` query parameter로 전달한다.
+
+코드 수정 후 자유주행 저장과 WebSocket은 승인 정책을 만족했다. 그러나 기록 기반 코스 생성은 DB 데이터 정합성은 지켰지만 사용자/API 계약을 완전히 만족하지 못했다.
+
+strict smoke 결과:
+
+- `duplicateClientRideId`: `200` 10건, DB ride record 1건, finalization job 1건
+- `duplicateCourseCreate`: `200` 4건, `503` 6건, DB course 1건
+- `socketTokenReuse`: 첫 연결 `101`, 재사용 연결 policy close frame
+
+## 문제
+
+기록 기반 코스 생성 10개가 같은 `sourceRideRecordId`로 동시에 들어오면 DB unique constraint가 중복 row는 막는다. 하지만 동시에 insert를 시도한 요청들이 unique conflict 대기와 후속 조회 과정에서 DB connection을 오래 점유한다. 그 결과 Hikari pool이 꽉 차고 일부 요청은 `503 database_unavailable`로 떨어졌다.
+
+운영 관점에서 이 상태는 불완전하다.
+
+- 데이터는 안전하지만 사용자는 같은 코스 생성 재시도에서 성공 화면 대신 503을 볼 수 있다.
+- `503`은 운영 장애 지표를 오염시킨다.
+- AWS ALB 2 targets에서는 같은 사용자의 중복 요청이 다른 인스턴스로 갈 수 있어 단일 JVM 내부 제어만으로는 부족하다.
+- Hikari pool size를 키우면 증상을 늦출 수는 있지만, 같은 key 중복 요청이 DB connection을 점유하는 구조 자체는 유지된다.
+
+## 목표
+
+- 같은 idempotency key의 중복 요청은 가능한 한 DB insert 경쟁 전에 직렬화한다.
+- 승인 정책처럼 중복 요청도 기존 리소스를 `200`으로 반환한다.
+- ALB 2 targets에서도 같은 정책이 유지되어야 한다.
+- Redis 장애가 있어도 데이터 정합성은 DB unique constraint로 최종 보호한다.
+- Redis lock은 영구 lock이 되지 않도록 TTL을 둔다.
+- AWS 테스트에서는 Redis 정상, Redis 실패, DB pressure 상황을 각각 evidence로 남긴다.
+
+## 선택지
+
+### A. 현재 방식 유지
+
+DB unique constraint를 최종 방어선으로 두고, 충돌 후 기존 row를 조회해 `200`을 반환한다.
+
+장점:
+
+- 구현이 가장 단순하다.
+- Redis나 별도 lock 정책이 없어도 DB 정합성은 유지된다.
+- Redis 장애와 무관하다.
+
+단점:
+
+- 이미 strict smoke에서 `503`이 확인됐다.
+- 같은 key의 중복 요청이 DB connection을 점유한다.
+- ALB 다중 인스턴스에서 중복 요청이 늘면 Hikari pressure가 더 빨리 나타날 수 있다.
+
+판단:
+
+- 운영 1차 E2E/AWS 검증 기준으로는 부족하다.
+
+### B. 인스턴스 내부 keyed lock
+
+애플리케이션 메모리에서 `ownerUserId + clientRideId`, `ownerUserId + sourceRideRecordId` 단위로 lock을 잡는다.
+
+장점:
+
+- 구현이 쉽고 빠르다.
+- 단일 인스턴스에서는 DB insert 경쟁을 크게 줄인다.
+- Redis 의존성이 없다.
+
+단점:
+
+- ALB 2 targets에서는 인스턴스 간 lock이 공유되지 않는다.
+- 장애 검증에서 “다중 인스턴스 상태 공유” 기준을 만족하지 못한다.
+- 인스턴스 재시작 시 lock 상태가 사라진다.
+
+판단:
+
+- 단일 인스턴스 임시 완화책으로는 가능하지만, 이번 목표의 ALB 2 targets 검증에는 부족하다.
+
+### C. Redis 기반 idempotency lock
+
+Redis에 짧은 TTL을 가진 lock key를 만든다. lock key 예시는 다음과 같다.
+
+- `bike:idempotency-lock:ride-record:{ownerUserId}:{clientRideId}`
+- `bike:idempotency-lock:course-from-ride:{ownerUserId}:{sourceRideRecordId}`
+
+기본 흐름:
+
+1. 요청 validation과 사용자 식별을 먼저 수행한다.
+2. 기존 리소스가 있으면 즉시 `200`으로 반환한다.
+3. 기존 리소스가 없으면 Redis lock 획득을 시도한다.
+4. lock을 얻은 요청만 생성 트랜잭션을 수행한다.
+5. lock을 얻지 못한 요청은 짧게 대기하며 기존 리소스 조회를 반복한다.
+6. 제한 시간 안에 기존 리소스가 보이면 `200`으로 반환한다.
+7. 제한 시간 안에 보이지 않으면 `503` 또는 `409/202` 중 정책에 맞는 응답을 반환한다.
+8. Redis 장애 시에는 lock 없이 현재 DB unique fallback을 사용한다.
+
+장점:
+
+- ALB 2 targets에서도 lock이 공유된다.
+- 같은 key 중복 요청이 DB insert 경쟁으로 몰리는 것을 줄인다.
+- Redis 장애가 있어도 DB unique constraint가 최종 정합성을 지킨다.
+- AWS 상태 공유 검증 항목과 잘 맞는다.
+
+단점:
+
+- Redis lock TTL, 대기 시간, 실패 응답 계약을 정해야 한다.
+- Redis 장애 시에는 현재 방식 fallback이라 DB pressure가 다시 생길 수 있다.
+- lock 구현과 테스트가 추가된다.
+
+판단:
+
+- 운영 1차 E2E/AWS 검증 기준으로 추천한다.
+
+### D. PostgreSQL advisory lock
+
+PostgreSQL advisory lock을 `ownerUserId + sourceRideRecordId` 기준으로 잡는다.
+
+장점:
+
+- 다중 인스턴스에서도 DB 기준으로 공유된다.
+- Redis 없이 구현할 수 있다.
+
+단점:
+
+- lock 대기 자체가 DB connection을 점유할 수 있다.
+- 이번에 관측된 Hikari pressure를 줄이는 목적에는 Redis보다 약하다.
+- DB vendor 의존성이 강해진다.
+
+판단:
+
+- Redis를 쓸 수 없을 때의 대안으로만 둔다.
+
+## 결정
+
+C. Redis 기반 idempotency lock을 선택한다.
+
+정책:
+
+- lock TTL: 10초
+- lock 대기 시간: 최대 2초
+- 대기 중 조회 주기: 50~100ms jitter
+- lock 획득 실패 후 기존 리소스가 조회되면 `200 existing`
+- lock 획득 실패 후 제한 시간 내 기존 리소스가 조회되지 않으면 `503` backpressure
+- Redis 장애 시 lock 없이 DB unique fallback을 사용하고 provider/infra failure metric을 남긴다.
+- lock release는 owner token을 비교해 본인이 잡은 lock만 삭제한다.
+
+## 구현 범위
+
+1차 구현 대상:
+
+- 자유주행 저장 `ownerUserId + clientRideId`
+- 기록 기반 코스 생성 `ownerUserId + sourceRideRecordId`
+- Redis lock adapter
+- lock 획득/대기/실패 metric
+- 단위 테스트
+- local strict concurrency smoke
+
+비범위:
+
+- 전체 API 공통 idempotency key 도입
+- Kafka/SQS/DLQ 도입
+- DB schema 변경
+- Redis route snapshot cache 구현
+- Hikari pool size 증설로 문제를 덮는 방식
+
+## 검증 기준
+
+Local:
+
+- `RideRecordServiceTest`
+- `CourseServiceTest`
+- `RidePartyLocationWebSocketHandlerTest`
+- `python3 -m py_compile ops/smoke/concurrency_consistency.py`
+- `ops/smoke/concurrency_consistency.py`
+  - `duplicateClientRideId=true`
+  - `duplicateCourseCreate=true`
+  - `socketTokenReuse=true`
+  - 중복 주행 저장 statusCounts: `{"200": 10}`
+  - 중복 코스 생성 statusCounts: `{"200": 10}`
+
+AWS:
+
+- single instance에서 같은 smoke runner 통과
+- ALB single target에서 request id/header/WebSocket 확인
+- ALB 2 targets에서 같은 key 중복 요청이 모두 기존 리소스 `200`으로 수렴하는지 확인
+- Redis 장애 drill에서는 DB unique fallback이 정합성을 유지하고 실패율/503이 evidence에 기록되는지 확인
+
+## 결정 결과
+
+사용자 결정으로 아래 정책을 확정했다.
+
+1. Redis idempotency lock을 자유주행 저장과 기록 기반 코스 생성 둘 다 적용한다.
+2. lock 대기 시간 2초, TTL 10초를 1차 기본값으로 둔다.
+3. lock 획득 실패 후 기존 리소스를 못 찾으면 `503 backpressure`로 응답한다.
+
+## 2026-06-27 구현 중 보정
+
+Local strict smoke에서 Redis lock을 단순 적용했을 때도 기록 기반 코스 생성이 실패했다. 원인은 lock 경쟁 요청이 DB 조회를 먼저 수행한 뒤 대기하면서 Hikari connection을 점유한 것이다.
+
+보정 결정:
+
+- `course_from_ride`는 DB 조회 전에 numeric JWT subject에서 `ownerUserId`를 파싱해 Redis lock key를 먼저 만든다.
+- legacy non-numeric subject는 기존 `AuthService.findUserBySubject`로 fallback한다.
+- `course_from_ride`는 command 성격이므로 기존 리소스 조회도 lock 경쟁자 대기 경로에서만 수행한다.
+- `course_from_ride` 대기 정책은 생성 작업 시간을 고려해 최대 8초, 조회 주기 300~500ms jitter로 둔다.
+- `ride_record_regenerate`도 command 성격이므로 lock을 얻은 요청 하나만 재처리 mark를 수행하고, 경쟁 요청은 현재 finalization 상태를 `200`으로 반환한다.
+
+최종 local evidence:
+
+- Evidence: `ops/smoke/results/concurrency_consistency_numeric_subject_lock_20260627_202815.json`
+- `duplicateClientRideId`: `200` 10건, ride record 1건, finalization job 1건
+- `duplicateRegenerate`: `200` 10건, finalization job 1건
+- `duplicateCourseCreate`: `200` 10건, course 1건, route point 3건
+- Prometheus:
+  - `bike_idempotency_lock_total{operation="course_from_ride",outcome="existing_after_wait"} 9`
+  - `hikaricp_connections_timeout_total 0`
+  - `hikaricp_connections_pending 0`

--- a/docs/검토/동시성_정합성_검증_보고_2026-06-27.md
+++ b/docs/검토/동시성_정합성_검증_보고_2026-06-27.md
@@ -131,3 +131,107 @@ join 후 member row는 host/member 2건, joined row는 2건이었다. leave 후 
 1. 자유주행 같은 `clientRideId` 동시 요청 응답을 `200 existing`으로 할지 `409 duplicate`로 할지 결정.
 2. 코스 생성 같은 `sourceRideRecordId` 동시 요청 응답을 `200 existing course`로 할지 `409 duplicate`로 할지 결정.
 3. Party WebSocket socket token 전달 방식을 `Authorization: Bearer socketToken`으로 유지하면서 security permit 처리할지, `?socketToken=` 쿼리로 바꿀지 결정.
+
+## 2026-06-27 19:26 재검증 결과
+
+사용자 결정으로 아래 정책을 적용했다.
+
+- 자유주행 같은 `clientRideId` 동시 저장은 기존 `rideRecordId`를 `200`으로 반환한다.
+- 같은 `sourceRideRecordId` 코스 생성은 기존 `courseId`를 `200`으로 반환한다.
+- Party WebSocket socket token은 `?socketToken=` query parameter로 전달한다.
+
+적용 후 local `bootRun` 상태에서 `ops/smoke/concurrency_consistency.py`를 다시 실행했다.
+
+- Evidence: `ops/smoke/results/concurrency_consistency_20260627_192607.json`
+- DB: `bike-back-postgres`
+- Redis: `bike-back-redis`
+- GraphHopper: `bike-back-graphhopper`
+
+| 시나리오 | 결과 | API 응답 | 데이터 정합성 | 판단 |
+|---|---:|---:|---:|---|
+| 같은 `clientRideId` 주행 저장 10회 동시 요청 | 통과 | `200` 10건 | ride record 1건, job 1건 | 승인 정책 충족 |
+| 같은 ride record finalization regenerate 10회 동시 요청 | 통과 | backpressure 포함 가능 | job 1건 | 정합성 충족 |
+| 같은 `sourceRideRecordId` 코스 생성 10회 동시 요청 | 부분 실패 | `200` 2건, `503` 8건 | course 1건 | 운영 자원 리스크 |
+| 같은 멤버의 party join/leave 10회 동시 요청 | 통과 | `200` | 중복 member 없음 | 정합성 충족 |
+| Party WebSocket socket token 재사용 | 통과 | 첫 연결 `101`, 재사용 close frame | 1회성 토큰 소비 | 승인 정책 충족 |
+
+### 신규 운영 이슈: 중복 코스 생성 시 DB connection 압력
+
+같은 `sourceRideRecordId`로 10개 요청이 동시에 들어오면 DB unique constraint는 중복 course row를 막는다. 그러나 대기 중인 insert와 후속 조회가 Hikari connection을 오래 점유해 일부 요청이 `503 database_unavailable`로 빠진다.
+
+확인된 evidence:
+
+- `duplicateCourseCreate.http.statusCounts`: `{"503": 8, "200": 2}`
+- `duplicateCourseCreate.db.courseCount`: `1`
+- `duplicateCourseCreate.db.routePointCount`: `3`
+- error sample message: `데이터베이스 연결이 일시적으로 부족합니다. 잠시 후 다시 시도해 주세요.`
+
+운영 영향:
+
+- 데이터 중복은 막지만 사용자는 같은 코스 생성 재시도에서 성공 화면 대신 503을 볼 수 있다.
+- Hikari pool pressure가 실제 장애 알람으로 올라올 수 있다.
+- AWS ALB 2 targets 검증에서는 인스턴스 간 같은 요청이 동시에 들어올 가능성이 있어, 단일 JVM 내부 처리만으로는 충분하지 않을 수 있다.
+
+### 추가 ADR 필요
+
+승인 정책인 “중복 코스 생성은 기존 course를 200 반환”을 AWS 다중 인스턴스에서도 만족하려면 idempotency 직렬화 정책을 정해야 한다.
+
+- ADR: `DOCS/ADR/ADR_중복요청_Redis_idempotency_lock_운영정책_2026-06-27.md`
+
+강화된 runner 기준으로 재실행한 결과도 같은 문제를 blocker로 판정했다.
+
+- Strict evidence: `ops/smoke/results/concurrency_consistency_strict_20260627_193509.json`
+- Summary: `duplicateClientRideId=true`, `duplicateRegenerate=true`, `duplicateCourseCreate=false`, `partyJoinLeave=true`, `socketTokenReuse=true`
+- `duplicateCourseCreate.http.statusCounts`: `{"503": 6, "200": 4}`
+- `duplicateCourseCreate.db.courseCount`: `1`
+- 판단: 데이터 정합성은 유지됐지만 승인 정책인 “모든 중복 코스 생성 요청이 기존 course를 200으로 반환”은 아직 미충족이다.
+
+선택지:
+
+1. 현재 방식 유지: DB unique constraint + 충돌 후 기존 row 조회. 구현은 단순하지만 connection pressure로 503이 남을 수 있다.
+2. 인스턴스 내부 keyed lock: `ownerUserId + sourceRideRecordId` 기준으로 단일 JVM 안에서만 직렬화한다. 단일 인스턴스에는 효과가 있지만 ALB 2 targets에서는 인스턴스 간 중복 요청을 막지 못한다.
+3. Redis 기반 idempotency lock: Redis `SET NX PX`로 `ownerUserId + sourceRideRecordId`를 짧게 직렬화한다. ALB 2 targets에서도 공유되고 DB pool pressure를 줄일 수 있다. Redis 장애 시 DB unique constraint fallback이 필요하다.
+4. PostgreSQL advisory lock: DB에서 공유 lock을 잡는다. 다중 인스턴스에는 대응되지만 대기 요청이 DB connection을 점유할 수 있어 이번 Hikari pressure를 줄이는 데는 한계가 있다.
+
+추천:
+
+- 운영 1차 AWS 검증과 ALB 2 targets 상태 공유 검증까지 고려하면 Redis 기반 idempotency lock을 추천한다.
+- 단, Redis 장애 시 동작, lock TTL, lock 획득 실패 시 대기/재시도/503 여부는 API 계약과 운영 정책이므로 ADR로 먼저 확정해야 한다.
+
+## 2026-06-27 20:28 최종 재검증 결과
+
+사용자 결정으로 Redis 기반 idempotency lock을 적용했고, local strict concurrency runner를 최종 재실행했다.
+
+- Evidence: `ops/smoke/results/concurrency_consistency_numeric_subject_lock_20260627_202815.json`
+- DB: `bike-back-postgres`
+- Redis: `bike-back-redis`
+- GraphHopper: `bike-back-graphhopper`
+- 실행 기준: request count 10
+
+| 시나리오 | 결과 | API 응답 | 데이터 정합성 | 판단 |
+|---|---:|---:|---:|---|
+| 같은 `clientRideId` 주행 저장 10회 동시 요청 | 통과 | `200` 10건 | ride record 1건, route point 4건, job 1건 | 승인 정책 충족 |
+| 같은 ride record finalization regenerate 10회 동시 요청 | 통과 | `200` 10건 | job 1건 | DB connection pressure 완화 |
+| 같은 `sourceRideRecordId` 코스 생성 10회 동시 요청 | 통과 | `200` 10건 | course 1건, route point 3건 | 승인 정책 충족 |
+| 같은 멤버의 party join/leave 10회 동시 요청 | 통과 | `200` | 중복 member 없음 | 정합성 충족 |
+| Party WebSocket socket token 재사용 | 통과 | 첫 연결 `101`, 재사용 close frame | 1회성 토큰 소비 | 승인 정책 충족 |
+
+최종 관측 지표:
+
+- `bike_idempotency_lock_total{operation="course_from_ride",outcome="existing_after_wait"} 9`
+- `bike_idempotency_lock_total{operation="ride_record_regenerate",outcome="existing_after_wait"} 9`
+- `hikaricp_connections_timeout_total`: `0`
+- `hikaricp_connections_pending`: `0`
+- `http_server_requests_seconds_count{method="POST",uri="/api/v1/courses",status="200"}`: 11
+
+구현상 중요한 보정:
+
+- 기록 기반 코스 생성은 DB 조회 전에 numeric JWT subject에서 `ownerUserId`를 파싱해 Redis lock key를 만든다.
+- lock을 잡은 creator만 사용자 활성 검증, ride record 소유권 검증, 최종 경로 복제를 수행한다.
+- lock 경쟁자는 기존 course가 보일 때까지 대기 후 `200 existing`으로 수렴한다.
+- `ride_record_regenerate`도 command형 idempotency lock을 적용해 같은 ride record 재처리 요청이 DB transaction 10개로 몰리지 않게 했다.
+
+남은 리스크:
+
+- legacy non-numeric subject는 기존 `AuthService.findUserBySubject` fallback을 타므로, 이 경로의 고부하 동시성은 별도 검증이 필요하다.
+- Redis 장애 시에는 DB unique fallback으로 정합성은 지키지만, connection pressure가 다시 발생할 수 있다. AWS failure/resilience goal에서 별도 evidence가 필요하다.

--- a/ops/smoke/concurrency_consistency.py
+++ b/ops/smoke/concurrency_consistency.py
@@ -258,6 +258,10 @@ def has_unexpected_5xx(results: list[dict[str, Any]]) -> bool:
     )
 
 
+def all_status(results: list[dict[str, Any]], expected: int) -> bool:
+    return all(result.get("status") == expected for result in results)
+
+
 def scenario_duplicate_client_ride(
         evidence: dict[str, Any],
         user: User,
@@ -293,14 +297,14 @@ def scenario_duplicate_client_ride(
               and r.client_ride_id = {sql_literal(client_ride_id)}
         ) s;
     """)
-    ok = len(ride_ids) <= 1 and db["rideRecordCount"] == 1 and db["jobCount"] == 1 and not has_unexpected_5xx(results)
+    ok = all_status(results, 200) and len(ride_ids) == 1 and db["rideRecordCount"] == 1 and db["jobCount"] == 1
     evidence[evidence_key] = {
         "ok": ok,
         "clientRideId": client_ride_id,
         "http": summarize_http(results),
         "distinctRideRecordIdsFromResponses": ride_ids,
         "db": db,
-        "expected": "HTTP 5xx 없이 같은 owner/clientRideId는 DB ride_records 1건, finalization job 1건만 남아야 함",
+        "expected": "같은 owner/clientRideId 동시 저장은 모든 응답이 200이고 같은 rideRecordId를 반환해야 하며 DB ride_records 1건, finalization job 1건만 남아야 함",
     }
     return ride_ids[0] if ride_ids else None
 
@@ -407,14 +411,14 @@ def scenario_duplicate_course_create(evidence: dict[str, Any], user: User, ride_
               and c.source_ride_record_id = {ride_record_id}
         ) s;
     """)
-    ok = len(course_ids) <= 1 and db["courseCount"] == 1 and not has_unexpected_5xx(results)
+    ok = all_status(results, 200) and len(course_ids) == 1 and db["courseCount"] == 1
     evidence["duplicateCourseCreate"] = {
         "ok": ok,
         "rideRecordId": ride_record_id,
         "http": summarize_http(results),
         "distinctCourseIdsFromResponses": course_ids,
         "db": db,
-        "expected": "같은 sourceRideRecordId는 코스 1건만 생성되고 나머지는 계약된 4xx로 끝나야 함",
+        "expected": "같은 sourceRideRecordId 동시 코스 생성은 모든 응답이 200이고 같은 courseId를 반환해야 하며 DB courses 1건만 남아야 함",
     }
     return course_ids[0] if course_ids else None
 
@@ -531,7 +535,8 @@ def websocket_handshake(base_url: str, party_id: int, token: str) -> dict[str, A
     host = parsed.hostname or "127.0.0.1"
     port = parsed.port or (443 if secure else 80)
     key = base64.b64encode(os.urandom(16)).decode()
-    path = f"/ws/v1/parties/{party_id}/locations"
+    encoded_token = urllib.parse.quote(token, safe="")
+    path = f"/ws/v1/parties/{party_id}/locations?socketToken={encoded_token}"
     request_text = (
         f"GET {path} HTTP/1.1\r\n"
         f"Host: {host}:{port}\r\n"
@@ -539,7 +544,6 @@ def websocket_handshake(base_url: str, party_id: int, token: str) -> dict[str, A
         "Connection: Upgrade\r\n"
         f"Sec-WebSocket-Key: {key}\r\n"
         "Sec-WebSocket-Version: 13\r\n"
-        f"Authorization: Bearer {token}\r\n"
         "\r\n"
     )
     started = time.perf_counter()

--- a/src/main/java/com/bikeprojectminji/bikeback/course/service/CourseService.java
+++ b/src/main/java/com/bikeprojectminji/bikeback/course/service/CourseService.java
@@ -21,6 +21,7 @@ import com.bikeprojectminji.bikeback.auth.entity.UserEntity;
 import com.bikeprojectminji.bikeback.global.exception.BadRequestException;
 import com.bikeprojectminji.bikeback.global.exception.ForbiddenException;
 import com.bikeprojectminji.bikeback.global.exception.NotFoundException;
+import com.bikeprojectminji.bikeback.global.idempotency.IdempotencyLockService;
 import com.bikeprojectminji.bikeback.global.metrics.MeasuredOperation;
 import com.bikeprojectminji.bikeback.global.validation.CoordinateValidator;
 import java.math.RoundingMode;
@@ -34,14 +35,24 @@ import java.math.BigDecimal;
 import java.util.List;
 import java.util.Comparator;
 import java.util.HashSet;
+import java.util.Optional;
+import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
+import java.time.Duration;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionOperations;
 
 @Service
 @Transactional
 public class CourseService {
+
+    private static final Duration COURSE_FROM_RIDE_IDEMPOTENCY_WAIT_TIMEOUT = Duration.ofSeconds(8);
+    private static final Duration COURSE_FROM_RIDE_IDEMPOTENCY_MIN_WAIT_INTERVAL = Duration.ofMillis(300);
+    private static final Duration COURSE_FROM_RIDE_IDEMPOTENCY_MAX_WAIT_INTERVAL = Duration.ofMillis(500);
 
     private final CourseRepository courseRepository;
     private final CourseRouteGeometryRepository courseRouteGeometryRepository;
@@ -51,6 +62,8 @@ public class CourseService {
     private final AuthService authService;
     private final CourseRouteSnapshotService courseRouteSnapshotService;
     private final AchievementCompletionDispatcher achievementCompletionDispatcher;
+    private final TransactionOperations transactionOperations;
+    private final IdempotencyLockService idempotencyLockService;
     private final CourseAccessPolicy courseAccessPolicy = new CourseAccessPolicy();
     private final GpxTrackParser gpxTrackParser = new GpxTrackParser();
 
@@ -62,7 +75,9 @@ public class CourseService {
             RideRecordProcessedPointRepository rideRecordProcessedPointRepository,
             AuthService authService,
             CourseRouteSnapshotService courseRouteSnapshotService,
-            AchievementCompletionDispatcher achievementCompletionDispatcher
+            AchievementCompletionDispatcher achievementCompletionDispatcher,
+            TransactionOperations transactionOperations,
+            IdempotencyLockService idempotencyLockService
     ) {
         this.courseRepository = courseRepository;
         this.courseRouteGeometryRepository = courseRouteGeometryRepository;
@@ -72,23 +87,59 @@ public class CourseService {
         this.authService = authService;
         this.courseRouteSnapshotService = courseRouteSnapshotService;
         this.achievementCompletionDispatcher = achievementCompletionDispatcher;
+        this.transactionOperations = transactionOperations;
+        this.idempotencyLockService = idempotencyLockService;
     }
 
     @MeasuredOperation("course.write.from_ride_record")
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
     public CourseWriteResponse createCourseFromRideRecord(String subject, CreateCourseFromRideRecordRequest request) {
         // 코스 생성은 사용자가 소유한 ride record를 읽어 route point를 course route point로 복제하는 방식이다.
         // 즉 ride 기록과 course는 source of truth를 공유하지 않고, 생성 시점에 복사본을 만든다.
         validateCreateRequest(request);
+        Long ownerUserId = resolveOwnerUserIdForIdempotency(subject);
+        return idempotencyLockService.executeOrWaitAfterContention(
+                "course_from_ride",
+                courseFromRideIdempotencyKey(ownerUserId, request.sourceRideRecordId()),
+                COURSE_FROM_RIDE_IDEMPOTENCY_WAIT_TIMEOUT,
+                COURSE_FROM_RIDE_IDEMPOTENCY_MIN_WAIT_INTERVAL,
+                COURSE_FROM_RIDE_IDEMPOTENCY_MAX_WAIT_INTERVAL,
+                () -> findExistingSourceCourseResponse(ownerUserId, request.sourceRideRecordId()),
+                () -> createCourseFromRideRecordWithDuplicateRecovery(subject, ownerUserId, request)
+        );
+    }
+
+    private CourseWriteResponse createCourseFromRideRecordWithDuplicateRecovery(String subject, Long ownerUserId, CreateCourseFromRideRecordRequest request) {
         UserEntity user = authService.findUserBySubject(subject);
+        if (!Objects.equals(user.getId(), ownerUserId)) {
+            throw new NotFoundException("자유 주행 기록을 찾을 수 없습니다.");
+        }
         RideRecordEntity rideRecord = rideRecordRepository.findByIdAndOwnerUserId(request.sourceRideRecordId(), user.getId())
                 .orElseThrow(() -> new NotFoundException("자유 주행 기록을 찾을 수 없습니다."));
         if (rideRecord.getFinalizationStatus() != RideRecordFinalizationStatus.READY) {
             throw new BadRequestException("경로 보정이 아직 완료되지 않았습니다. 잠시 후 다시 시도해 주세요.");
         }
-        courseRepository.findTopByOwnerUserIdAndSourceRideRecordIdOrderByIdDesc(user.getId(), rideRecord.getId())
-                .ifPresent(course -> {
-                    throw new BadRequestException("이미 코스로 저장된 자유 주행 기록입니다.");
-                });
+        try {
+            return requireTransactionResponse(transactionOperations.execute(status -> createCourseFromRideRecord(user, rideRecord, request)));
+        } catch (DataIntegrityViolationException exception) {
+            return findExistingSourceCourseResponse(user.getId(), rideRecord.getId())
+                    .orElseThrow(() -> exception);
+        }
+    }
+
+    private Long resolveOwnerUserIdForIdempotency(String subject) {
+        try {
+            return Long.valueOf(subject);
+        } catch (NumberFormatException exception) {
+            return authService.findUserBySubject(subject).getId();
+        }
+    }
+
+    private CourseWriteResponse createCourseFromRideRecord(UserEntity user, RideRecordEntity rideRecord, CreateCourseFromRideRecordRequest request) {
+        Optional<CourseWriteResponse> existingResponse = findExistingSourceCourseResponse(user.getId(), rideRecord.getId());
+        if (existingResponse.isPresent()) {
+            return existingResponse.get();
+        }
         List<RideRecordProcessedPointEntity> rideRecordPoints = rideRecordProcessedPointRepository.findByRideRecordIdOrderByPointOrderAsc(rideRecord.getId());
         if (rideRecordPoints.isEmpty()) {
             throw new BadRequestException("최종 경로가 비어 있어 코스를 생성할 수 없습니다.");
@@ -110,6 +161,7 @@ public class CourseService {
                 visibility
         );
         CourseEntity savedCourse = courseRepository.save(course);
+        courseRepository.flush();
 
         List<CourseRoutePointEntity> courseRoutePoints = rideRecordPoints.stream()
                 .map(point -> new CourseRoutePointEntity(savedCourse.getId(), point.getPointOrder(), point.getLatitude(), point.getLongitude()))
@@ -274,6 +326,22 @@ public class CourseService {
         } catch (IllegalArgumentException exception) {
             throw new BadRequestException("visibility는 PRIVATE, UNLISTED, PUBLIC 중 하나여야 합니다.");
         }
+    }
+
+    private Optional<CourseWriteResponse> findExistingSourceCourseResponse(Long ownerUserId, Long sourceRideRecordId) {
+        return courseRepository.findTopByOwnerUserIdAndSourceRideRecordIdOrderByIdDesc(ownerUserId, sourceRideRecordId)
+                .map(this::toCourseWriteResponse);
+    }
+
+    private String courseFromRideIdempotencyKey(Long ownerUserId, Long sourceRideRecordId) {
+        if (ownerUserId == null || sourceRideRecordId == null) {
+            return null;
+        }
+        return "course-from-ride:" + ownerUserId + ":" + sourceRideRecordId;
+    }
+
+    private CourseWriteResponse requireTransactionResponse(CourseWriteResponse response) {
+        return Objects.requireNonNull(response, "course transaction response must not be null");
     }
 
     private int resolveNextDisplayOrder() {

--- a/src/main/java/com/bikeprojectminji/bikeback/global/config/SecurityConfig.java
+++ b/src/main/java/com/bikeprojectminji/bikeback/global/config/SecurityConfig.java
@@ -69,6 +69,7 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.POST, "/api/v1/ai-routes/plan/from-text").permitAll()
                         .requestMatchers("/api/v1/ai-route-sessions/**").authenticated()
                         .requestMatchers("/ws/v1/ai-routes/**").authenticated()
+                        .requestMatchers("/ws/v1/parties/**").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/v1/courses").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/v1/courses/featured").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/v1/courses/search").permitAll()

--- a/src/main/java/com/bikeprojectminji/bikeback/global/idempotency/IdempotencyLockService.java
+++ b/src/main/java/com/bikeprojectminji/bikeback/global/idempotency/IdempotencyLockService.java
@@ -1,0 +1,250 @@
+package com.bikeprojectminji.bikeback.global.idempotency;
+
+import com.bikeprojectminji.bikeback.global.exception.ServiceUnavailableException;
+import com.bikeprojectminji.bikeback.global.metrics.BikeMetricsRecorder;
+import java.time.Duration;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.function.Supplier;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.script.RedisScript;
+import org.springframework.stereotype.Component;
+
+@Component
+public class IdempotencyLockService {
+
+    private static final Logger log = LoggerFactory.getLogger(IdempotencyLockService.class);
+    private static final String KEY_PREFIX = "bike:idempotency-lock:";
+    private static final Duration DEFAULT_LOCK_TTL = Duration.ofSeconds(10);
+    private static final Duration DEFAULT_WAIT_TIMEOUT = Duration.ofSeconds(2);
+    private static final Duration DEFAULT_MIN_WAIT_INTERVAL = Duration.ofMillis(50);
+    private static final Duration DEFAULT_MAX_WAIT_INTERVAL = Duration.ofMillis(100);
+    private static final String BACKPRESSURE_MESSAGE = "같은 요청이 처리 중입니다. 잠시 후 다시 시도해 주세요.";
+    private static final RedisScript<Long> RELEASE_SCRIPT = RedisScript.of("""
+            if redis.call('GET', KEYS[1]) == ARGV[1] then
+                return redis.call('DEL', KEYS[1])
+            end
+            return 0
+            """, Long.class);
+
+    private final StringRedisTemplate stringRedisTemplate;
+    private final BikeMetricsRecorder bikeMetricsRecorder;
+    private final Duration lockTtl;
+    private final Duration waitTimeout;
+    private final Duration minWaitInterval;
+    private final Duration maxWaitInterval;
+    private final Supplier<String> lockTokenSupplier;
+
+    @Autowired
+    public IdempotencyLockService(StringRedisTemplate stringRedisTemplate, BikeMetricsRecorder bikeMetricsRecorder) {
+        this(
+                stringRedisTemplate,
+                bikeMetricsRecorder,
+                DEFAULT_LOCK_TTL,
+                DEFAULT_WAIT_TIMEOUT,
+                DEFAULT_MIN_WAIT_INTERVAL,
+                DEFAULT_MAX_WAIT_INTERVAL,
+                () -> UUID.randomUUID().toString()
+        );
+    }
+
+    IdempotencyLockService(
+            StringRedisTemplate stringRedisTemplate,
+            BikeMetricsRecorder bikeMetricsRecorder,
+            Duration lockTtl,
+            Duration waitTimeout,
+            Duration minWaitInterval,
+            Duration maxWaitInterval,
+            Supplier<String> lockTokenSupplier
+    ) {
+        this.stringRedisTemplate = stringRedisTemplate;
+        this.bikeMetricsRecorder = bikeMetricsRecorder;
+        this.lockTtl = normalizePositive(lockTtl, DEFAULT_LOCK_TTL);
+        this.waitTimeout = normalizeNonNegative(waitTimeout, DEFAULT_WAIT_TIMEOUT);
+        this.minWaitInterval = normalizePositive(minWaitInterval, DEFAULT_MIN_WAIT_INTERVAL);
+        this.maxWaitInterval = normalizePositive(maxWaitInterval, DEFAULT_MAX_WAIT_INTERVAL);
+        this.lockTokenSupplier = lockTokenSupplier;
+    }
+
+    public <T> T executeOrWait(
+            String operation,
+            String key,
+            Supplier<Optional<T>> existingLookup,
+            Supplier<T> creator
+    ) {
+        return executeOrWait(operation, key, waitTimeout, existingLookup, creator);
+    }
+
+    public <T> T executeOrWait(
+            String operation,
+            String key,
+            Duration waitTimeout,
+            Supplier<Optional<T>> existingLookup,
+            Supplier<T> creator
+    ) {
+        return executeOrWait(operation, key, waitTimeout, minWaitInterval, maxWaitInterval, existingLookup, creator);
+    }
+
+    public <T> T executeOrWait(
+            String operation,
+            String key,
+            Duration waitTimeout,
+            Duration minWaitInterval,
+            Duration maxWaitInterval,
+            Supplier<Optional<T>> existingLookup,
+            Supplier<T> creator
+    ) {
+        return executeOrWaitInternal(operation, key, waitTimeout, minWaitInterval, maxWaitInterval, true, existingLookup, creator);
+    }
+
+    public <T> T executeOrWaitAfterContention(
+            String operation,
+            String key,
+            Supplier<Optional<T>> existingLookup,
+            Supplier<T> creator
+    ) {
+        return executeOrWaitInternal(operation, key, waitTimeout, minWaitInterval, maxWaitInterval, false, existingLookup, creator);
+    }
+
+    public <T> T executeOrWaitAfterContention(
+            String operation,
+            String key,
+            Duration waitTimeout,
+            Duration minWaitInterval,
+            Duration maxWaitInterval,
+            Supplier<Optional<T>> existingLookup,
+            Supplier<T> creator
+    ) {
+        return executeOrWaitInternal(operation, key, waitTimeout, minWaitInterval, maxWaitInterval, false, existingLookup, creator);
+    }
+
+    private <T> T executeOrWaitInternal(
+            String operation,
+            String key,
+            Duration waitTimeout,
+            Duration minWaitInterval,
+            Duration maxWaitInterval,
+            boolean lookupBeforeLock,
+            Supplier<Optional<T>> existingLookup,
+            Supplier<T> creator
+    ) {
+        if (lookupBeforeLock) {
+            Optional<T> existing = existingLookup.get();
+            if (existing.isPresent()) {
+                record(operation, "existing_before_lock");
+                return existing.get();
+            }
+        }
+        if (key == null || key.isBlank()) {
+            record(operation, "missing_key");
+            return creator.get();
+        }
+
+        String redisKey = KEY_PREFIX + key;
+        String token = lockTokenSupplier.get();
+        if (!tryAcquire(operation, redisKey, token)) {
+            return waitForExisting(
+                    operation,
+                    normalizeNonNegative(waitTimeout, this.waitTimeout),
+                    normalizePositive(minWaitInterval, this.minWaitInterval),
+                    normalizePositive(maxWaitInterval, this.maxWaitInterval),
+                    existingLookup
+            );
+        }
+
+        try {
+            return creator.get();
+        } finally {
+            release(operation, redisKey, token);
+        }
+    }
+
+    private boolean tryAcquire(String operation, String redisKey, String token) {
+        try {
+            Boolean acquired = stringRedisTemplate.opsForValue().setIfAbsent(redisKey, token, lockTtl);
+            if (Boolean.TRUE.equals(acquired)) {
+                record(operation, "acquired");
+                return true;
+            }
+            record(operation, "contended");
+            return false;
+        } catch (RuntimeException exception) {
+            log.warn("idempotency_lock_redis_unavailable operation={} key={}", operation, redisKey, exception);
+            record(operation, "redis_unavailable");
+            return true;
+        }
+    }
+
+    private <T> T waitForExisting(
+            String operation,
+            Duration waitTimeout,
+            Duration minWaitInterval,
+            Duration maxWaitInterval,
+            Supplier<Optional<T>> existingLookup
+    ) {
+        long startedNanos = System.nanoTime();
+        long deadlineNanos = startedNanos + waitTimeout.toNanos();
+        while (System.nanoTime() <= deadlineNanos) {
+            sleepBeforeRetry(operation, minWaitInterval, maxWaitInterval);
+            Optional<T> existing = existingLookup.get();
+            if (existing.isPresent()) {
+                Duration waited = Duration.ofNanos(System.nanoTime() - startedNanos);
+                bikeMetricsRecorder.recordIdempotencyLockWaitDuration(operation, "existing_found", waited);
+                record(operation, "existing_after_wait");
+                return existing.get();
+            }
+        }
+        Duration waited = Duration.ofNanos(System.nanoTime() - startedNanos);
+        bikeMetricsRecorder.recordIdempotencyLockWaitDuration(operation, "timeout", waited);
+        record(operation, "wait_timeout");
+        throw new ServiceUnavailableException(BACKPRESSURE_MESSAGE);
+    }
+
+    private void sleepBeforeRetry(String operation, Duration minWaitInterval, Duration maxWaitInterval) {
+        long minMillis = Math.max(1, minWaitInterval.toMillis());
+        long maxMillis = Math.max(minMillis, maxWaitInterval.toMillis());
+        long sleepMillis = minMillis == maxMillis
+                ? minMillis
+                : ThreadLocalRandom.current().nextLong(minMillis, maxMillis + 1);
+        try {
+            Thread.sleep(sleepMillis);
+        } catch (InterruptedException exception) {
+            Thread.currentThread().interrupt();
+            record(operation, "interrupted");
+            throw new ServiceUnavailableException(BACKPRESSURE_MESSAGE);
+        }
+    }
+
+    private void release(String operation, String redisKey, String token) {
+        try {
+            stringRedisTemplate.execute(RELEASE_SCRIPT, List.of(redisKey), token);
+            record(operation, "released");
+        } catch (RuntimeException exception) {
+            log.warn("idempotency_lock_release_failed operation={} key={}", operation, redisKey, exception);
+            record(operation, "release_failed");
+        }
+    }
+
+    private void record(String operation, String outcome) {
+        bikeMetricsRecorder.recordIdempotencyLock(operation, outcome);
+    }
+
+    private Duration normalizePositive(Duration value, Duration fallback) {
+        if (value == null || value.isZero() || value.isNegative()) {
+            return fallback;
+        }
+        return value;
+    }
+
+    private Duration normalizeNonNegative(Duration value, Duration fallback) {
+        if (value == null || value.isNegative()) {
+            return fallback;
+        }
+        return value;
+    }
+}

--- a/src/main/java/com/bikeprojectminji/bikeback/global/metrics/BikeMetricsRecorder.java
+++ b/src/main/java/com/bikeprojectminji/bikeback/global/metrics/BikeMetricsRecorder.java
@@ -158,6 +158,22 @@ public class BikeMetricsRecorder {
         ).increment();
     }
 
+    public void recordIdempotencyLock(String operation, String outcome) {
+        meterRegistry.counter(
+                "bike_idempotency_lock_total",
+                "operation", normalize(operation),
+                "outcome", normalize(outcome)
+        ).increment();
+    }
+
+    public void recordIdempotencyLockWaitDuration(String operation, String outcome, Duration duration) {
+        meterRegistry.timer(
+                "bike_idempotency_lock_wait_duration",
+                "operation", normalize(operation),
+                "outcome", normalize(outcome)
+        ).record(duration);
+    }
+
     public void recordOperationDuration(String operation, String outcome, Duration duration) {
         Timer.builder("bike_operation_duration")
                 .tag("operation", normalize(operation))

--- a/src/main/java/com/bikeprojectminji/bikeback/party/websocket/RidePartyLocationWebSocketHandler.java
+++ b/src/main/java/com/bikeprojectminji/bikeback/party/websocket/RidePartyLocationWebSocketHandler.java
@@ -7,13 +7,14 @@ import com.bikeprojectminji.bikeback.party.service.RidePartySocketTokenPayload;
 import com.bikeprojectminji.bikeback.party.service.RidePartySocketTokenService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.net.URI;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.time.OffsetDateTime;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Component;
 import org.springframework.web.socket.CloseStatus;
 import org.springframework.web.socket.TextMessage;
@@ -44,7 +45,7 @@ public class RidePartyLocationWebSocketHandler extends TextWebSocketHandler {
     @Override
     public void afterConnectionEstablished(WebSocketSession session) throws Exception {
         Long partyId = extractPartyId(session.getUri());
-        Optional<RidePartySocketTokenPayload> token = socketTokenService.consume(bearerToken(session.getHandshakeHeaders()), partyId);
+        Optional<RidePartySocketTokenPayload> token = socketTokenService.consume(socketToken(session.getUri()), partyId);
         if (token.isEmpty()) {
             session.close(CloseStatus.POLICY_VIOLATION.withReason("invalid party socket token"));
             return;
@@ -116,12 +117,24 @@ public class RidePartyLocationWebSocketHandler extends TextWebSocketHandler {
         return new TextMessage(objectMapper.writeValueAsString(payload));
     }
 
-    private String bearerToken(HttpHeaders headers) {
-        String authorization = headers.getFirst(HttpHeaders.AUTHORIZATION);
-        if (authorization == null || !authorization.startsWith("Bearer ")) {
+    private String socketToken(URI uri) {
+        if (uri == null || uri.getRawQuery() == null || uri.getRawQuery().isBlank()) {
             return "";
         }
-        return authorization.substring("Bearer ".length()).trim();
+        for (String pair : uri.getRawQuery().split("&")) {
+            int separator = pair.indexOf('=');
+            String name = separator >= 0 ? pair.substring(0, separator) : pair;
+            if (!"socketToken".equals(urlDecode(name))) {
+                continue;
+            }
+            String value = separator >= 0 ? pair.substring(separator + 1) : "";
+            return urlDecode(value).trim();
+        }
+        return "";
+    }
+
+    private String urlDecode(String value) {
+        return URLDecoder.decode(value, StandardCharsets.UTF_8);
     }
 
     private Long extractPartyId(URI uri) {

--- a/src/main/java/com/bikeprojectminji/bikeback/ride/service/RideRecordService.java
+++ b/src/main/java/com/bikeprojectminji/bikeback/ride/service/RideRecordService.java
@@ -6,6 +6,7 @@ import com.bikeprojectminji.bikeback.course.repository.CourseRepository;
 import com.bikeprojectminji.bikeback.global.exception.BadRequestException;
 import com.bikeprojectminji.bikeback.global.exception.ConflictException;
 import com.bikeprojectminji.bikeback.global.exception.NotFoundException;
+import com.bikeprojectminji.bikeback.global.idempotency.IdempotencyLockService;
 import com.bikeprojectminji.bikeback.global.metrics.MeasuredOperation;
 import com.bikeprojectminji.bikeback.location.service.RecentLocationCacheService;
 import com.bikeprojectminji.bikeback.ride.dto.CreateRideRecordRequest;
@@ -25,12 +26,17 @@ import java.time.OffsetDateTime;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.Objects;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.support.TransactionSynchronization;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionOperations;
 
 @Service
 public class RideRecordService {
@@ -43,6 +49,8 @@ public class RideRecordService {
     private final RideRecordPointRepository rideRecordPointRepository;
     private final RecentLocationCacheService recentLocationCacheService;
     private final RideRecordFinalizationService rideRecordFinalizationService;
+    private final TransactionOperations transactionOperations;
+    private final IdempotencyLockService idempotencyLockService;
 
     public RideRecordService(
             AuthService authService,
@@ -50,7 +58,9 @@ public class RideRecordService {
             RideRecordRepository rideRecordRepository,
             RideRecordPointRepository rideRecordPointRepository,
             RecentLocationCacheService recentLocationCacheService,
-            RideRecordFinalizationService rideRecordFinalizationService
+            RideRecordFinalizationService rideRecordFinalizationService,
+            TransactionOperations transactionOperations,
+            IdempotencyLockService idempotencyLockService
     ) {
         this.authService = authService;
         this.courseRepository = courseRepository;
@@ -58,30 +68,39 @@ public class RideRecordService {
         this.rideRecordPointRepository = rideRecordPointRepository;
         this.recentLocationCacheService = recentLocationCacheService;
         this.rideRecordFinalizationService = rideRecordFinalizationService;
+        this.transactionOperations = transactionOperations;
+        this.idempotencyLockService = idempotencyLockService;
     }
 
     @MeasuredOperation("ride.record.save_full")
-    @Transactional
     public RideRecordResponse saveRideRecord(String subject, CreateRideRecordRequest request) {
         // 자유 주행 저장은 입력 검증 -> 현재 사용자 식별 -> ride record 저장 -> route point 저장 순서로 진행한다.
         // point와 summary는 항상 DB가 원본이고, 캐시는 후속 조회 최적화 용도로만 갱신한다.
         RideRecordRequestValidator.validateCreateRequest(request);
         UserEntity user = authService.findUserBySubject(subject);
         String clientRideId = normalizeClientRideId(request.clientRideId());
-        if (clientRideId != null) {
-            java.util.Optional<RideRecordEntity> existingRideRecord = rideRecordRepository.findByOwnerUserIdAndClientRideId(user.getId(), clientRideId);
-            if (existingRideRecord.isPresent()) {
-                RideRecordEntity existing = existingRideRecord.get();
-                long routePointCount = rideRecordPointRepository.countByRideRecordId(existing.getId());
-                return new RideRecordResponse(
-                        existing.getId(),
-                        existing.getOwnerUserId(),
-                        Math.toIntExact(routePointCount),
-                        existing.getFinalizationStatus().name()
-                );
-            }
-        }
+        return idempotencyLockService.executeOrWait(
+                "ride_record_save_full",
+                rideRecordIdempotencyKey(user.getId(), clientRideId),
+                () -> findExistingRideRecordResponse(user.getId(), clientRideId),
+                () -> saveRideRecordWithDuplicateRecovery(subject, user, clientRideId, request)
+        );
+    }
 
+    private RideRecordResponse saveRideRecordWithDuplicateRecovery(String subject, UserEntity user, String clientRideId, CreateRideRecordRequest request) {
+        try {
+            return requireTransactionResponse(transactionOperations.execute(status -> createRideRecord(subject, user, clientRideId, request)));
+        } catch (DataIntegrityViolationException exception) {
+            return findExistingRideRecordResponse(user.getId(), clientRideId)
+                    .orElseThrow(() -> exception);
+        }
+    }
+
+    private RideRecordResponse createRideRecord(String subject, UserEntity user, String clientRideId, CreateRideRecordRequest request) {
+        Optional<RideRecordResponse> existingResponse = findExistingRideRecordResponse(user.getId(), clientRideId);
+        if (existingResponse.isPresent()) {
+            return existingResponse.get();
+        }
         RideRecordEntity rideRecord = rideRecordRepository.save(new RideRecordEntity(
                 user.getId(),
                 clientRideId,
@@ -90,6 +109,7 @@ public class RideRecordService {
                 request.summary().distanceM(),
                 request.summary().durationSec()
         ));
+        rideRecordRepository.flush();
 
         rideRecord.markFinalizing(OffsetDateTime.now());
         rideRecord = rideRecordRepository.save(rideRecord);
@@ -107,26 +127,33 @@ public class RideRecordService {
     }
 
     @MeasuredOperation("ride.record.save_summary")
-    @Transactional
     public RideRecordResponse saveRideRecordSummary(String subject, CreateRideRecordSummaryRequest request) {
         // 웹 HUD 기본 저장은 요약만 남긴다. trace가 없으면 후처리 대상 raw point가 없어 finalization을 시작하지 않는다.
         RideRecordRequestValidator.validateSummaryRequest(request);
         UserEntity user = authService.findUserBySubject(subject);
         String clientRideId = normalizeClientRideId(request.clientRideId());
-        if (clientRideId != null) {
-            java.util.Optional<RideRecordEntity> existingRideRecord = rideRecordRepository.findByOwnerUserIdAndClientRideId(user.getId(), clientRideId);
-            if (existingRideRecord.isPresent()) {
-                RideRecordEntity existing = existingRideRecord.get();
-                long routePointCount = rideRecordPointRepository.countByRideRecordId(existing.getId());
-                return new RideRecordResponse(
-                        existing.getId(),
-                        existing.getOwnerUserId(),
-                        Math.toIntExact(routePointCount),
-                        existing.getFinalizationStatus().name()
-                );
-            }
-        }
+        return idempotencyLockService.executeOrWait(
+                "ride_record_save_summary",
+                rideRecordIdempotencyKey(user.getId(), clientRideId),
+                () -> findExistingRideRecordResponse(user.getId(), clientRideId),
+                () -> saveRideRecordSummaryWithDuplicateRecovery(user, clientRideId, request)
+        );
+    }
 
+    private RideRecordResponse saveRideRecordSummaryWithDuplicateRecovery(UserEntity user, String clientRideId, CreateRideRecordSummaryRequest request) {
+        try {
+            return requireTransactionResponse(transactionOperations.execute(status -> createRideRecordSummary(user, clientRideId, request)));
+        } catch (DataIntegrityViolationException exception) {
+            return findExistingRideRecordResponse(user.getId(), clientRideId)
+                    .orElseThrow(() -> exception);
+        }
+    }
+
+    private RideRecordResponse createRideRecordSummary(UserEntity user, String clientRideId, CreateRideRecordSummaryRequest request) {
+        Optional<RideRecordResponse> existingResponse = findExistingRideRecordResponse(user.getId(), clientRideId);
+        if (existingResponse.isPresent()) {
+            return existingResponse.get();
+        }
         RideRecordEntity rideRecord = rideRecordRepository.save(new RideRecordEntity(
                 user.getId(),
                 clientRideId,
@@ -135,6 +162,7 @@ public class RideRecordService {
                 request.summary().distanceM(),
                 request.summary().durationSec()
         ));
+        rideRecordRepository.flush();
 
         return new RideRecordResponse(rideRecord.getId(), user.getId(), 0, rideRecord.getFinalizationStatus().name());
     }
@@ -189,35 +217,32 @@ public class RideRecordService {
         UserEntity user = authService.findUserBySubject(subject);
         RideRecordEntity rideRecord = rideRecordRepository.findByIdAndOwnerUserId(rideRecordId, user.getId())
                 .orElseThrow(() -> new NotFoundException("자유 주행 기록을 찾을 수 없습니다."));
-        RideRecordFinalizationStatusResponse status = rideRecordFinalizationService.getStatus(rideRecord);
-
-        return new RideRecordFinalizationStatusResponse(
-                status.rideRecordId(),
-                status.status(),
-                status.rawPointCount(),
-                status.processedPointCount(),
-                status.finalizationAttempts(),
-                status.errorMessage(),
-                rideRecord.getStartedAt(),
-                rideRecord.getEndedAt(),
-                rideRecord.getDistanceM(),
-                rideRecord.getDurationSec(),
-                findLinkedCourseId(user.getId(), rideRecord.getId())
-        );
+        return toRideRecordFinalizationStatusResponse(user.getId(), rideRecord);
     }
 
     @MeasuredOperation("ride.record.regenerate")
-    @Transactional
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
     public RideRecordFinalizationStatusResponse regenerateRideRecord(String subject, Long rideRecordId) {
         UserEntity user = authService.findUserBySubject(subject);
-        RideRecordEntity rideRecord = rideRecordRepository.findByIdAndOwnerUserId(rideRecordId, user.getId())
-                .orElseThrow(() -> new NotFoundException("자유 주행 기록을 찾을 수 없습니다."));
-        if (rideRecordPointRepository.countByRideRecordId(rideRecordId) == 0) {
-            throw new BadRequestException("trace가 없는 자유 주행 기록은 재처리할 수 없습니다.");
-        }
-        rideRecordFinalizationService.markForRegeneration(rideRecord);
-        registerFinalizationAfterCommit(rideRecordId);
-        return rideRecordFinalizationService.getStatus(rideRecord);
+        return idempotencyLockService.executeOrWaitAfterContention(
+                "ride_record_regenerate",
+                rideRecordRegenerateIdempotencyKey(user.getId(), rideRecordId),
+                () -> findRideRecordStatusResponse(user.getId(), rideRecordId),
+                () -> regenerateRideRecordWithLock(user.getId(), rideRecordId)
+        );
+    }
+
+    private RideRecordFinalizationStatusResponse regenerateRideRecordWithLock(Long ownerUserId, Long rideRecordId) {
+        return requireFinalizationTransactionResponse(transactionOperations.execute(status -> {
+            RideRecordEntity rideRecord = rideRecordRepository.findByIdAndOwnerUserId(rideRecordId, ownerUserId)
+                    .orElseThrow(() -> new NotFoundException("자유 주행 기록을 찾을 수 없습니다."));
+            if (rideRecordPointRepository.countByRideRecordId(rideRecordId) == 0) {
+                throw new BadRequestException("trace가 없는 자유 주행 기록은 재처리할 수 없습니다.");
+            }
+            rideRecordFinalizationService.markForRegeneration(rideRecord);
+            registerFinalizationAfterCommit(rideRecordId);
+            return toRideRecordFinalizationStatusResponse(ownerUserId, rideRecord);
+        }));
     }
 
     private void cacheLatestCompletedLocation(
@@ -247,6 +272,28 @@ public class RideRecordService {
                 .orElse(null);
     }
 
+    private Optional<RideRecordFinalizationStatusResponse> findRideRecordStatusResponse(Long ownerUserId, Long rideRecordId) {
+        return rideRecordRepository.findByIdAndOwnerUserId(rideRecordId, ownerUserId)
+                .map(rideRecord -> toRideRecordFinalizationStatusResponse(ownerUserId, rideRecord));
+    }
+
+    private RideRecordFinalizationStatusResponse toRideRecordFinalizationStatusResponse(Long ownerUserId, RideRecordEntity rideRecord) {
+        RideRecordFinalizationStatusResponse status = rideRecordFinalizationService.getStatus(rideRecord);
+        return new RideRecordFinalizationStatusResponse(
+                status.rideRecordId(),
+                status.status(),
+                status.rawPointCount(),
+                status.processedPointCount(),
+                status.finalizationAttempts(),
+                status.errorMessage(),
+                rideRecord.getStartedAt(),
+                rideRecord.getEndedAt(),
+                rideRecord.getDistanceM(),
+                rideRecord.getDurationSec(),
+                findLinkedCourseId(ownerUserId, rideRecord.getId())
+        );
+    }
+
     private Map<Long, Long> resolveLinkedCourseIds(Long ownerUserId, List<RideRecordEntity> rideRecords) {
         Map<Long, Long> linkedCourseIds = new HashMap<>();
         if (rideRecords.isEmpty()) {
@@ -271,6 +318,44 @@ public class RideRecordService {
             return null;
         }
         return clientRideId.trim();
+    }
+
+    private Optional<RideRecordResponse> findExistingRideRecordResponse(Long ownerUserId, String clientRideId) {
+        if (clientRideId == null) {
+            return Optional.empty();
+        }
+        return rideRecordRepository.findByOwnerUserIdAndClientRideId(ownerUserId, clientRideId)
+                .map(existing -> {
+                    long routePointCount = rideRecordPointRepository.countByRideRecordId(existing.getId());
+                    return new RideRecordResponse(
+                            existing.getId(),
+                            existing.getOwnerUserId(),
+                            Math.toIntExact(routePointCount),
+                            existing.getFinalizationStatus().name()
+                    );
+                });
+    }
+
+    private String rideRecordIdempotencyKey(Long ownerUserId, String clientRideId) {
+        if (ownerUserId == null || clientRideId == null) {
+            return null;
+        }
+        return "ride-record:" + ownerUserId + ":" + clientRideId;
+    }
+
+    private String rideRecordRegenerateIdempotencyKey(Long ownerUserId, Long rideRecordId) {
+        if (ownerUserId == null || rideRecordId == null) {
+            return null;
+        }
+        return "ride-record-regenerate:" + ownerUserId + ":" + rideRecordId;
+    }
+
+    private RideRecordResponse requireTransactionResponse(RideRecordResponse response) {
+        return Objects.requireNonNull(response, "ride record transaction response must not be null");
+    }
+
+    private RideRecordFinalizationStatusResponse requireFinalizationTransactionResponse(RideRecordFinalizationStatusResponse response) {
+        return Objects.requireNonNull(response, "ride record finalization transaction response must not be null");
     }
 
     private void registerFinalizationAfterCommit(Long rideRecordId) {

--- a/src/test/java/com/bikeprojectminji/bikeback/course/service/CourseServiceTest.java
+++ b/src/test/java/com/bikeprojectminji/bikeback/course/service/CourseServiceTest.java
@@ -4,7 +4,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
@@ -22,6 +24,7 @@ import com.bikeprojectminji.bikeback.ride.entity.RideRecordFinalizationStatus;
 import com.bikeprojectminji.bikeback.ride.entity.RideRecordProcessedPointEntity;
 import com.bikeprojectminji.bikeback.auth.entity.UserEntity;
 import com.bikeprojectminji.bikeback.global.exception.ForbiddenException;
+import com.bikeprojectminji.bikeback.global.idempotency.IdempotencyLockService;
 import com.bikeprojectminji.bikeback.global.exception.NotFoundException;
 import com.bikeprojectminji.bikeback.course.repository.CourseRepository;
 import com.bikeprojectminji.bikeback.course.repository.CourseRouteGeometryRepository;
@@ -33,6 +36,8 @@ import com.bikeprojectminji.bikeback.global.exception.BadRequestException;
 import java.math.BigDecimal;
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Supplier;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -40,7 +45,11 @@ import org.mockito.InjectMocks;
 import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.transaction.support.SimpleTransactionStatus;
+import org.springframework.transaction.support.TransactionCallback;
+import org.springframework.transaction.support.TransactionOperations;
 
 @ExtendWith(MockitoExtension.class)
 class CourseServiceTest {
@@ -69,8 +78,31 @@ class CourseServiceTest {
     @Mock
     private AchievementCompletionDispatcher achievementCompletionDispatcher;
 
+    @Mock
+    private TransactionOperations transactionOperations;
+
+    @Mock
+    private IdempotencyLockService idempotencyLockService;
+
     @InjectMocks
     private CourseService courseService;
+
+    @BeforeEach
+    void executeTransactionsInline() {
+        lenient().when(transactionOperations.execute(any())).thenAnswer(invocation -> {
+            TransactionCallback<?> callback = invocation.getArgument(0);
+            return callback.doInTransaction(new SimpleTransactionStatus());
+        });
+        lenient().when(idempotencyLockService.executeOrWaitAfterContention(any(), any(), any(), any(), any(), any(), any())).thenAnswer(invocation -> {
+            Supplier<Optional<?>> existingLookup = invocation.getArgument(5);
+            Optional<?> existing = existingLookup.get();
+            if (existing.isPresent()) {
+                return existing.get();
+            }
+            Supplier<?> creator = invocation.getArgument(6);
+            return creator.get();
+        });
+    }
 
     private List<CourseEntity> createCourses(int count) {
         return java.util.stream.IntStream.rangeClosed(1, count)
@@ -115,10 +147,69 @@ class CourseServiceTest {
         assertThat(response.visibility()).isEqualTo("PRIVATE");
         assertThat(response.sourceRideRecordId()).isEqualTo(1001L);
         assertThat(response.sourceDetached()).isFalse();
+        verify(idempotencyLockService).executeOrWaitAfterContention(
+                eq("course_from_ride"),
+                eq("course-from-ride:1:1001"),
+                eq(java.time.Duration.ofSeconds(8)),
+                eq(java.time.Duration.ofMillis(300)),
+                eq(java.time.Duration.ofMillis(500)),
+                any(),
+                any()
+        );
         InOrder inOrder = inOrder(courseRoutePointRepository, courseRouteGeometryRepository);
         inOrder.verify(courseRoutePointRepository).saveAll(any());
         inOrder.verify(courseRoutePointRepository).flush();
         inOrder.verify(courseRouteGeometryRepository).refreshRouteLine(2001L);
+    }
+
+    @Test
+    @DisplayName("기록 기반 코스 생성은 이미 저장된 sourceRideRecordId면 기존 코스를 200 응답으로 반환한다")
+    void createCourseFromRideRecordReturnsExistingCourseForDuplicateSourceRideRecord() {
+        CourseEntity existingCourse = new CourseEntity("기존 한강 코스", "설명", BigDecimal.valueOf(18.3), 60, 11, false, null, BigDecimal.valueOf(37.5665), BigDecimal.valueOf(126.9780), 1L, 1001L, CourseVisibility.PRIVATE);
+        ReflectionTestUtils.setField(existingCourse, "id", 2001L);
+
+        given(courseRepository.findTopByOwnerUserIdAndSourceRideRecordIdOrderByIdDesc(1L, 1001L))
+                .willReturn(Optional.of(existingCourse));
+
+        CourseWriteResponse response = courseService.createCourseFromRideRecord("1", new CreateCourseFromRideRecordRequest(1001L, "한강 코스", "설명", "PRIVATE"));
+
+        assertThat(response.courseId()).isEqualTo(2001L);
+        assertThat(response.sourceRideRecordId()).isEqualTo(1001L);
+        assertThat(response.visibility()).isEqualTo("PRIVATE");
+        verify(courseRoutePointRepository, never()).saveAll(any());
+        verify(courseRouteGeometryRepository, never()).refreshRouteLine(any());
+    }
+
+    @Test
+    @DisplayName("기록 기반 코스 생성은 같은 sourceRideRecordId 동시 생성 경쟁에서 기존 코스를 200 응답으로 복구한다")
+    void createCourseFromRideRecordReturnsExistingCourseAfterConcurrentSourceRideRecordRace() {
+        UserEntity user = new UserEntity(null, "bikeoasis@example.com", "encoded-password", "bikeoasis", null);
+        ReflectionTestUtils.setField(user, "id", 1L);
+        RideRecordEntity rideRecord = new RideRecordEntity(1L, java.time.OffsetDateTime.parse("2026-03-29T10:00:00+09:00"), java.time.OffsetDateTime.parse("2026-03-29T11:00:00+09:00"), 18250, 3600);
+        ReflectionTestUtils.setField(rideRecord, "id", 1001L);
+        rideRecord.markReady(java.time.OffsetDateTime.parse("2026-03-29T11:01:00+09:00"));
+        CourseEntity existingCourse = new CourseEntity("기존 한강 코스", "설명", BigDecimal.valueOf(18.3), 60, 11, false, null, BigDecimal.valueOf(37.5665), BigDecimal.valueOf(126.9780), 1L, 1001L, CourseVisibility.PRIVATE);
+        ReflectionTestUtils.setField(existingCourse, "id", 2001L);
+
+        given(authService.findUserBySubject("1")).willReturn(user);
+        given(rideRecordRepository.findByIdAndOwnerUserId(1001L, 1L)).willReturn(Optional.of(rideRecord));
+        given(courseRepository.findTopByOwnerUserIdAndSourceRideRecordIdOrderByIdDesc(1L, 1001L))
+                .willReturn(Optional.empty(), Optional.empty(), Optional.of(existingCourse));
+        given(rideRecordProcessedPointRepository.findByRideRecordIdOrderByPointOrderAsc(1001L)).willReturn(List.of(
+                new RideRecordProcessedPointEntity(1001L, 1, BigDecimal.valueOf(37.5665), BigDecimal.valueOf(126.9780)),
+                new RideRecordProcessedPointEntity(1001L, 2, BigDecimal.valueOf(37.5671), BigDecimal.valueOf(126.9792))
+        ));
+        given(courseRepository.findTopByOrderByDisplayOrderDescIdDesc()).willReturn(Optional.of(createCourses(10).get(9)));
+        given(courseRepository.save(any(CourseEntity.class)))
+                .willThrow(new DataIntegrityViolationException("uq_courses_owner_source_ride_record"));
+
+        CourseWriteResponse response = courseService.createCourseFromRideRecord("1", new CreateCourseFromRideRecordRequest(1001L, "한강 코스", "설명", "PRIVATE"));
+
+        assertThat(response.courseId()).isEqualTo(2001L);
+        assertThat(response.sourceRideRecordId()).isEqualTo(1001L);
+        assertThat(response.visibility()).isEqualTo("PRIVATE");
+        verify(courseRoutePointRepository, never()).saveAll(any());
+        verify(courseRouteGeometryRepository, never()).refreshRouteLine(any());
     }
 
     @Test

--- a/src/test/java/com/bikeprojectminji/bikeback/global/idempotency/IdempotencyLockServiceTest.java
+++ b/src/test/java/com/bikeprojectminji/bikeback/global/idempotency/IdempotencyLockServiceTest.java
@@ -1,0 +1,159 @@
+package com.bikeprojectminji.bikeback.global.idempotency;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.bikeprojectminji.bikeback.global.exception.ServiceUnavailableException;
+import com.bikeprojectminji.bikeback.global.metrics.BikeMetricsRecorder;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.time.Duration;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.data.redis.core.script.RedisScript;
+
+@SuppressWarnings({"rawtypes", "unchecked"})
+class IdempotencyLockServiceTest {
+
+    @Test
+    @DisplayName("idempotency lock은 기존 리소스가 있으면 Redis를 호출하지 않고 반환한다")
+    void returnsExistingWithoutRedisWhenResourceAlreadyExists() {
+        StringRedisTemplate redisTemplate = org.mockito.Mockito.mock(StringRedisTemplate.class);
+        IdempotencyLockService service = service(redisTemplate);
+
+        String result = service.executeOrWait(
+                "course_from_ride",
+                "course-from-ride:1:1001",
+                () -> Optional.of("existing-course"),
+                () -> "created-course"
+        );
+
+        assertThat(result).isEqualTo("existing-course");
+        verify(redisTemplate, never()).opsForValue();
+    }
+
+    @Test
+    @DisplayName("idempotency lock은 Redis lock을 얻은 요청만 creator를 실행하고 lock을 해제한다")
+    void executesCreatorWhenRedisLockIsAcquired() {
+        StringRedisTemplate redisTemplate = org.mockito.Mockito.mock(StringRedisTemplate.class);
+        ValueOperations<String, String> valueOperations = org.mockito.Mockito.mock(ValueOperations.class);
+        given(redisTemplate.opsForValue()).willReturn(valueOperations);
+        given(valueOperations.setIfAbsent(
+                eq("bike:idempotency-lock:course-from-ride:1:1001"),
+                eq("token-1"),
+                eq(Duration.ofSeconds(10))
+        )).willReturn(true);
+        IdempotencyLockService service = service(redisTemplate);
+
+        String result = service.executeOrWait(
+                "course_from_ride",
+                "course-from-ride:1:1001",
+                Optional::<String>empty,
+                () -> "created-course"
+        );
+
+        assertThat(result).isEqualTo("created-course");
+        verify(redisTemplate).execute(any(RedisScript.class), eq(List.of("bike:idempotency-lock:course-from-ride:1:1001")), eq("token-1"));
+    }
+
+    @Test
+    @DisplayName("idempotency lock은 lock 경쟁 중 기존 리소스가 보이면 200 응답 경로로 반환한다")
+    void waitsUntilExistingResourceAppearsWhenRedisLockIsContended() {
+        StringRedisTemplate redisTemplate = org.mockito.Mockito.mock(StringRedisTemplate.class);
+        ValueOperations<String, String> valueOperations = org.mockito.Mockito.mock(ValueOperations.class);
+        given(redisTemplate.opsForValue()).willReturn(valueOperations);
+        given(valueOperations.setIfAbsent(anyString(), anyString(), eq(Duration.ofSeconds(10)))).willReturn(false);
+        IdempotencyLockService service = service(redisTemplate);
+        AtomicInteger lookups = new AtomicInteger();
+
+        String result = service.executeOrWait(
+                "course_from_ride",
+                "course-from-ride:1:1001",
+                () -> lookups.incrementAndGet() < 3 ? Optional.empty() : Optional.of("existing-course"),
+                () -> "created-course"
+        );
+
+        assertThat(result).isEqualTo("existing-course");
+        assertThat(lookups.get()).isGreaterThanOrEqualTo(3);
+    }
+
+    @Test
+    @DisplayName("idempotency lock은 작업별 대기 시간이 주어지면 기본값 대신 해당 시간을 사용한다")
+    void usesOperationSpecificWaitTimeoutWhenProvided() {
+        StringRedisTemplate redisTemplate = org.mockito.Mockito.mock(StringRedisTemplate.class);
+        ValueOperations<String, String> valueOperations = org.mockito.Mockito.mock(ValueOperations.class);
+        given(redisTemplate.opsForValue()).willReturn(valueOperations);
+        given(valueOperations.setIfAbsent(anyString(), anyString(), eq(Duration.ofSeconds(10)))).willReturn(false);
+        IdempotencyLockService service = service(redisTemplate);
+        AtomicInteger lookups = new AtomicInteger();
+
+        String result = service.executeOrWait(
+                "course_from_ride",
+                "course-from-ride:1:1001",
+                Duration.ofMillis(30),
+                () -> lookups.incrementAndGet() < 8 ? Optional.empty() : Optional.of("existing-course"),
+                () -> "created-course"
+        );
+
+        assertThat(result).isEqualTo("existing-course");
+        assertThat(lookups.get()).isGreaterThanOrEqualTo(8);
+    }
+
+    @Test
+    @DisplayName("idempotency lock은 Redis 장애 시 DB unique fallback 경로로 creator를 실행한다")
+    void fallsBackToCreatorWhenRedisIsUnavailable() {
+        StringRedisTemplate redisTemplate = org.mockito.Mockito.mock(StringRedisTemplate.class);
+        given(redisTemplate.opsForValue()).willThrow(new IllegalStateException("redis down"));
+        IdempotencyLockService service = service(redisTemplate);
+
+        String result = service.executeOrWait(
+                "course_from_ride",
+                "course-from-ride:1:1001",
+                Optional::<String>empty,
+                () -> "created-course"
+        );
+
+        assertThat(result).isEqualTo("created-course");
+    }
+
+    @Test
+    @DisplayName("idempotency lock은 대기 시간 안에 기존 리소스를 찾지 못하면 503으로 빠진다")
+    void throwsServiceUnavailableWhenExistingResourceDoesNotAppear() {
+        StringRedisTemplate redisTemplate = org.mockito.Mockito.mock(StringRedisTemplate.class);
+        ValueOperations<String, String> valueOperations = org.mockito.Mockito.mock(ValueOperations.class);
+        given(redisTemplate.opsForValue()).willReturn(valueOperations);
+        given(valueOperations.setIfAbsent(anyString(), anyString(), eq(Duration.ofSeconds(10)))).willReturn(false);
+        IdempotencyLockService service = service(redisTemplate);
+
+        assertThatThrownBy(() -> service.executeOrWait(
+                "course_from_ride",
+                "course-from-ride:1:1001",
+                Optional::<String>empty,
+                () -> "created-course"
+        ))
+                .isInstanceOf(ServiceUnavailableException.class)
+                .hasMessage("같은 요청이 처리 중입니다. 잠시 후 다시 시도해 주세요.");
+    }
+
+    private IdempotencyLockService service(StringRedisTemplate redisTemplate) {
+        return new IdempotencyLockService(
+                redisTemplate,
+                new BikeMetricsRecorder(new SimpleMeterRegistry()),
+                Duration.ofSeconds(10),
+                Duration.ofMillis(5),
+                Duration.ofMillis(1),
+                Duration.ofMillis(1),
+                () -> "token-1"
+        );
+    }
+}

--- a/src/test/java/com/bikeprojectminji/bikeback/global/metrics/BikeMetricsRecorderTest.java
+++ b/src/test/java/com/bikeprojectminji/bikeback/global/metrics/BikeMetricsRecorderTest.java
@@ -40,6 +40,8 @@ class BikeMetricsRecorderTest {
         recorder.recordRoutingProviderFailure("GraphHopper", "http_429");
         recorder.recordProviderCall("GraphHopper", "route", "success", java.time.Duration.ofMillis(35));
         recorder.recordDatabaseBackpressureRejected("pool_exhausted");
+        recorder.recordIdempotencyLock("course_from_ride", "acquired");
+        recorder.recordIdempotencyLockWaitDuration("course_from_ride", "existing_found", java.time.Duration.ofMillis(75));
         recorder.recordOperationDuration("ride.policy.evaluate", "success", java.time.Duration.ofMillis(42));
 
         assertThat(meterRegistry.get("bike_weather_fallback_total").counter().count()).isEqualTo(1.0);
@@ -102,6 +104,16 @@ class BikeMetricsRecorderTest {
                 .tag("reason", "pool_exhausted")
                 .counter()
                 .count()).isEqualTo(1.0);
+        assertThat(meterRegistry.get("bike_idempotency_lock_total")
+                .tag("operation", "course_from_ride")
+                .tag("outcome", "acquired")
+                .counter()
+                .count()).isEqualTo(1.0);
+        assertThat(meterRegistry.get("bike_idempotency_lock_wait_duration")
+                .tag("operation", "course_from_ride")
+                .tag("outcome", "existing_found")
+                .timer()
+                .count()).isEqualTo(1);
         assertThat(meterRegistry.get("bike_operation_duration")
                 .tag("operation", "ride.policy.evaluate")
                 .tag("outcome", "success")

--- a/src/test/java/com/bikeprojectminji/bikeback/party/websocket/RidePartyLocationWebSocketHandlerTest.java
+++ b/src/test/java/com/bikeprojectminji/bikeback/party/websocket/RidePartyLocationWebSocketHandlerTest.java
@@ -18,7 +18,6 @@ import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
-import org.springframework.http.HttpHeaders;
 import org.springframework.web.socket.TextMessage;
 import org.springframework.web.socket.WebSocketSession;
 
@@ -71,10 +70,7 @@ class RidePartyLocationWebSocketHandlerTest {
 
     private WebSocketSession session(String token) {
         WebSocketSession session = mock(WebSocketSession.class);
-        HttpHeaders headers = new HttpHeaders();
-        headers.setBearerAuth(token);
-        when(session.getUri()).thenReturn(URI.create("ws://localhost/ws/v1/parties/20/locations"));
-        when(session.getHandshakeHeaders()).thenReturn(headers);
+        when(session.getUri()).thenReturn(URI.create("ws://localhost/ws/v1/parties/20/locations?socketToken=" + token));
         when(session.getAttributes()).thenReturn(new HashMap<>());
         when(session.isOpen()).thenReturn(true);
         return session;

--- a/src/test/java/com/bikeprojectminji/bikeback/ride/service/RideRecordServiceTest.java
+++ b/src/test/java/com/bikeprojectminji/bikeback/ride/service/RideRecordServiceTest.java
@@ -4,9 +4,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
 
 import com.bikeprojectminji.bikeback.auth.entity.UserEntity;
+import com.bikeprojectminji.bikeback.global.idempotency.IdempotencyLockService;
 import com.bikeprojectminji.bikeback.location.service.RecentLocationCacheService;
 import com.bikeprojectminji.bikeback.ride.dto.CreateRideRecordSummaryRequest;
 import com.bikeprojectminji.bikeback.ride.dto.CreateRideRecordRequest;
@@ -22,13 +24,19 @@ import java.math.BigDecimal;
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Supplier;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.transaction.support.SimpleTransactionStatus;
+import org.springframework.transaction.support.TransactionCallback;
+import org.springframework.transaction.support.TransactionOperations;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -54,8 +62,35 @@ class RideRecordServiceTest {
     @Mock
     private RideRecordFinalizationService rideRecordFinalizationService;
 
+    @Mock
+    private TransactionOperations transactionOperations;
+
+    @Mock
+    private IdempotencyLockService idempotencyLockService;
+
     @InjectMocks
     private RideRecordService rideRecordService;
+
+    @BeforeEach
+    void executeTransactionsInline() {
+        lenient().when(transactionOperations.execute(any())).thenAnswer(invocation -> {
+            TransactionCallback<?> callback = invocation.getArgument(0);
+            return callback.doInTransaction(new SimpleTransactionStatus());
+        });
+        lenient().when(idempotencyLockService.executeOrWait(any(), any(), any(), any())).thenAnswer(invocation -> {
+            Supplier<Optional<?>> existingLookup = invocation.getArgument(2);
+            Optional<?> existing = existingLookup.get();
+            if (existing.isPresent()) {
+                return existing.get();
+            }
+            Supplier<?> creator = invocation.getArgument(3);
+            return creator.get();
+        });
+        lenient().when(idempotencyLockService.executeOrWaitAfterContention(any(), any(), any(), any())).thenAnswer(invocation -> {
+            Supplier<?> creator = invocation.getArgument(3);
+            return creator.get();
+        });
+    }
 
     @Test
     @DisplayName("자유 주행 기록 저장은 10초 미만 duration을 거절한다")
@@ -248,6 +283,51 @@ class RideRecordServiceTest {
 
         assertThat(response.rideRecordId()).isEqualTo(1001L);
         assertThat(response.routePointCount()).isEqualTo(2);
+        verifyNoInteractions(recentLocationCacheService, rideRecordFinalizationService);
+    }
+
+    @Test
+    @DisplayName("자유 주행 기록 저장은 같은 clientRideId 동시 저장 경쟁에서 기존 기록을 200 응답으로 복구한다")
+    void saveRideRecordReturnsExistingRecordAfterConcurrentClientRideIdRace() {
+        UserEntity user = new UserEntity(null, "bikeoasis@example.com", "encoded-password", "bikeoasis", null);
+        ReflectionTestUtils.setField(user, "id", 1L);
+        RideRecordEntity existingRideRecord = new RideRecordEntity(
+                1L,
+                "android-ride-race-001",
+                OffsetDateTime.parse("2026-03-29T10:00:00+09:00"),
+                OffsetDateTime.parse("2026-03-29T11:00:00+09:00"),
+                18250,
+                3600
+        );
+        ReflectionTestUtils.setField(existingRideRecord, "id", 1001L);
+
+        given(authService.findUserBySubject("1")).willReturn(user);
+        given(rideRecordRepository.findByOwnerUserIdAndClientRideId(1L, "android-ride-race-001"))
+                .willReturn(Optional.empty(), Optional.empty(), Optional.of(existingRideRecord));
+        given(rideRecordRepository.save(any(RideRecordEntity.class)))
+                .willThrow(new DataIntegrityViolationException("uq_ride_records_owner_client_ride_id"));
+        given(rideRecordPointRepository.countByRideRecordId(1001L)).willReturn(2L);
+
+        RideRecordResponse response = rideRecordService.saveRideRecord("1", new CreateRideRecordRequest(
+                "android-ride-race-001",
+                OffsetDateTime.parse("2026-03-29T10:00:00+09:00"),
+                OffsetDateTime.parse("2026-03-29T11:00:00+09:00"),
+                new RideRecordSummaryRequest(18250, 3600),
+                List.of(
+                        new RideRecordPointRequest(1, BigDecimal.valueOf(37.5665), BigDecimal.valueOf(126.9780)),
+                        new RideRecordPointRequest(2, BigDecimal.valueOf(37.5671), BigDecimal.valueOf(126.9792))
+                )
+        ));
+
+        assertThat(response.rideRecordId()).isEqualTo(1001L);
+        assertThat(response.routePointCount()).isEqualTo(2);
+        assertThat(response.finalizationStatus()).isEqualTo("FINALIZING");
+        verify(idempotencyLockService).executeOrWait(
+                eq("ride_record_save_full"),
+                eq("ride-record:1:android-ride-race-001"),
+                any(),
+                any()
+        );
         verifyNoInteractions(recentLocationCacheService, rideRecordFinalizationService);
     }
 


### PR DESCRIPTION
## Summary
- Add Redis-backed idempotency locking for duplicate ride save, ride regenerate, and course-from-ride commands.
- Make duplicate course creation and duplicate ride save converge to the existing resource with HTTP 200 under local concurrency smoke.
- Move party WebSocket socket token usage to query parameter flow and permit `/ws/v1/parties/**` through the JWT filter.
- Document the Redis lock ADR and final local concurrency evidence.

## Root Cause
- Duplicate course creation was protected by DB uniqueness, but concurrent requests could still fan out into DB work and exhaust Hikari connections before returning existing course data.
- Contended requests were also doing JPA reads before waiting on the idempotency lock, so the request-scoped persistence context could retain DB connections while waiting.
- Duplicate regenerate requests could similarly produce avoidable DB pressure before the course scenario.

## Key Changes
- `IdempotencyLockService` uses Redis `SET NX` with owner-token release and metrics for acquired/contended/existing/timeout outcomes.
- `CourseService` computes the idempotency key from numeric JWT subject before DB access, then lets only the creator validate the user and source ride record.
- `RideRecordService` serializes duplicate regenerate commands and returns current finalization status for contenders.
- `ops/smoke/concurrency_consistency.py` now enforces strict 200 convergence for duplicate ride save and duplicate course creation.

## Validation
- `./gradlew --no-daemon test --tests com.bikeprojectminji.bikeback.global.idempotency.IdempotencyLockServiceTest --tests com.bikeprojectminji.bikeback.global.metrics.BikeMetricsRecorderTest --tests com.bikeprojectminji.bikeback.ride.service.RideRecordServiceTest --tests com.bikeprojectminji.bikeback.course.service.CourseServiceTest --tests com.bikeprojectminji.bikeback.party.websocket.RidePartyLocationWebSocketHandlerTest`
- `python3 -m py_compile ops/smoke/concurrency_consistency.py`
- `git diff --check`
- Local E2E evidence: `ops/smoke/results/concurrency_consistency_numeric_subject_lock_20260627_202815.json`
- Final smoke: duplicateClientRideId=true, duplicateRegenerate=true, duplicateCourseCreate=true, partyJoinLeave=true, socketTokenReuse=true.
- Final metrics: Hikari timeout=0, pending=0, course_from_ride existing_after_wait=9.

## Review Personas
- Backend architecture/domain reviewer: focus on idempotency key boundaries, transaction scope, Redis fail-open behavior, and numeric subject fallback risk.
- QA/security/operations reviewer: focus on 200 convergence contract, WebSocket token query flow, observability metrics, and Redis failure drill follow-up.

## Remaining Risk
- Legacy non-numeric JWT subject still falls back to DB-backed AuthService lookup before lock; AWS/failure-resilience validation should cover this if legacy tokens remain supported.
- Redis outage falls back to DB unique constraints, so data remains protected but connection pressure can return under duplicate writes.
