### PR TITLE
chore: add hybrid dev infra preflight

### DIFF
--- a/.env.hybrid.example
+++ b/.env.hybrid.example
@@ -1,0 +1,58 @@
+# Hybrid development/staging template.
+# Copy to `.env.hybrid` or your local secret manager and replace placeholders.
+# Do not commit real secrets.
+
+# Purpose:
+# - Keep DB/Redis available for repeated phone/device tests without running AWS EC2.
+# - Do not use this as AWS performance evidence.
+
+# Neon Postgres candidate. Use the JDBC URL from Neon and keep sslmode=require.
+SPRING_DATASOURCE_URL=jdbc:postgresql://replace-with-neon-host.neon.tech/bike?sslmode=require
+SPRING_DATASOURCE_USERNAME=replace-with-neon-user
+SPRING_DATASOURCE_PASSWORD=replace-with-neon-password
+SPRING_DATASOURCE_HIKARI_MAXIMUM_POOL_SIZE=10
+SPRING_DATASOURCE_HIKARI_CONNECTION_TIMEOUT_MS=5000
+
+# Upstash Redis candidate. Prefer rediss:// when TLS is required.
+SPRING_DATA_REDIS_URL=rediss://default:replace-with-upstash-token@replace-with-upstash-host.upstash.io:6379
+BIKE_RATE_LIMIT_STORE=redis
+
+# JWT and app runtime.
+AUTH_JWT_SECRET=replace-with-at-least-32-byte-random-secret
+AUTH_JWT_ISSUER=bike-back-hybrid-dev
+AUTH_JWT_TOKEN_VALIDITY_SEC=900
+PORT=8080
+SERVER_FORWARD_HEADERS_STRATEGY=framework
+
+# Keep management local/private. Do not expose this through ngrok/Cloudflare Tunnel.
+MANAGEMENT_PORT=18081
+MANAGEMENT_SERVER_ADDRESS=127.0.0.1
+MANAGEMENT_PROMETHEUS_PUBLIC_SCRAPE_ENABLED=false
+
+# Device tunnel candidate. Keep this value descriptive; the tunnel tool owns the real URL.
+# Example allowed origin: https://replace-with-ngrok-or-cloudflare-host
+APP_CORS_ALLOWED_ORIGINS=http://127.0.0.1:8081,http://localhost:8081,https://replace-with-device-tunnel-host
+
+# Provider defaults for cheap repeated testing.
+ADDRESS_SEARCH_PROVIDER=fake
+KAKAO_LOCAL_BASE_URL=https://dapi.kakao.com
+KAKAO_LOCAL_REST_API_KEY=
+
+# Use fake routing for fast device smoke unless the scenario explicitly needs GraphHopper.
+BICYCLE_ROUTING_PROVIDER=fake
+BICYCLE_ROUTING_FAKE_ENABLED=true
+GRAPHHOPPER_BASE_URL=http://127.0.0.1:8989
+GRAPHHOPPER_HOSTED_BASE_URL=
+GRAPHHOPPER_API_KEY=
+GRAPHHOPPER_RETRY_MAX_ATTEMPTS=2
+
+# Leave unset/blank to use backend deterministic AI route fallback.
+AI_ROUTE_WORKER_BASE_URL=
+GEMINI_API_KEY=
+GEMINI_MODEL=gemini-2.5-flash
+
+# Ride save protection remains enabled in hybrid dev.
+BIKE_DATABASE_BACKPRESSURE_ENABLED=true
+BIKE_RIDE_SAVE_GATE_ENABLED=true
+BIKE_RIDE_SAVE_GATE_MAX_CONCURRENCY=10
+BIKE_RIDE_SAVE_GATE_RETRY_AFTER_SECONDS=3

--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ out/
 .env.*
 !.env.example
 !.env.test.example
+!.env.hybrid.example
 
 # Terraform local state
 ops/aws/alb-acm-route53/.terraform/

