### PR TITLE
docs: document private prometheus scrape flag

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,8 @@ PORT=8080
 SERVER_FORWARD_HEADERS_STRATEGY=framework
 MANAGEMENT_PORT=18081
 MANAGEMENT_SERVER_ADDRESS=0.0.0.0
+# Keep false unless the management port is private/local-only. Set true for local/AWS private Prometheus scrape validation.
+MANAGEMENT_PROMETHEUS_PUBLIC_SCRAPE_ENABLED=false
 
 # Optional local smoke value. Do not commit a real token.
 NGROK_AUTHTOKEN=


### PR DESCRIPTION
## Summary\n- document the management prometheus public scrape flag in .env.example\n- keep the default secure and clarify that it is only for local/private management scrape validation\n\n## Verification\n- ./gradlew test\n- local smoke/contract HTTP run: 13/13 passed\n- local duplicate clientRideId concurrency run: duplicate save contract passed\n- local prometheus scrape run with MANAGEMENT_PROMETHEUS_PUBLIC_SCRAPE_ENABLED=true: 2/2 passed\n\n## Evidence\n- ops/loadtest/results/local_smoke_contract_20260628_143326/report.md\n- ops/loadtest/results/local_concurrency_observability_20260628_143433/report.md\n- ops/loadtest/results/local_observability_public_scrape_20260628_143757/report.md