--- a/README.md
+++ b/README.md
@@ -64,6 +64,14 @@ curl -i http://127.0.0.1:8080/health/monitor
 ./gradlew --no-daemon clean check
 ```
 
+AWS를 켜기 전 Hybrid 개발 레인 preflight는 아래 명령으로 확인한다.
+
+```bash
+./ops/smoke/run-hybrid-preflight.sh
+```
+
+이 명령은 compose config, AWS wrapper 문법, targeted backend test, AI route worker pytest를 비용 없이 확인하고 `ops/smoke/results/`에 evidence를 남긴다.
+
 운영 smoke, k6, AWS 검증 순서와 중단 기준은 루트 `DOCS/개발용/06_개발_운영_검증.md`와 `07_운영_장애_테스트_대응록.md`를 따른다.
 
 ## Git 기준

--- a/ops/smoke/run-hybrid-preflight.sh
+++ b/ops/smoke/run-hybrid-preflight.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+AI_ROUTE_DIR="${AI_ROUTE_DIR:-$ROOT_DIR/../bike-ai-route}"
+RESULTS_DIR="${RESULTS_DIR:-$ROOT_DIR/ops/smoke/results/hybrid-preflight-$(date +%Y%m%d-%H%M%S)}"
+
+RUN_COMPOSE_CONFIG="${RUN_COMPOSE_CONFIG:-true}"
+RUN_AWS_SCRIPT_SYNTAX="${RUN_AWS_SCRIPT_SYNTAX:-true}"
+RUN_BACKEND_TESTS="${RUN_BACKEND_TESTS:-true}"
+RUN_AI_ROUTE_TESTS="${RUN_AI_ROUTE_TESTS:-true}"
+BACKEND_TEST_SELECTOR="${BACKEND_TEST_SELECTOR:-com.bikeprojectminji.bikeback.ops.GraphHopperReadinessScriptTest}"
+UV_PYTHON="${UV_PYTHON:-3.12}"
+AI_ROUTE_VENV=""
+
+mkdir -p "$RESULTS_DIR"
+
+log() {
+  printf '[%s] %s\n' "$(date -Iseconds)" "$*"
+}
+
+require_command() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "missing required command: $1" >&2
+    exit 10
+  fi
+}
+
+run_shell_step() {
+  local name="$1"
+  local command="$2"
+  log "start $name"
+  (cd "$ROOT_DIR" && bash -lc "$command") >"$RESULTS_DIR/$name.log" 2>&1
+  log "pass $name"
+}
+
+cleanup_ai_route_artifacts() {
+  rm -rf \
+    ${AI_ROUTE_VENV:+"$AI_ROUTE_VENV"} \
+    "$AI_ROUTE_DIR/.pytest_cache" \
+    "$AI_ROUTE_DIR/app/__pycache__" \
+    "$AI_ROUTE_DIR/tests/__pycache__"
+}
+
+write_summary() {
+  local status="$1"
+  cat >"$RESULTS_DIR/summary.json" <<EOF
+{
+  "status": "$status",
+  "createdAt": "$(date -Iseconds)",
+  "rootDir": "$ROOT_DIR",
+  "aiRouteDir": "$AI_ROUTE_DIR",
+  "backendTestSelector": "$BACKEND_TEST_SELECTOR",
+  "composeConfig": "$RUN_COMPOSE_CONFIG",
+  "awsScriptSyntax": "$RUN_AWS_SCRIPT_SYNTAX",
+  "backendTests": "$RUN_BACKEND_TESTS",
+  "aiRouteTests": "$RUN_AI_ROUTE_TESTS"
+}
+EOF
+}
+
+on_error() {
+  local exit_code="$?"
+  cleanup_ai_route_artifacts
+  write_summary "failed"
+  log "failed with exit_code=$exit_code. Evidence: $RESULTS_DIR"
+  exit "$exit_code"
+}
+
+trap on_error ERR
+
+main() {
+  cd "$ROOT_DIR"
+  require_command bash
+
+  if [[ "$RUN_COMPOSE_CONFIG" == "true" ]]; then
+    require_command docker
+    run_shell_step "compose-local-config" "docker compose -f docker-compose.local.yml config >/tmp/bike-compose-local.yml"
+    run_shell_step "compose-test-config" "docker compose -f docker-compose.test.yml config >/tmp/bike-compose-test.yml"
+  fi
+
+  if [[ "$RUN_AWS_SCRIPT_SYNTAX" == "true" ]]; then
+    run_shell_step "aws-wrapper-syntax" "bash -n ops/loadtest/run-aws-compose-k6.sh"
+  fi
+
+  if [[ "$RUN_BACKEND_TESTS" == "true" ]]; then
+    run_shell_step "backend-targeted-test" "./gradlew test --tests '$BACKEND_TEST_SELECTOR'"
+  fi
+
+  if [[ "$RUN_AI_ROUTE_TESTS" == "true" ]]; then
+    require_command uv
+    if [[ ! -d "$AI_ROUTE_DIR" ]]; then
+      echo "AI route worker directory not found: $AI_ROUTE_DIR" >&2
+      exit 11
+    fi
+    AI_ROUTE_VENV="$(mktemp -d "${TMPDIR:-/tmp}/bike-ai-route-venv.XXXXXX")"
+    run_shell_step "ai-route-pytest" "cd '$AI_ROUTE_DIR' && TMPDIR='${TMPDIR:-/tmp}' UV_LINK_MODE=copy UV_PROJECT_ENVIRONMENT='$AI_ROUTE_VENV' uv run --python '$UV_PYTHON' python -m pytest tests -q"
+    cleanup_ai_route_artifacts
+    AI_ROUTE_VENV=""
+  fi
+
+  write_summary "passed"
+  log "hybrid preflight passed. Evidence: $RESULTS_DIR"
+}
+
+main "$@"


### PR DESCRIPTION
## Summary
- Add `.env.hybrid.example` for Neon/Upstash/device-tunnel based repeated development testing without AWS EC2.
- Add `ops/smoke/run-hybrid-preflight.sh` to validate the no-cost Hybrid lane before AWS evidence runs.
- Document the preflight entry point in `README.md` and allow the hybrid env template through `.gitignore`.

## Verification
- `bash -n ops/smoke/run-hybrid-preflight.sh`
- `git diff --check`
- `./ops/smoke/run-hybrid-preflight.sh`
  - compose-local-config: pass
  - compose-test-config: pass
  - aws-wrapper-syntax: pass
  - backend targeted test: pass
  - ai-route pytest: pass

## Evidence
- Latest local evidence: `ops/smoke/results/hybrid-preflight-20260628-172757/summary.json`

## Operational Notes
- No AWS resources are created by this preflight.
- `.env.hybrid.example` intentionally uses placeholders only.
- Real Neon, Upstash, provider, and tunnel secrets must stay in local secret storage/GitHub Secrets/SSM, not docs or evidence.
- This is a repeated development/staging lane, not an AWS performance-evidence replacement.
