### PR TITLE
[codex] add hybrid and AI route evidence smoke

### DIFF
--- a/.env.hybrid.example
+++ b/.env.hybrid.example
@@ -56,3 +56,9 @@ BIKE_DATABASE_BACKPRESSURE_ENABLED=true
 BIKE_RIDE_SAVE_GATE_ENABLED=true
 BIKE_RIDE_SAVE_GATE_MAX_CONCURRENCY=10
 BIKE_RIDE_SAVE_GATE_RETRY_AFTER_SECONDS=3
+
+# HTTP smoke target for phone/device tunnel checks.
+# Set this to a local URL or to the public tunnel URL that points to the backend.
+BIKE_SMOKE_BASE_URL=http://127.0.0.1:8080
+BIKE_SMOKE_ADDRESS_QUERY=Seoul City Hall
+BIKE_SMOKE_AI_ROUTE_TEXT=flat riverside route to test provider fallback

--- a/.env.hybrid.example
+++ b/.env.hybrid.example
@@ -37,6 +37,7 @@ APP_CORS_ALLOWED_ORIGINS=http://127.0.0.1:8081,http://localhost:8081,https://rep
 ADDRESS_SEARCH_PROVIDER=fake
 KAKAO_LOCAL_BASE_URL=https://dapi.kakao.com
 KAKAO_LOCAL_REST_API_KEY=
+WEATHER_PROVIDER=fake
 
 # Use fake routing for fast device smoke unless the scenario explicitly needs GraphHopper.
 BICYCLE_ROUTING_PROVIDER=fake

--- a/README.md
+++ b/README.md
@@ -72,6 +72,15 @@ AWS를 켜기 전 Hybrid 개발 레인 preflight는 아래 명령으로 확인�
 
 이 명령은 compose config, AWS wrapper 문법, targeted backend test, AI route worker pytest를 비용 없이 확인하고 `ops/smoke/results/`에 evidence를 남긴다.
 
+Neon/Upstash/터널을 붙인 뒤 실제 기기 접근 경로는 아래 HTTP smoke로 확인한다.
+
+```bash
+BIKE_SMOKE_BASE_URL=http://127.0.0.1:8080 ./ops/smoke/run-hybrid-device-smoke.sh
+BIKE_SMOKE_BASE_URL=https://replace-with-device-tunnel-host ./ops/smoke/run-hybrid-device-smoke.sh
+```
+
+이 명령은 Docker DB/Redis 내부 상태에 의존하지 않고 `health`, 코스 목록, 주소 검색, 회원가입/로그인, AI 경로 생성, 주행 summary 저장 API 계약과 `X-Request-Id`/`X-Trace-Id` evidence를 `ops/smoke/results/`에 남긴다.
+
 운영 smoke, k6, AWS 검증 순서와 중단 기준은 루트 `DOCS/개발용/06_개발_운영_검증.md`와 `07_운영_장애_테스트_대응록.md`를 따른다.
 
 ## Git 기준

--- a/README.md
+++ b/README.md
@@ -132,6 +132,14 @@ BIKE_SMOKE_BASE_URL=http://127.0.0.1:8080 ./ops/smoke/run-hybrid-device-smoke.sh
 BIKE_SMOKE_BASE_URL=https://replace-with-device-tunnel-host ./ops/smoke/run-hybrid-device-smoke.sh
 ```
 
+AI route/GraphHopper evidence smoke:
+
+```bash
+BIKE_SMOKE_BASE_URL=http://127.0.0.1:8080 \
+BIKE_SMOKE_GRAPHHOPPER_URL=http://127.0.0.1:8989 \
+./ops/smoke/run-ai-route-evidence-smoke.sh
+```
+
 AWS short evidence gate:
 
 ```bash
@@ -140,6 +148,12 @@ AWS_ROUTING_MODE=fake ./ops/loadtest/run-aws-compose-k6.sh
 
 GraphHopper 실 provider drill은 fake smoke와 분리해서 실행한다.
 GraphHopper cache restore를 쓰는 경우 `GRAPHHOPPER_CACHE_ARCHIVE_FILE` 또는 `GRAPHHOPPER_CACHE_ARCHIVE_URL`을 명시한다.
+
+DB/Flyway 기준:
+
+- 이미 적용된 migration 파일은 수정하지 않는다.
+- 개발/검증 DB에서 Flyway checksum mismatch가 나면 기본 판단은 새 DB recreate 또는 smoke 전용 DB 생성이다.
+- 보존해야 하는 DB의 `flyway repair`는 사용자 결정과 변경 전 evidence 없이는 수행하지 않는다.
 
 ## 최근 AWS 검증 요약
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,64 @@
 # BIKE Backend
 
-Spring Boot 백엔드 저장소다.
-제품, 정책, API, 인프라, ADR, 운영 검증, 장애 대응, USM의 최종 원본은 이 저장소 내부 문서가 아니라 루트 `DOCS/개발용` 문서 묶음이다.
+BIKE/GAJA의 Spring Boot 백엔드 저장소다.
+자전거 여행 경로 추천, 코스따라가기 HUD, 자유주행 기록 저장/보정, Party 위치 공유, 운영 관측성을 담당한다.
+
+## 핵심 목표
+
+- 사용자가 `평지`, `한강이 보이는`, `자전거도로 위주` 같은 자연어 조건으로 코스를 추천받는다.
+- 추천 후보는 GraphHopper/GIS evidence와 백엔드 scorer를 근거로 점수화한다.
+- AI worker는 route point를 직접 만들지 않고, 사용자 의도 정규화와 후보 설명/주의 문구를 보강한다.
+- 자유주행 trace는 저장 후 finalization worker가 보정하고, READY 상태가 되면 코스로 승격할 수 있다.
+- 코스따라가기 HUD는 route point 단순 최근접이 아니라 route polyline 정사영, 진행률, 이탈, coverage 기반 완주 판정을 사용한다.
+- 운영 검증은 smoke, contract, integration, concurrency, load, failure, recovery, observability 순서로 evidence를 남긴다.
+
+## 기술 스택
+
+| 영역 | 기준 |
+|---|---|
+| Runtime | Java 17, Spring Boot 3.5.x, Gradle |
+| DB | PostgreSQL 16, PostGIS, Flyway |
+| Cache/Lock | Redis, quota/rate-limit, socket token, idempotency lock |
+| Routing | GraphHopper self-host 우선, fake/hosted fallback 후보 |
+| AI route | 별도 `bike-ai-route` worker, Gemini provider, backend fallback |
+| Observability | Actuator, Prometheus metrics, request id / trace id, k6 evidence |
+| Infra | Local compose, Neon/Upstash dev 후보, AWS short evidence gate |
+
+## 주요 기능
+
+| 기능 | 구현/검증 기준 |
+|---|---|
+| Auth | 이메일/카카오 로그인, refresh token rotation, logout, me/delete |
+| Course | 목록, 상세, route points, 공개 범위, 신고/공유/다운로드 후보 |
+| Course follow | HUD 진행률, 이탈 후보/경고/복귀, coverage 완주 판정 |
+| Ride record | 자유주행 저장, trace 저장, finalization job, 코스 승격 |
+| AI route | 주소/텍스트 기반 코스 생성, GraphHopper evidence, AI 설명, fallback metadata |
+| Address | Kakao Local 우선, Nominatim fallback |
+| Weather | Open-Meteo, 구역 단위 Redis cache, stale fallback, prewarm |
+| Party | 생성/참여/나가기/신고, socket token, 위치 공유 |
+| Ops | health, monitor, metrics, smoke, k6, AWS cleanup evidence |
+
+## AI 코스생성 방향
+
+현재 기준은 "LLM이 좌표를 만드는 서비스"가 아니다.
+
+1. 사용자의 자연어를 `RoutePreference`로 정규화한다.
+   예: `FLAT_FIRST`, `RIVERSIDE`, `BIKE_PATH_FIRST`, `LOW_TRAFFIC`, `LOOP`.
+2. 백엔드가 `RoutePreference`를 GraphHopper profile/custom model/weighting 후보로 변환한다.
+3. GraphHopper가 route와 detail을 반환한다.
+4. 백엔드 scorer가 경사, 고도, 노면, 자전거도로, 수변/공원 근접도 같은 GIS evidence로 점수화한다.
+5. AI worker는 이미 검증된 후보에 대한 설명, trade-off, 주의 문구만 생성한다.
+
+운영 제한:
+
+- GraphHopper 호출은 기본 1회, 후보 비교 시 최대 3회로 제한한다.
+- hard filter는 안전/통행 가능성에만 사용하고, 사용자 취향은 soft weight로 반영한다.
+- 풍경/한강/공원 근거가 별도 GIS layer 없이 근사되면 `PARTIAL` 또는 `UNKNOWN` metadata로 표시한다.
+- 고도 요약이 없으면 `elevationStatus=UNAVAILABLE` 같은 명시 상태를 내려야 한다.
 
 ## 원본 문서
+
+제품, 정책, API, 인프라, ADR, 운영 검증, 장애 대응, USM의 최종 원본은 이 저장소 내부 `docs/`가 아니라 루트 `DOCS/개발용` 문서 묶음이다.
 
 | 기준 | 위치 |
 |---|---|
@@ -23,8 +78,8 @@ cd /mnt/e/bike-work/bike/dev/bike-back
 ./gradlew bootRun
 ```
 
-환경 변수와 외부 provider 설정은 루트 `DOCS/개발용/04_데이터_인프라_아키텍처.md`와 실제 배포 환경의 secret store를 기준으로 확인한다.
-비밀값은 README나 Markdown에 평문으로 쓰지 않는다.
+환경 변수와 provider 설정은 루트 `DOCS/개발용/04_데이터_인프라_아키텍처.md`와 실제 secret store를 기준으로 확인한다.
+비밀값은 README, Markdown, k6 summary, app log에 평문으로 쓰지 않는다.
 
 ## 로컬 30분 온보딩
 
@@ -35,13 +90,13 @@ git status --short --branch
 git remote -v
 ```
 
-2. JDK/Gradle 빌드가 되는지 확인한다.
+2. JDK/Gradle 빌드와 테스트를 확인한다.
 
 ```bash
 ./gradlew --no-daemon clean check
 ```
 
-3. 로컬 실행 전 필요한 DB/Redis/GraphHopper 구성은 루트 `DOCS/개발용/04_데이터_인프라_아키텍처.md`를 확인한다.
+3. 로컬 DB/Redis/GraphHopper 구성은 루트 `DOCS/개발용/04_데이터_인프라_아키텍처.md`를 확인한다.
 
 4. 앱을 실행한다.
 
@@ -56,38 +111,55 @@ curl -fsS http://127.0.0.1:8080/health
 curl -i http://127.0.0.1:8080/health/monitor
 ```
 
-6. smoke, k6, AWS 테스트는 루트 `DOCS/개발용/07_운영_장애_테스트_대응록.md`의 순서와 중단 기준을 따른다.
+## Smoke / 검증
 
-## 검증
+기본 검증:
 
 ```bash
 ./gradlew --no-daemon clean check
 ```
 
-AWS를 켜기 전 Hybrid 개발 레인 preflight는 아래 명령으로 확인한다.
+AWS를 켜기 전 Hybrid 개발 레인 preflight:
 
 ```bash
 ./ops/smoke/run-hybrid-preflight.sh
 ```
 
-이 명령은 compose config, AWS wrapper 문법, targeted backend test, AI route worker pytest를 비용 없이 확인하고 `ops/smoke/results/`에 evidence를 남긴다.
-
-Neon/Upstash/터널을 붙인 뒤 실제 기기 접근 경로는 아래 HTTP smoke로 확인한다.
+Neon/Upstash/터널을 붙인 뒤 실제 기기 접근 smoke:
 
 ```bash
 BIKE_SMOKE_BASE_URL=http://127.0.0.1:8080 ./ops/smoke/run-hybrid-device-smoke.sh
 BIKE_SMOKE_BASE_URL=https://replace-with-device-tunnel-host ./ops/smoke/run-hybrid-device-smoke.sh
 ```
 
-이 명령은 Docker DB/Redis 내부 상태에 의존하지 않고 `health`, 코스 목록, 주소 검색, 회원가입/로그인, AI 경로 생성, 주행 summary 저장 API 계약과 `X-Request-Id`/`X-Trace-Id` evidence를 `ops/smoke/results/`에 남긴다.
+AWS short evidence gate:
 
-운영 smoke, k6, AWS 검증 순서와 중단 기준은 루트 `DOCS/개발용/06_개발_운영_검증.md`와 `07_운영_장애_테스트_대응록.md`를 따른다.
+```bash
+AWS_ROUTING_MODE=fake ./ops/loadtest/run-aws-compose-k6.sh
+```
+
+GraphHopper 실 provider drill은 fake smoke와 분리해서 실행한다.
+GraphHopper cache restore를 쓰는 경우 `GRAPHHOPPER_CACHE_ARCHIVE_FILE` 또는 `GRAPHHOPPER_CACHE_ARCHIVE_URL`을 명시한다.
+
+## 최근 AWS 검증 요약
+
+| 날짜 | 테스트 | 결과 |
+|---|---|---|
+| 2026-06-28 | AWS fake routing 3VU smoke | 실패율 0%, p95 약 99ms |
+| 2026-06-28 | AWS real GraphHopper 2VU drill | 실패율 0%, p95 약 78ms |
+| 2026-06-28 | AWS real GraphHopper 5VU read/HUD drill | 실패율 0%, p95 약 35ms |
+| 2026-06-29 | AWS real GraphHopper 10VU read/HUD drill | 실패율 0%, p95 약 43ms |
+| 2026-06-29 | AWS fake routing 25VU mixed smoke | 실패율 0%, p95 약 116ms |
+| 2026-06-29 | AWS Gemini AI route 1VU provider drill | HTTP 실패율 0%, checks 89.7%, elevation summary 품질 계약 보강 필요 |
+
+상세 evidence와 판단은 `/mnt/e/bike-work/bike/DOCS/개발용/07_운영_장애_테스트_대응록.md`를 기준으로 본다.
 
 ## Git 기준
 
 - 작업 시작 전 `git status --short --branch`와 `git remote -v`를 확인한다.
 - 기능/API 변경은 가능한 한 작은 브랜치와 PR로 나눈다.
 - API, DB, 운영, 장애 대응, 사용자 시나리오 기준이 바뀌면 루트 `DOCS/개발용` 문서 동기화 여부를 확인한다.
+- PR 본문에는 변경 요약, 검증 명령, evidence 위치, 남은 리스크를 남긴다.
 
 ## 이 저장소 안에서 원본으로 보지 않는 것
 

--- a/docker-compose.test.fake-routing.yml
+++ b/docker-compose.test.fake-routing.yml
@@ -1,0 +1,18 @@
+services:
+  graphhopper-prepare:
+    image: alpine:3.20
+    command: ["sh", "-c", "echo fake routing mode: skip graphhopper prepare"]
+    environment: {}
+    volumes: []
+
+  graphhopper:
+    image: alpine:3.20
+    command: ["sh", "-c", "echo fake routing mode: graphhopper disabled; sleep infinity"]
+    environment: {}
+    volumes: []
+
+  bike-back:
+    environment:
+      BICYCLE_ROUTING_PROVIDER: fake
+      BICYCLE_ROUTING_FAKE_ENABLED: "true"
+      GRAPHHOPPER_BASE_URL: http://graphhopper:8989

--- a/ops/loadtest/k6/ai-route-graphhopper-100-users.js
+++ b/ops/loadtest/k6/ai-route-graphhopper-100-users.js
@@ -618,10 +618,19 @@ function boolEnv(name, fallback) {
 }
 
 export function handleSummary(data) {
+  const sanitizedData = sanitizedSummaryData(data);
   return {
     stdout: summaryText(data),
-    [SUMMARY_PATH]: JSON.stringify(data, null, 2),
+    [SUMMARY_PATH]: JSON.stringify(sanitizedData, null, 2),
   };
+}
+
+function sanitizedSummaryData(data) {
+  const sanitized = JSON.parse(JSON.stringify(data));
+  if (sanitized.setup_data && sanitized.setup_data.tokens) {
+    sanitized.setup_data.tokens = '[REDACTED]';
+  }
+  return sanitized;
 }
 
 function summaryText(data) {

--- a/ops/loadtest/k6/bike-api.js
+++ b/ops/loadtest/k6/bike-api.js
@@ -382,6 +382,17 @@ function commonChecks(response, expectedStatus) {
   return check(response, checksObj);
 }
 
+function parseJsonBody(response) {
+  if (!response || !response.body) {
+    return null;
+  }
+  try {
+    return JSON.parse(response.body);
+  } catch (_) {
+    return null;
+  }
+}
+
 function runHealthCheck() {
   group('health', function() {
     var response = getJson('/health', { flow: 'health', endpoint: 'health' });
@@ -570,6 +581,29 @@ function runWeatherRead() {
       endpoint: 'weather-current',
     });
     commonChecks(response, 200);
+    check(response, {
+      'weather freshness status is valid': function(r) {
+        var payload = parseJsonBody(r);
+        var status = payload && payload.data && payload.data.freshnessStatus;
+        return [
+          'FRESH_PROVIDER',
+          'FRESH_CACHE',
+          'STALE_LAST_SUCCESS',
+          'UNAVAILABLE',
+        ].indexOf(status) >= 0;
+      },
+      'weather unavailable keeps payload explicit': function(r) {
+        var payload = parseJsonBody(r);
+        var data = payload && payload.data;
+        if (!data || data.freshnessStatus !== 'UNAVAILABLE') {
+          return true;
+        }
+        return data.weather === null
+          && data.wind === null
+          && data.stale === false
+          && data.staleReason === 'PROVIDER_FAILURE';
+      },
+    });
   });
 }
 
@@ -784,9 +818,21 @@ export function handleSummary(data) {
     write_route_point_count: WRITE_ROUTE_POINT_COUNT,
     write_poll_finalization: WRITE_POLL_FINALIZATION,
   };
+  var sanitizedData = sanitizedSummaryData(data);
   result.stdout = textSummary(data, { indent: ' ', enableColors: true });
-  result[SUMMARY_DIR + '/' + TEST_ID + '-summary.json'] = JSON.stringify(data, null, 2);
+  result[SUMMARY_DIR + '/' + TEST_ID + '-summary.json'] = JSON.stringify(sanitizedData, null, 2);
   return result;
+}
+
+function sanitizedSummaryData(data) {
+  var sanitized = JSON.parse(JSON.stringify(data));
+  if (sanitized.setup_data && sanitized.setup_data.tokens) {
+    sanitized.setup_data.tokens = '[REDACTED]';
+  }
+  if (sanitized.setup_data && sanitized.setup_data.authToken) {
+    sanitized.setup_data.authToken = '[REDACTED]';
+  }
+  return sanitized;
 }
 
 function textSummary(data, options) {

--- a/ops/loadtest/k6/bike-api.js
+++ b/ops/loadtest/k6/bike-api.js
@@ -7,6 +7,7 @@ var ACTIVE_PERSONAS = parsePersonaFilter(__ENV.PERSONAS || 'home,profile,preRide
 var TEST_ID = __ENV.TEST_ID || 'bike-' + SCENARIO;
 var SUMMARY_DIR = (__ENV.SUMMARY_DIR || 'ops/loadtest/results').replace(/\/$/, '');
 var ENABLE_WEATHER_READ = ((__ENV.ENABLE_WEATHER_READ || 'true') + '').toLowerCase() !== 'false';
+var ENABLE_ADDRESS_SEARCH = ((__ENV.ENABLE_ADDRESS_SEARCH || 'true') + '').toLowerCase() !== 'false';
 var SLOW_REQUEST_SAMPLE_MS = intEnv('SLOW_REQUEST_SAMPLE_MS', 1000);
 var WRITE_ROUTE_POINT_COUNT = Math.max(2, intEnv('WRITE_ROUTE_POINT_COUNT', 2));
 var WRITE_POLL_FINALIZATION = ((__ENV.WRITE_POLL_FINALIZATION || 'false') + '').toLowerCase() === 'true';
@@ -215,6 +216,7 @@ function buildOptions() {
     'http_req_duration{flow:health}': ['p(95)<300'],
     'http_req_duration{flow:course-read}': ['p(95)<' + p95Ms],
     'http_req_duration{flow:route-read}': ['p(95)<' + intEnv('ROUTE_READ_P95_MS', 1000)],
+    'http_req_duration{flow:address-search}': ['p(95)<' + intEnv('ADDRESS_SEARCH_P95_MS', 1200)],
     'http_req_duration{flow:weather-read}': ['p(95)<' + intEnv('WEATHER_P95_MS', 1200)],
     'http_req_duration{flow:ride-policy}': ['p(95)<' + intEnv('RIDE_POLICY_P95_MS', 1200)],
     checks: ['rate>0.99'],
@@ -569,6 +571,47 @@ function runRoutePointsRead(setupData) {
   });
 }
 
+function runAddressSearch() {
+  if (!ENABLE_ADDRESS_SEARCH) {
+    return;
+  }
+  group('address search', function() {
+    var query = encodeURIComponent(stringEnv('ADDRESS_SEARCH_QUERY', '여의나루역'));
+    var response = getJson('/api/v1/addresses/search?query=' + query + '&page=1&size=5', {
+      flow: 'address-search',
+      endpoint: 'address-search',
+    });
+    commonChecks(response, 200);
+    check(response, {
+      'address status is valid': function(r) {
+        var payload = parseJsonBody(r);
+        var status = payload && payload.data && payload.data.status;
+        return [
+          'SUCCESS',
+          'AMBIGUOUS',
+          'EMPTY',
+          'RATE_LIMITED',
+          'PROVIDER_FAILURE',
+        ].indexOf(status) >= 0;
+      },
+      'address fallback metadata contract is preserved': function(r) {
+        var payload = parseJsonBody(r);
+        var data = payload && payload.data;
+        if (!data) {
+          return false;
+        }
+        if (typeof data.fallbackUsed !== 'boolean') {
+          return false;
+        }
+        if (data.fallbackUsed) {
+          return !!data.primaryProvider && !!data.provider && !!data.fallbackReason;
+        }
+        return true;
+      },
+    });
+  });
+}
+
 function runWeatherRead() {
   if (!ENABLE_WEATHER_READ) {
     return;
@@ -766,6 +809,7 @@ export function coreJourney(setupData) {
   runHealthCheck();
   runCourseReads(setupData);
   runRoutePointsRead(setupData);
+  runAddressSearch();
   runWeatherRead();
   runRidePolicy(setupData);
   runRecentLocation(setupData);
@@ -786,6 +830,7 @@ export function personaProfileSummary(setupData) {
 export function personaPreRide(setupData) {
   runCourseReads(setupData);
   runRoutePointsRead(setupData);
+  runAddressSearch();
   runWeatherRead();
   runRidePolicy(setupData);
   sleep(Number.parseFloat(stringEnv('SLEEP_SECONDS', '1')));
@@ -814,6 +859,7 @@ export function handleSummary(data) {
     test_id: TEST_ID,
     scenario: SCENARIO,
     personas: ACTIVE_PERSONAS,
+    address_search_enabled: ENABLE_ADDRESS_SEARCH,
     weather_enabled: ENABLE_WEATHER_READ,
     write_route_point_count: WRITE_ROUTE_POINT_COUNT,
     write_poll_finalization: WRITE_POLL_FINALIZATION,

--- a/ops/loadtest/run-aws-compose-k6.sh
+++ b/ops/loadtest/run-aws-compose-k6.sh
@@ -35,7 +35,9 @@ SSH_CONNECT_TIMEOUT_SECONDS="${SSH_CONNECT_TIMEOUT_SECONDS:-10}"
 REMOTE_HEALTH_MAX_ATTEMPTS="${REMOTE_HEALTH_MAX_ATTEMPTS:-120}"
 REMOTE_GRAPHHOPPER_READY_MAX_ATTEMPTS="${REMOTE_GRAPHHOPPER_READY_MAX_ATTEMPTS:-180}"
 GRAPHHOPPER_CACHE_ARCHIVE_URL="${GRAPHHOPPER_CACHE_ARCHIVE_URL:-}"
+GRAPHHOPPER_CACHE_ARCHIVE_FILE="${GRAPHHOPPER_CACHE_ARCHIVE_FILE:-}"
 GRAPHHOPPER_CACHE_EXPORT="${GRAPHHOPPER_CACHE_EXPORT:-false}"
+AWS_ROUTING_MODE="${AWS_ROUTING_MODE:-graphhopper}"
 INSTANCE_TTL_SECONDS="${INSTANCE_TTL_SECONDS:-1800}"
 MAX_INSTANCE_TTL_SECONDS="${MAX_INSTANCE_TTL_SECONDS:-3600}"
 ALLOW_AFTER_K6_FAILURE="${ALLOW_AFTER_K6_FAILURE:-false}"
@@ -53,6 +55,7 @@ SG_ID=""
 INSTANCE_ID=""
 INSTANCE_PUBLIC_IP=""
 REMOTE_SECRET_ENV=""
+REMOTE_GRAPHHOPPER_CACHE_ARCHIVE=""
 CLEANUP_DETAILS=""
 
 log() {
@@ -113,6 +116,23 @@ duration_to_seconds() {
 validate_cost_guardrails() {
   local duration_seconds total_vus
   validate_instance_type
+
+  case "$AWS_ROUTING_MODE" in
+    graphhopper|fake)
+      ;;
+    *)
+      echo "AWS_ROUTING_MODE must be either graphhopper or fake: $AWS_ROUTING_MODE" >&2
+      exit 22
+      ;;
+  esac
+  if [[ -n "$GRAPHHOPPER_CACHE_ARCHIVE_URL" && -n "$GRAPHHOPPER_CACHE_ARCHIVE_FILE" ]]; then
+    echo "Use only one of GRAPHHOPPER_CACHE_ARCHIVE_URL or GRAPHHOPPER_CACHE_ARCHIVE_FILE." >&2
+    exit 23
+  fi
+  if [[ -n "$GRAPHHOPPER_CACHE_ARCHIVE_FILE" && ! -f "$GRAPHHOPPER_CACHE_ARCHIVE_FILE" ]]; then
+    echo "GRAPHHOPPER_CACHE_ARCHIVE_FILE does not exist: $GRAPHHOPPER_CACHE_ARCHIVE_FILE" >&2
+    exit 24
+  fi
 
   for value_name in ROOT_VOLUME_SIZE_GB MAX_ROOT_VOLUME_SIZE_GB INSTANCE_TTL_SECONDS MAX_INSTANCE_TTL_SECONDS MAX_RUN_DURATION_SECONDS \
     K6_AI_ROUTE_VUS K6_COURSE_MAP_READ_VUS K6_FREE_RIDE_VUS K6_COURSE_FOLLOW_VUS K6_RIDE_FINALIZATION_VUS MAX_SINGLE_COMPOSE_TOTAL_VUS; do
@@ -177,6 +197,9 @@ write_preflight_receipt() {
     echo "  \"runDuration\": \"$RUN_DURATION\","
     echo "  \"runDurationSeconds\": $duration_seconds,"
     echo "  \"maxRunDurationSeconds\": $MAX_RUN_DURATION_SECONDS,"
+    echo "  \"routingMode\": \"$AWS_ROUTING_MODE\","
+    echo "  \"graphhopperCacheArchiveUrlProvided\": $([[ -n "$GRAPHHOPPER_CACHE_ARCHIVE_URL" ]] && echo true || echo false),"
+    echo "  \"graphhopperCacheArchiveFileProvided\": $([[ -n "$GRAPHHOPPER_CACHE_ARCHIVE_FILE" ]] && echo true || echo false),"
     echo "  \"runBefore\": $run_before_json,"
     echo "  \"instanceTtlSeconds\": $INSTANCE_TTL_SECONDS,"
     echo "  \"maxInstanceTtlSeconds\": $MAX_INSTANCE_TTL_SECONDS,"
@@ -208,6 +231,10 @@ cleanup() {
   if [[ -n "$REMOTE_SECRET_ENV" && -n "$INSTANCE_PUBLIC_IP" && -f "$KEY_FILE" ]]; then
     ssh_run "rm -f '$REMOTE_SECRET_ENV'" >/dev/null 2>&1
     add_cleanup_detail "remote_secret_env_removed" "$?"
+  fi
+  if [[ -n "$REMOTE_GRAPHHOPPER_CACHE_ARCHIVE" && -n "$INSTANCE_PUBLIC_IP" && -f "$KEY_FILE" ]]; then
+    ssh_run "rm -f '$REMOTE_GRAPHHOPPER_CACHE_ARCHIVE'" >/dev/null 2>&1
+    add_cleanup_detail "remote_graphhopper_cache_archive_removed" "$?"
   fi
 
   if [[ -n "$INSTANCE_ID" ]]; then
@@ -276,16 +303,25 @@ package_tree() {
     cp "$ROOT_DIR/ops/loadtest/k6/ai-route-graphhopper-100-users.js" \
       "$package_dir/dev/bike-back/ops/loadtest/k6/ai-route-graphhopper-100-users.js"
   else
-    rsync -a --delete \
-      --exclude .git \
-      --exclude .gradle \
-      --include '.env.example' \
-      --include '.env.test.example' \
-      --exclude '.env' \
-      --exclude '.env.*' \
-      --exclude build \
-      --exclude 'ops/loadtest/results' \
-      "$ROOT_DIR/" "$package_dir/dev/bike-back/"
+    local backend_rsync_args=(
+      rsync -a --delete
+      --exclude .git
+      --exclude .gradle
+      --include '.env.example'
+      --include '.env.test.example'
+      --exclude '.env'
+      --exclude '.env.*'
+      --exclude build
+      --exclude 'ops/loadtest/results'
+    )
+    if [[ "$AWS_ROUTING_MODE" == "fake" ]]; then
+      backend_rsync_args+=(
+        --exclude 'ops/graphhopper/data'
+        --exclude 'ops/graphhopper/graphhopper-web-*.jar'
+      )
+    fi
+    backend_rsync_args+=("$ROOT_DIR/" "$package_dir/dev/bike-back/")
+    "${backend_rsync_args[@]}"
   fi
 
   rsync -a --delete \
@@ -352,12 +388,16 @@ run_remote_case() {
   log "running $label compose+k6"
   local remote_status
   set +e
-  ssh_run "LABEL='$label' REMOTE_TAR='$remote_tar' REMOTE_DIR='$remote_dir' TEST_ID='$test_id' RUN_DURATION='$RUN_DURATION' REMOTE_SECRET_ENV='$REMOTE_SECRET_ENV' K6_AI_ROUTE_VUS='$K6_AI_ROUTE_VUS' K6_COURSE_MAP_READ_VUS='$K6_COURSE_MAP_READ_VUS' K6_FREE_RIDE_VUS='$K6_FREE_RIDE_VUS' K6_COURSE_FOLLOW_VUS='$K6_COURSE_FOLLOW_VUS' K6_RIDE_FINALIZATION_VUS='$K6_RIDE_FINALIZATION_VUS' K6_COURSE_READY_MAX_ATTEMPTS='$K6_COURSE_READY_MAX_ATTEMPTS' K6_COURSE_READY_POLL_SECONDS='$K6_COURSE_READY_POLL_SECONDS' K6_RIDE_FINALIZATION_REQUIRE_READY='$K6_RIDE_FINALIZATION_REQUIRE_READY' K6_RIDE_FINALIZATION_READY_FAILURE_THRESHOLD='$K6_RIDE_FINALIZATION_READY_FAILURE_THRESHOLD' REMOTE_HEALTH_MAX_ATTEMPTS='$REMOTE_HEALTH_MAX_ATTEMPTS' REMOTE_GRAPHHOPPER_READY_MAX_ATTEMPTS='$REMOTE_GRAPHHOPPER_READY_MAX_ATTEMPTS' RESET_GRAPHHOPPER_CACHE='$RESET_GRAPHHOPPER_CACHE' GRAPHHOPPER_CACHE_ARCHIVE_URL='$GRAPHHOPPER_CACHE_ARCHIVE_URL' GRAPHHOPPER_CACHE_EXPORT='$GRAPHHOPPER_CACHE_EXPORT' bash -s" <<'REMOTE'
+  ssh_run "LABEL='$label' REMOTE_TAR='$remote_tar' REMOTE_DIR='$remote_dir' TEST_ID='$test_id' RUN_DURATION='$RUN_DURATION' REMOTE_SECRET_ENV='$REMOTE_SECRET_ENV' REMOTE_GRAPHHOPPER_CACHE_ARCHIVE='$REMOTE_GRAPHHOPPER_CACHE_ARCHIVE' K6_AI_ROUTE_VUS='$K6_AI_ROUTE_VUS' K6_COURSE_MAP_READ_VUS='$K6_COURSE_MAP_READ_VUS' K6_FREE_RIDE_VUS='$K6_FREE_RIDE_VUS' K6_COURSE_FOLLOW_VUS='$K6_COURSE_FOLLOW_VUS' K6_RIDE_FINALIZATION_VUS='$K6_RIDE_FINALIZATION_VUS' K6_COURSE_READY_MAX_ATTEMPTS='$K6_COURSE_READY_MAX_ATTEMPTS' K6_COURSE_READY_POLL_SECONDS='$K6_COURSE_READY_POLL_SECONDS' K6_RIDE_FINALIZATION_REQUIRE_READY='$K6_RIDE_FINALIZATION_REQUIRE_READY' K6_RIDE_FINALIZATION_READY_FAILURE_THRESHOLD='$K6_RIDE_FINALIZATION_READY_FAILURE_THRESHOLD' REMOTE_HEALTH_MAX_ATTEMPTS='$REMOTE_HEALTH_MAX_ATTEMPTS' REMOTE_GRAPHHOPPER_READY_MAX_ATTEMPTS='$REMOTE_GRAPHHOPPER_READY_MAX_ATTEMPTS' RESET_GRAPHHOPPER_CACHE='$RESET_GRAPHHOPPER_CACHE' GRAPHHOPPER_CACHE_ARCHIVE_URL='$GRAPHHOPPER_CACHE_ARCHIVE_URL' GRAPHHOPPER_CACHE_EXPORT='$GRAPHHOPPER_CACHE_EXPORT' AWS_ROUTING_MODE='$AWS_ROUTING_MODE' bash -s" <<'REMOTE'
 	set -Eeuo pipefail
 	mkdir -p "$REMOTE_DIR"
 	tar -xzf "$REMOTE_TAR" -C "$REMOTE_DIR"
 	cd "$REMOTE_DIR/dev/bike-back"
 	mkdir -p ops/loadtest/results
+	COMPOSE_FILES="-f docker-compose.test.yml"
+	if [[ "$AWS_ROUTING_MODE" == "fake" ]]; then
+	  COMPOSE_FILES="$COMPOSE_FILES -f docker-compose.test.fake-routing.yml"
+	fi
 	write_remote_stage() {
 	  printf '%s %s\n' "$(date -Iseconds)" "$1" >> ops/loadtest/results/"$TEST_ID"-remote-stage.txt
 	}
@@ -372,22 +412,22 @@ run_remote_case() {
 	  write_remote_stage "cleanup remote_status=$remote_status"
 	  echo "$remote_status" > ops/loadtest/results/"$TEST_ID"-remote-exit-code.txt
 	  if [[ "$remote_status" != "0" ]]; then
-	    docker compose --env-file .env.test -f docker-compose.test.yml ps \
+	    docker compose --env-file .env.test $COMPOSE_FILES ps \
 	      > ops/loadtest/results/"$TEST_ID"-compose-ps.txt 2>&1 || true
-	    docker compose --env-file .env.test -f docker-compose.test.yml logs --tail=300 bike-back \
+	    docker compose --env-file .env.test $COMPOSE_FILES logs --tail=300 bike-back \
 	      > ops/loadtest/results/"$TEST_ID"-bike-back-tail.log 2>&1 || true
-	    docker compose --env-file .env.test -f docker-compose.test.yml logs --tail=300 ai-route-worker graphhopper \
+	    docker compose --env-file .env.test $COMPOSE_FILES logs --tail=300 ai-route-worker graphhopper \
 	      > ops/loadtest/results/"$TEST_ID"-routing-logs.txt 2>&1 || true
 	    cp /tmp/"$LABEL"-health.json ops/loadtest/results/"$TEST_ID"-health.json 2>/dev/null || true
 	    cp /tmp/"$LABEL"-health.err ops/loadtest/results/"$TEST_ID"-health.err 2>/dev/null || true
 	    cp /tmp/"$LABEL"-graphhopper-ready.err ops/loadtest/results/"$TEST_ID"-graphhopper-ready.err 2>/dev/null || true
 	  fi
 	  if [[ "$RESET_GRAPHHOPPER_CACHE" == "true" ]]; then
-	    docker compose --env-file .env.test -f docker-compose.test.yml down -v >/dev/null 2>&1 || true
+	    docker compose --env-file .env.test $COMPOSE_FILES down -v >/dev/null 2>&1 || true
 	  else
-	    docker compose --env-file .env.test -f docker-compose.test.yml down >/dev/null 2>&1 || true
+	    docker compose --env-file .env.test $COMPOSE_FILES down >/dev/null 2>&1 || true
 	  fi
-	  rm -f .env.test "$REMOTE_SECRET_ENV"
+	  rm -f .env.test "$REMOTE_SECRET_ENV" "$REMOTE_GRAPHHOPPER_CACHE_ARCHIVE"
 	  exit "$remote_status"
 	}
 	trap remote_cleanup EXIT
@@ -400,31 +440,49 @@ write_remote_stage "bootJar_start"
 write_remote_stage "bootJar_done"
 if [[ "$RESET_GRAPHHOPPER_CACHE" == "true" ]]; then
   write_remote_stage "compose_down_with_volume_reset"
-  docker compose --env-file .env.test -f docker-compose.test.yml down -v >/dev/null 2>&1 || true
+  docker compose --env-file .env.test $COMPOSE_FILES down -v >/dev/null 2>&1 || true
 else
   write_remote_stage "compose_down_keep_volumes"
-  docker compose --env-file .env.test -f docker-compose.test.yml down >/dev/null 2>&1 || true
+  docker compose --env-file .env.test $COMPOSE_FILES down >/dev/null 2>&1 || true
 fi
 
 restore_graphhopper_cache() {
+  if [[ "$AWS_ROUTING_MODE" == "fake" ]]; then
+    write_remote_stage "cache_restore_skipped_fake_routing"
+    return 0
+  fi
+  if [[ -n "$REMOTE_GRAPHHOPPER_CACHE_ARCHIVE" ]]; then
+    echo "restore_graphhopper_cache source=remote_file"
+    write_remote_stage "cache_restore_start remote_file"
+    docker compose --env-file .env.test $COMPOSE_FILES run -T --rm --no-deps \
+      --volume "$REMOTE_GRAPHHOPPER_CACHE_ARCHIVE:/cache.tgz:ro" \
+      --entrypoint sh graphhopper-prepare -c \
+      "set -eu; mkdir -p /data; tar -xzf /cache.tgz -C /data; test -d /data/graph-cache" \
+      < /dev/null
+    write_remote_stage "cache_restore_done remote_file"
+    return 0
+  fi
   if [[ -z "$GRAPHHOPPER_CACHE_ARCHIVE_URL" ]]; then
     write_remote_stage "cache_restore_skipped"
     return 0
   fi
   echo "restore_graphhopper_cache source=$GRAPHHOPPER_CACHE_ARCHIVE_URL"
   write_remote_stage "cache_restore_start"
-  docker compose --env-file .env.test -f docker-compose.test.yml run -T --rm --no-deps --entrypoint sh graphhopper-prepare -c \
+  docker compose --env-file .env.test $COMPOSE_FILES run -T --rm --no-deps --entrypoint sh graphhopper-prepare -c \
     "set -eu; mkdir -p /data; curl -fsSL '$GRAPHHOPPER_CACHE_ARCHIVE_URL' -o /tmp/graphhopper-cache.tgz; tar -xzf /tmp/graphhopper-cache.tgz -C /data; test -d /data/graph-cache" \
     < /dev/null
   write_remote_stage "cache_restore_done"
 }
 
 export_graphhopper_cache() {
+  if [[ "$AWS_ROUTING_MODE" == "fake" ]]; then
+    return 0
+  fi
   if [[ "$GRAPHHOPPER_CACHE_EXPORT" != "true" ]]; then
     return 0
   fi
   echo "export_graphhopper_cache target=ops/loadtest/results/$TEST_ID-graphhopper-cache.tgz"
-  docker compose --env-file .env.test -f docker-compose.test.yml run -T --rm --no-deps --entrypoint sh graphhopper-prepare -c \
+  docker compose --env-file .env.test $COMPOSE_FILES run -T --rm --no-deps --entrypoint sh graphhopper-prepare -c \
     "set -eu; test -d /data/graph-cache; tar -czf - -C /data graph-cache" \
     < /dev/null \
     > ops/loadtest/results/"$TEST_ID"-graphhopper-cache.tgz
@@ -432,7 +490,7 @@ export_graphhopper_cache() {
 
 restore_graphhopper_cache
 write_remote_stage "compose_up_start"
-docker compose --env-file .env.test -f docker-compose.test.yml up --build -d
+docker compose --env-file .env.test $COMPOSE_FILES up --build -d
 write_remote_stage "compose_up_done"
 
 health_status() {
@@ -455,8 +513,8 @@ for attempt in $(seq 1 "$REMOTE_HEALTH_MAX_ATTEMPTS"); do
   sleep 5
 done
 if [[ "${status:-}" != "200" ]]; then
-  docker compose --env-file .env.test -f docker-compose.test.yml ps || true
-  docker compose --env-file .env.test -f docker-compose.test.yml logs --tail=200 bike-back || true
+  docker compose --env-file .env.test $COMPOSE_FILES ps || true
+  docker compose --env-file .env.test $COMPOSE_FILES logs --tail=200 bike-back || true
   echo "health check did not pass after $REMOTE_HEALTH_MAX_ATTEMPTS attempts; last_status=${status:-000}" >&2
   exit 21
 fi
@@ -464,34 +522,39 @@ echo "health_status=$status"
 write_remote_stage "health_ready status=$status"
 
 graphhopper_route_status() {
-  docker compose --env-file .env.test -f docker-compose.test.yml run -T --rm --no-deps --entrypoint sh graphhopper-prepare -c \
+  docker compose --env-file .env.test $COMPOSE_FILES run -T --rm --no-deps --entrypoint sh graphhopper-prepare -c \
     "curl -sS -o /tmp/graphhopper-route-ready.json -w '%{http_code}' --max-time 10 'http://graphhopper:8989/route?profile=bike&point=37.481247,126.952739&point=37.551200,126.988200&points_encoded=false&elevation=true'" \
     < /dev/null \
     2>/tmp/"$LABEL"-graphhopper-ready.err || true
 }
 
-for attempt in $(seq 1 "$REMOTE_GRAPHHOPPER_READY_MAX_ATTEMPTS"); do
-  graphhopper_status="$(graphhopper_route_status)"
-  echo "graphhopper_attempt=$attempt status=${graphhopper_status:-000}"
-  if [[ "$graphhopper_status" == "200" ]]; then
-    break
-  fi
-  if [[ "$attempt" == "$REMOTE_GRAPHHOPPER_READY_MAX_ATTEMPTS" ]]; then
-    docker compose --env-file .env.test -f docker-compose.test.yml ps || true
-    docker compose --env-file .env.test -f docker-compose.test.yml logs --tail=200 graphhopper || true
+if [[ "$AWS_ROUTING_MODE" == "fake" ]]; then
+  echo "graphhopper_route_ready_status=skipped_fake_routing"
+  write_remote_stage "graphhopper_ready skipped_fake_routing"
+else
+  for attempt in $(seq 1 "$REMOTE_GRAPHHOPPER_READY_MAX_ATTEMPTS"); do
+    graphhopper_status="$(graphhopper_route_status)"
+    echo "graphhopper_attempt=$attempt status=${graphhopper_status:-000}"
+    if [[ "$graphhopper_status" == "200" ]]; then
+      break
+    fi
+    if [[ "$attempt" == "$REMOTE_GRAPHHOPPER_READY_MAX_ATTEMPTS" ]]; then
+      docker compose --env-file .env.test $COMPOSE_FILES ps || true
+      docker compose --env-file .env.test $COMPOSE_FILES logs --tail=200 graphhopper || true
+      echo "GraphHopper route readiness did not pass after $REMOTE_GRAPHHOPPER_READY_MAX_ATTEMPTS attempts; last_status=${graphhopper_status:-000}" >&2
+      exit 23
+    fi
+    sleep 5
+  done
+  if [[ "${graphhopper_status:-}" != "200" ]]; then
+    docker compose --env-file .env.test $COMPOSE_FILES ps || true
+    docker compose --env-file .env.test $COMPOSE_FILES logs --tail=200 graphhopper || true
     echo "GraphHopper route readiness did not pass after $REMOTE_GRAPHHOPPER_READY_MAX_ATTEMPTS attempts; last_status=${graphhopper_status:-000}" >&2
     exit 23
   fi
-  sleep 5
-done
-if [[ "${graphhopper_status:-}" != "200" ]]; then
-  docker compose --env-file .env.test -f docker-compose.test.yml ps || true
-  docker compose --env-file .env.test -f docker-compose.test.yml logs --tail=200 graphhopper || true
-  echo "GraphHopper route readiness did not pass after $REMOTE_GRAPHHOPPER_READY_MAX_ATTEMPTS attempts; last_status=${graphhopper_status:-000}" >&2
-  exit 23
+  echo "graphhopper_route_ready_status=$graphhopper_status"
+  write_remote_stage "graphhopper_ready status=$graphhopper_status"
 fi
-echo "graphhopper_route_ready_status=$graphhopper_status"
-write_remote_stage "graphhopper_ready status=$graphhopper_status"
 
 mkdir -p ops/loadtest/results
 set +e
@@ -522,18 +585,18 @@ write_remote_stage "k6_done status=$k6_status"
 docker stats --no-stream --format 'table {{.Name}}\t{{.CPUPerc}}\t{{.MemUsage}}' \
   bike-test-backend bike-test-postgres bike-test-graphhopper bike-test-ai-route-worker \
   > ops/loadtest/results/"$TEST_ID"-docker-stats.txt || true
-docker compose --env-file .env.test -f docker-compose.test.yml logs --since=20m bike-back \
+docker compose --env-file .env.test $COMPOSE_FILES logs --since=20m bike-back \
   | grep -E 'duplicate key|UnexpectedRollbackException|ride_record_finalization_failed|ERROR' \
   > ops/loadtest/results/"$TEST_ID"-error-scan.txt || true
-docker compose --env-file .env.test -f docker-compose.test.yml logs --since=20m ai-route-worker graphhopper \
+docker compose --env-file .env.test $COMPOSE_FILES logs --since=20m ai-route-worker graphhopper \
   > ops/loadtest/results/"$TEST_ID"-routing-logs.txt || true
-docker compose --env-file .env.test -f docker-compose.test.yml ps \
+docker compose --env-file .env.test $COMPOSE_FILES ps \
   > ops/loadtest/results/"$TEST_ID"-compose-ps.txt || true
 export_graphhopper_cache
 if [[ "$RESET_GRAPHHOPPER_CACHE" == "true" ]]; then
-  docker compose --env-file .env.test -f docker-compose.test.yml down -v
+  docker compose --env-file .env.test $COMPOSE_FILES down -v
 else
-  docker compose --env-file .env.test -f docker-compose.test.yml down
+  docker compose --env-file .env.test $COMPOSE_FILES down
 fi
 rm -f .env.test
 REMOTE
@@ -673,6 +736,12 @@ EOF
 	    scp_to_instance "$SECRET_ENV_FILE" "$REMOTE_SECRET_ENV"
 	    ssh_run "chmod 600 '$REMOTE_SECRET_ENV'"
 	  fi
+  if [[ -n "$GRAPHHOPPER_CACHE_ARCHIVE_FILE" ]]; then
+    REMOTE_GRAPHHOPPER_CACHE_ARCHIVE="/home/$SSH_USER/$PREFIX-graphhopper-cache.tgz"
+    log "uploading graphhopper cache archive for runtime restore"
+    scp_to_instance "$GRAPHHOPPER_CACHE_ARCHIVE_FILE" "$REMOTE_GRAPHHOPPER_CACHE_ARCHIVE"
+    ssh_run "chmod 600 '$REMOTE_GRAPHHOPPER_CACHE_ARCHIVE'"
+  fi
 
   log "installing remote dependencies"
   ssh_run "K6_VERSION='$K6_VERSION' bash -s" <<'REMOTE'
@@ -723,6 +792,9 @@ REMOTE
     echo "  \"publicIp\": \"$INSTANCE_PUBLIC_IP\","
     echo "  \"beforeRef\": \"$BEFORE_REF\","
 	    echo "  \"runDuration\": \"$RUN_DURATION\","
+	    echo "  \"routingMode\": \"$AWS_ROUTING_MODE\","
+	    echo "  \"graphhopperCacheArchiveUrlProvided\": $([[ -n "$GRAPHHOPPER_CACHE_ARCHIVE_URL" ]] && echo true || echo false),"
+	    echo "  \"graphhopperCacheArchiveFileProvided\": $([[ -n "$GRAPHHOPPER_CACHE_ARCHIVE_FILE" ]] && echo true || echo false),"
 	    echo "  \"instanceTtlSeconds\": $INSTANCE_TTL_SECONDS,"
 	    echo "  \"expiresAt\": \"$expires_at\","
 	    echo "  \"vus\": {\"aiRoute\": $K6_AI_ROUTE_VUS, \"courseMapRead\": $K6_COURSE_MAP_READ_VUS, \"freeRide\": $K6_FREE_RIDE_VUS, \"courseFollow\": $K6_COURSE_FOLLOW_VUS},"

--- a/ops/smoke/run-ai-route-evidence-smoke.sh
+++ b/ops/smoke/run-ai-route-evidence-smoke.sh
@@ -1,0 +1,268 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+BASE_URL="${BIKE_SMOKE_BASE_URL:-http://127.0.0.1:8080}"
+GRAPHHOPPER_URL="${BIKE_SMOKE_GRAPHHOPPER_URL:-http://127.0.0.1:8989}"
+RESULTS_DIR="${RESULTS_DIR:-$ROOT_DIR/ops/smoke/results/ai-route-evidence-smoke-$(date +%Y%m%d-%H%M%S)}"
+
+RUN_GRAPHHOPPER_DIRECT="${RUN_GRAPHHOPPER_DIRECT:-true}"
+RUN_OPENAPI_CONTRACT="${RUN_OPENAPI_CONTRACT:-true}"
+RUN_AI_ROUTE_SMOKE="${RUN_AI_ROUTE_SMOKE:-true}"
+VALIDATE_ONLY="${VALIDATE_ONLY:-false}"
+
+mkdir -p "$RESULTS_DIR"
+
+log() {
+  printf '[%s] %s\n' "$(date -Iseconds)" "$*"
+}
+
+require_command() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "missing required command: $1" >&2
+    exit 10
+  fi
+}
+
+write_summary() {
+  local status="$1"
+  python3 - "$RESULTS_DIR" "$status" "$BASE_URL" "$GRAPHHOPPER_URL" <<'PY'
+import json
+import pathlib
+import sys
+from datetime import datetime, timezone
+
+results_dir = pathlib.Path(sys.argv[1])
+steps = []
+for path in sorted(results_dir.glob("*.step.json")):
+    with path.open("r", encoding="utf-8") as handle:
+        steps.append(json.load(handle))
+summary = {
+    "status": sys.argv[2],
+    "baseUrl": sys.argv[3],
+    "graphhopperUrl": sys.argv[4],
+    "createdAt": datetime.now(timezone.utc).isoformat(),
+    "steps": steps,
+}
+with (results_dir / "summary.json").open("w", encoding="utf-8") as handle:
+    json.dump(summary, handle, ensure_ascii=False, indent=2)
+PY
+}
+
+record_step() {
+  local label="$1"
+  local status="$2"
+  local body_file="$3"
+  cat >"$RESULTS_DIR/$label.step.json" <<EOF
+{
+  "label": "$label",
+  "status": "$status",
+  "bodyFile": "$(basename "$body_file")"
+}
+EOF
+}
+
+http_json() {
+  local label="$1"
+  local method="$2"
+  local url="$3"
+  local payload="${4:-}"
+  shift 4 || true
+
+  local body_file="$RESULTS_DIR/$label.body.json"
+  local status_file="$RESULTS_DIR/$label.status"
+  local status
+  local -a args
+  args=(-sS -X "$method" "$url" -o "$body_file" -w "%{http_code}" -H "Accept: application/json")
+  if [[ -n "$payload" ]]; then
+    args+=(-H "Content-Type: application/json" --data "$payload")
+  fi
+  args+=("$@")
+  status="$(curl "${args[@]}")"
+  printf '%s' "$status" >"$status_file"
+  record_step "$label" "$status" "$body_file"
+}
+
+require_status() {
+  local label="$1"
+  local expected="$2"
+  local actual
+  actual="$(cat "$RESULTS_DIR/$label.status")"
+  if [[ "$actual" != "$expected" ]]; then
+    echo "$label expected HTTP $expected but got $actual" >&2
+    echo "body: $RESULTS_DIR/$label.body.json" >&2
+    exit 20
+  fi
+}
+
+assert_graphhopper_route() {
+  local label="$1"
+  python3 - "$RESULTS_DIR/$label.body.json" "$label" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], "r", encoding="utf-8") as handle:
+    payload = json.load(handle)
+paths = payload.get("paths")
+if not isinstance(paths, list) or not paths:
+    raise SystemExit(f"{sys.argv[2]}: expected non-empty paths")
+details = paths[0].get("details")
+if not isinstance(details, dict):
+    raise SystemExit(f"{sys.argv[2]}: expected route details")
+required = {"average_slope", "bike_network", "max_slope", "road_class", "road_environment", "smoothness", "surface"}
+missing = sorted(required.difference(details))
+if missing:
+    raise SystemExit(f"{sys.argv[2]}: missing route details {missing}")
+PY
+}
+
+assert_openapi_fields() {
+  python3 - "$RESULTS_DIR/openapi.body.json" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], "r", encoding="utf-8") as handle:
+    raw = handle.read()
+json.loads(raw)
+required = [
+    "preferenceSummary",
+    "elevationStatus",
+    "sceneryEvidenceStatus",
+    "routingMetadata",
+    "aiWorkerMetadata",
+    "evidenceBadges",
+]
+missing = [field for field in required if field not in raw]
+if missing:
+    raise SystemExit(f"OpenAPI missing fields: {missing}")
+PY
+}
+
+assert_ai_route_response() {
+  local label="$1"
+  python3 - "$RESULTS_DIR/$label.body.json" "$label" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], "r", encoding="utf-8") as handle:
+    payload = json.load(handle)
+if payload.get("code") != 200:
+    raise SystemExit(f"{sys.argv[2]}: expected code=200, got {payload.get('code')}")
+data = payload.get("data")
+if not isinstance(data, dict):
+    raise SystemExit(f"{sys.argv[2]}: expected data object")
+routing = data.get("routingMetadata")
+if not isinstance(routing, dict):
+    raise SystemExit(f"{sys.argv[2]}: expected routingMetadata object")
+if routing.get("provider") != "GRAPHHOPPER":
+    raise SystemExit(f"{sys.argv[2]}: expected GraphHopper routing provider, got {routing.get('provider')}")
+if not data.get("preferenceSummary"):
+    raise SystemExit(f"{sys.argv[2]}: preferenceSummary is empty")
+if data.get("elevationStatus") is None:
+    raise SystemExit(f"{sys.argv[2]}: elevationStatus is missing")
+if data.get("sceneryEvidenceStatus") is None:
+    raise SystemExit(f"{sys.argv[2]}: sceneryEvidenceStatus is missing")
+if not isinstance(data.get("aiWorkerMetadata"), dict):
+    raise SystemExit(f"{sys.argv[2]}: aiWorkerMetadata is missing")
+if not isinstance(data.get("evidenceBadges"), list):
+    raise SystemExit(f"{sys.argv[2]}: evidenceBadges is missing")
+PY
+}
+
+graphhopper_payload() {
+  local mode="$1"
+  python3 - "$mode" <<'PY'
+import json
+import sys
+
+payload = {
+    "profile": "bike",
+    "points": [[126.9527, 37.4812], [126.9894, 37.5499]],
+    "points_encoded": False,
+    "details": [
+        "average_slope",
+        "bike_network",
+        "max_slope",
+        "road_class",
+        "road_environment",
+        "smoothness",
+        "surface",
+    ],
+}
+if sys.argv[1] == "custom":
+    payload["custom_model"] = {
+        "priority": [
+            {"if": "road_class == MOTORWAY", "multiply_by": "0.0"},
+            {"if": "bike_network == MISSING", "multiply_by": "0.9"},
+        ]
+    }
+print(json.dumps(payload))
+PY
+}
+
+ai_route_payload() {
+  local text="$1"
+  python3 - "$text" <<'PY'
+import json
+import sys
+
+print(json.dumps({
+    "lat": 37.4812,
+    "lon": 126.9527,
+    "text": sys.argv[1],
+}, ensure_ascii=False))
+PY
+}
+
+on_error() {
+  local exit_code="$?"
+  write_summary "failed"
+  log "failed with exit_code=$exit_code. Evidence: $RESULTS_DIR"
+  exit "$exit_code"
+}
+
+trap on_error ERR
+
+main() {
+  require_command curl
+  require_command python3
+
+  if [[ "$VALIDATE_ONLY" == "true" ]]; then
+    write_summary "validated"
+    log "validated script prerequisites only. Evidence: $RESULTS_DIR"
+    return
+  fi
+
+  if [[ "$RUN_GRAPHHOPPER_DIRECT" == "true" ]]; then
+    log "GraphHopper direct baseline route"
+    http_json "graphhopper-baseline" "POST" "${GRAPHHOPPER_URL%/}/route" "$(graphhopper_payload baseline)"
+    require_status "graphhopper-baseline" "200"
+    assert_graphhopper_route "graphhopper-baseline"
+
+    log "GraphHopper direct custom-model route"
+    http_json "graphhopper-custom-model" "POST" "${GRAPHHOPPER_URL%/}/route" "$(graphhopper_payload custom)"
+    require_status "graphhopper-custom-model" "200"
+    assert_graphhopper_route "graphhopper-custom-model"
+  fi
+
+  if [[ "$RUN_OPENAPI_CONTRACT" == "true" ]]; then
+    log "OpenAPI AI route metadata fields"
+    http_json "openapi" "GET" "${BASE_URL%/}/v3/api-docs" ""
+    require_status "openapi" "200"
+    assert_openapi_fields
+  fi
+
+  if [[ "$RUN_AI_ROUTE_SMOKE" == "true" ]]; then
+    log "AI route from text metadata smoke"
+    http_json "ai-route-from-text" "POST" "${BASE_URL%/}/api/v1/ai-routes/plan/from-text" \
+      "$(ai_route_payload '평지 한강이 보이는 목적지 없는 코스')" \
+      -H "X-Guest-Device-Id: ai-route-evidence-smoke-$(date +%s)"
+    require_status "ai-route-from-text" "200"
+    assert_ai_route_response "ai-route-from-text"
+  fi
+
+  write_summary "passed"
+  log "AI route evidence smoke passed. Evidence: $RESULTS_DIR"
+}
+
+main "$@"

--- a/ops/smoke/run-hybrid-device-smoke.sh
+++ b/ops/smoke/run-hybrid-device-smoke.sh
@@ -1,0 +1,331 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+BASE_URL="${BIKE_SMOKE_BASE_URL:-http://127.0.0.1:8080}"
+RESULTS_DIR="${RESULTS_DIR:-$ROOT_DIR/ops/smoke/results/hybrid-device-smoke-$(date +%Y%m%d-%H%M%S)}"
+
+RUN_ADDRESS_SMOKE="${RUN_ADDRESS_SMOKE:-true}"
+RUN_AI_ROUTE_SMOKE="${RUN_AI_ROUTE_SMOKE:-true}"
+RUN_RIDE_SUMMARY_SMOKE="${RUN_RIDE_SUMMARY_SMOKE:-true}"
+RUN_ACCOUNT_CLEANUP="${RUN_ACCOUNT_CLEANUP:-true}"
+VALIDATE_ONLY="${VALIDATE_ONLY:-false}"
+
+REQUEST_ID_PREFIX="${REQUEST_ID_PREFIX:-hybrid-device-smoke}"
+EMAIL="${BIKE_SMOKE_EMAIL:-bike-smoke-$(date +%s)@example.com}"
+PASSWORD="${BIKE_SMOKE_PASSWORD:-SmokePassword123!}"
+DISPLAY_NAME="${BIKE_SMOKE_DISPLAY_NAME:-Hybrid Device Smoke}"
+ADDRESS_QUERY="${BIKE_SMOKE_ADDRESS_QUERY:-Seoul City Hall}"
+AI_ROUTE_TEXT="${BIKE_SMOKE_AI_ROUTE_TEXT:-flat riverside route to test provider fallback}"
+
+mkdir -p "$RESULTS_DIR"
+
+log() {
+  printf '[%s] %s\n' "$(date -Iseconds)" "$*"
+}
+
+require_command() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "missing required command: $1" >&2
+    exit 10
+  fi
+}
+
+urlencode() {
+  python3 - "$1" <<'PY'
+import sys
+from urllib.parse import quote
+
+print(quote(sys.argv[1], safe=""))
+PY
+}
+
+json_value() {
+  local file="$1"
+  local path="$2"
+  python3 - "$file" "$path" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], "r", encoding="utf-8") as handle:
+    value = json.load(handle)
+for part in sys.argv[2].split("."):
+    if isinstance(value, dict):
+        value = value.get(part)
+    else:
+        value = None
+        break
+if isinstance(value, (dict, list)):
+    print(json.dumps(value, ensure_ascii=False))
+elif value is not None:
+    print(value)
+PY
+}
+
+assert_api_response() {
+  local label="$1"
+  local body_file="$RESULTS_DIR/$label.body.json"
+  python3 - "$body_file" "$label" <<'PY'
+import json
+import sys
+
+body_file = sys.argv[1]
+label = sys.argv[2]
+with open(body_file, "r", encoding="utf-8") as handle:
+    payload = json.load(handle)
+if not isinstance(payload, dict):
+    raise SystemExit(f"{label}: response is not a JSON object")
+if payload.get("code") != 200:
+    raise SystemExit(f"{label}: expected code=200, got {payload.get('code')}")
+if "message" not in payload or "data" not in payload:
+    raise SystemExit(f"{label}: expected code/message/data wrapper")
+PY
+}
+
+redact_auth_body() {
+  local label="$1"
+  local body_file="$RESULTS_DIR/$label.body.json"
+  python3 - "$body_file" <<'PY'
+import json
+import sys
+
+body_file = sys.argv[1]
+with open(body_file, "r", encoding="utf-8") as handle:
+    payload = json.load(handle)
+data = payload.get("data")
+if isinstance(data, dict):
+    for key in ("accessToken", "refreshToken"):
+        if key in data and data[key]:
+            data[key] = "__redacted__"
+with open(body_file, "w", encoding="utf-8") as handle:
+    json.dump(payload, handle, ensure_ascii=False, indent=2)
+PY
+}
+
+require_status() {
+  local label="$1"
+  local expected="$2"
+  local actual
+  actual="$(cat "$RESULTS_DIR/$label.status")"
+  if [[ "$actual" != "$expected" ]]; then
+    echo "$label expected HTTP $expected but got $actual" >&2
+    echo "body: $RESULTS_DIR/$label.body.json" >&2
+    exit 20
+  fi
+}
+
+record_step() {
+  local label="$1"
+  local method="$2"
+  local path="$3"
+  local status="$4"
+  local request_id="$5"
+  local trace_id="$6"
+  cat >"$RESULTS_DIR/$label.step.json" <<EOF
+{
+  "label": "$label",
+  "method": "$method",
+  "path": "$path",
+  "status": "$status",
+  "requestId": "$request_id",
+  "traceId": "$trace_id",
+  "bodyFile": "$label.body.json",
+  "headersFile": "$label.headers.txt"
+}
+EOF
+}
+
+extract_header() {
+  local file="$1"
+  local name="$2"
+  awk -v header="$name" 'BEGIN {IGNORECASE=1} $0 ~ "^" header ":" {sub("\r$", "", $0); sub("^[^:]+:[[:space:]]*", "", $0); print; exit}' "$file"
+}
+
+http_request() {
+  local label="$1"
+  local method="$2"
+  local path="$3"
+  local payload="${4:-}"
+  shift 4
+
+  local body_file="$RESULTS_DIR/$label.body.json"
+  local headers_file="$RESULTS_DIR/$label.headers.txt"
+  local status_file="$RESULTS_DIR/$label.status"
+  local request_id="$REQUEST_ID_PREFIX-$label-$(date +%s%N)"
+  local url="${BASE_URL%/}$path"
+  local status
+
+  local -a args
+  args=(-sS -X "$method" "$url" -D "$headers_file" -o "$body_file" -w "%{http_code}"
+    -H "Accept: application/json"
+    -H "X-Request-Id: $request_id")
+  if [[ -n "$payload" ]]; then
+    args+=(-H "Content-Type: application/json" --data "$payload")
+  fi
+  args+=("$@")
+
+  log "$method $path"
+  status="$(curl "${args[@]}")"
+  printf '%s' "$status" >"$status_file"
+
+  local response_request_id
+  local trace_id
+  response_request_id="$(extract_header "$headers_file" "X-Request-Id" || true)"
+  trace_id="$(extract_header "$headers_file" "X-Trace-Id" || true)"
+  record_step "$label" "$method" "$path" "$status" "${response_request_id:-$request_id}" "$trace_id"
+}
+
+write_summary() {
+  local status="$1"
+  python3 - "$RESULTS_DIR" "$status" "$BASE_URL" <<'PY'
+import json
+import pathlib
+import sys
+
+results_dir = pathlib.Path(sys.argv[1])
+summary_status = sys.argv[2]
+base_url = sys.argv[3]
+steps = []
+for path in sorted(results_dir.glob("*.step.json")):
+    with path.open("r", encoding="utf-8") as handle:
+        steps.append(json.load(handle))
+summary = {
+    "status": summary_status,
+    "baseUrl": base_url,
+    "createdAt": __import__("datetime").datetime.now(__import__("datetime").timezone.utc).isoformat(),
+    "steps": steps,
+}
+with (results_dir / "summary.json").open("w", encoding="utf-8") as handle:
+    json.dump(summary, handle, ensure_ascii=False, indent=2)
+PY
+}
+
+on_error() {
+  local exit_code="$?"
+  write_summary "failed"
+  log "failed with exit_code=$exit_code. Evidence: $RESULTS_DIR"
+  exit "$exit_code"
+}
+
+trap on_error ERR
+
+main() {
+  require_command curl
+  require_command python3
+
+  if [[ "$VALIDATE_ONLY" == "true" ]]; then
+    write_summary "validated"
+    log "validated script prerequisites only. Evidence: $RESULTS_DIR"
+    return
+  fi
+
+  local encoded_query
+  encoded_query="$(urlencode "$ADDRESS_QUERY")"
+
+  http_request "health" "GET" "/health" ""
+  require_status "health" "200"
+
+  http_request "courses-list" "GET" "/api/v1/courses?limit=5" ""
+  require_status "courses-list" "200"
+  assert_api_response "courses-list"
+
+  if [[ "$RUN_ADDRESS_SMOKE" == "true" ]]; then
+    http_request "address-search" "GET" "/api/v1/addresses/search?query=$encoded_query&page=1&size=5" ""
+    require_status "address-search" "200"
+    assert_api_response "address-search"
+  fi
+
+  local register_payload
+  register_payload="$(python3 - "$EMAIL" "$PASSWORD" "$DISPLAY_NAME" <<'PY'
+import json
+import sys
+
+print(json.dumps({
+    "email": sys.argv[1],
+    "password": sys.argv[2],
+    "displayName": sys.argv[3],
+    "profileImageUrl": None,
+    "legacyExternalId": None,
+    "inviteCode": None,
+}))
+PY
+)"
+  http_request "auth-register" "POST" "/api/v1/auth/register" "$register_payload"
+  require_status "auth-register" "200"
+  assert_api_response "auth-register"
+
+  local access_token
+  access_token="$(json_value "$RESULTS_DIR/auth-register.body.json" "data.accessToken")"
+  if [[ -z "$access_token" ]]; then
+    echo "auth-register response did not include data.accessToken" >&2
+    exit 21
+  fi
+  redact_auth_body "auth-register"
+
+  local login_payload
+  login_payload="$(python3 - "$EMAIL" "$PASSWORD" <<'PY'
+import json
+import sys
+
+print(json.dumps({"email": sys.argv[1], "password": sys.argv[2]}))
+PY
+)"
+  http_request "auth-login" "POST" "/api/v1/auth/login" "$login_payload"
+  require_status "auth-login" "200"
+  assert_api_response "auth-login"
+  redact_auth_body "auth-login"
+
+  if [[ "$RUN_AI_ROUTE_SMOKE" == "true" ]]; then
+    local ai_payload
+    ai_payload="$(python3 - "$AI_ROUTE_TEXT" <<'PY'
+import json
+import sys
+
+print(json.dumps({
+    "lat": 37.5665,
+    "lon": 126.9780,
+    "text": sys.argv[1],
+}))
+PY
+)"
+    http_request "ai-route-from-text" "POST" "/api/v1/ai-routes/plan/from-text" "$ai_payload" -H "X-Guest-Device-Id: hybrid-device-smoke"
+    require_status "ai-route-from-text" "200"
+    assert_api_response "ai-route-from-text"
+  fi
+
+  if [[ "$RUN_RIDE_SUMMARY_SMOKE" == "true" ]]; then
+    local ride_payload
+    ride_payload="$(python3 <<'PY'
+import datetime
+import json
+import time
+
+started_at = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(minutes=18)
+ended_at = datetime.datetime.now(datetime.timezone.utc)
+print(json.dumps({
+    "clientRideId": f"hybrid-device-smoke-{int(time.time())}",
+    "startedAt": started_at.isoformat(),
+    "endedAt": ended_at.isoformat(),
+    "summary": {
+        "distanceM": 3200,
+        "durationSec": 1080,
+    },
+}))
+PY
+)"
+    http_request "ride-summary-save" "POST" "/api/v1/ride-records/summary" "$ride_payload" -H "Authorization: Bearer $access_token"
+    require_status "ride-summary-save" "200"
+    assert_api_response "ride-summary-save"
+  fi
+
+  if [[ "$RUN_ACCOUNT_CLEANUP" == "true" ]]; then
+    http_request "auth-delete-me" "DELETE" "/api/v1/auth/me" "" -H "Authorization: Bearer $access_token"
+    require_status "auth-delete-me" "200"
+    assert_api_response "auth-delete-me"
+  fi
+
+  write_summary "passed"
+  log "hybrid device smoke passed. Evidence: $RESULTS_DIR"
+}
+
+main "$@"

--- a/ops/smoke/run-hybrid-preflight.sh
+++ b/ops/smoke/run-hybrid-preflight.sh
@@ -77,6 +77,7 @@ main() {
     require_command docker
     run_shell_step "compose-local-config" "docker compose -f docker-compose.local.yml config >/tmp/bike-compose-local.yml"
     run_shell_step "compose-test-config" "docker compose -f docker-compose.test.yml config >/tmp/bike-compose-test.yml"
+    run_shell_step "compose-test-fake-routing-config" "docker compose -f docker-compose.test.yml -f docker-compose.test.fake-routing.yml config >/tmp/bike-compose-test-fake-routing.yml"
   fi
 
   if [[ "$RUN_AWS_SCRIPT_SYNTAX" == "true" ]]; then

--- a/src/main/java/com/bikeprojectminji/bikeback/airoute/dto/AiRoutePlanResponse.java
+++ b/src/main/java/com/bikeprojectminji/bikeback/airoute/dto/AiRoutePlanResponse.java
@@ -21,7 +21,10 @@ public record AiRoutePlanResponse(
         boolean aiGenerated,
         AiRouteElevationSummaryResponse elevationSummary,
         AiRouteRoutingMetadataResponse routingMetadata,
-        AiRouteWorkerMetadataResponse aiWorkerMetadata
+        AiRouteWorkerMetadataResponse aiWorkerMetadata,
+        String preferenceSummary,
+        String elevationStatus,
+        String sceneryEvidenceStatus
 ) {
 
     public AiRoutePlanResponse(
@@ -55,6 +58,9 @@ public record AiRoutePlanResponse(
                 explanation,
                 evidenceBadges,
                 aiGenerated,
+                null,
+                null,
+                null,
                 null,
                 null,
                 null
@@ -95,6 +101,9 @@ public record AiRoutePlanResponse(
                 aiGenerated,
                 elevationSummary,
                 null,
+                null,
+                null,
+                null,
                 null
         );
     }
@@ -134,7 +143,55 @@ public record AiRoutePlanResponse(
                 aiGenerated,
                 elevationSummary,
                 routingMetadata,
+                null,
+                null,
+                null,
                 null
+        );
+    }
+
+    public AiRoutePlanResponse(
+            String planId,
+            String status,
+            String summary,
+            String confidence,
+            WeatherData weather,
+            WindData wind,
+            List<AiRoutePointResponse> routePoints,
+            List<AiRouteRiskResponse> risks,
+            List<String> actions,
+            int recommendationScore,
+            RecommendationScoreResponse scoreBreakdown,
+            RecommendationExplanationResponse explanation,
+            List<ProviderEvidenceBadgeResponse> evidenceBadges,
+            boolean aiGenerated,
+            AiRouteElevationSummaryResponse elevationSummary,
+            AiRouteRoutingMetadataResponse routingMetadata,
+            String preferenceSummary,
+            String elevationStatus,
+            String sceneryEvidenceStatus
+    ) {
+        this(
+                planId,
+                status,
+                summary,
+                confidence,
+                weather,
+                wind,
+                routePoints,
+                risks,
+                actions,
+                recommendationScore,
+                scoreBreakdown,
+                explanation,
+                evidenceBadges,
+                aiGenerated,
+                elevationSummary,
+                routingMetadata,
+                null,
+                preferenceSummary,
+                elevationStatus,
+                sceneryEvidenceStatus
         );
     }
 
@@ -156,7 +213,10 @@ public record AiRoutePlanResponse(
                 aiGenerated,
                 elevationSummary,
                 routingMetadata,
-                metadata
+                metadata,
+                preferenceSummary,
+                elevationStatus,
+                sceneryEvidenceStatus
         );
     }
 }

--- a/src/main/java/com/bikeprojectminji/bikeback/airoute/service/AiRoutePlanComposer.java
+++ b/src/main/java/com/bikeprojectminji/bikeback/airoute/service/AiRoutePlanComposer.java
@@ -40,7 +40,7 @@ public class AiRoutePlanComposer {
     }
 
     public AiRoutePlanResponse composeFallback(AiRoutePlanRequest request, AiRouteConditionContext context) {
-        Optional<CurrentWeatherResponse> weather = context.weather();
+        Optional<CurrentWeatherResponse> weather = usableWeather(context.weather());
         List<AiRouteRiskResponse> risks = detailsFactory.buildRisks(weather, context);
         List<ProviderEvidenceBadgeResponse> evidenceBadges = detailsFactory.buildEvidenceBadges(weather, context);
         RecommendationScore score = recommendationScoreCalculator.calculateFallback(
@@ -81,7 +81,7 @@ public class AiRoutePlanComposer {
             BicycleRouteCandidate candidate,
             BicycleRoutePlan routePlan
     ) {
-        Optional<CurrentWeatherResponse> weather = context.weather();
+        Optional<CurrentWeatherResponse> weather = usableWeather(context.weather());
         List<AiRouteRiskResponse> risks = detailsFactory.buildRisks(weather, context);
         List<ProviderEvidenceBadgeResponse> evidenceBadges = detailsFactory.buildEvidenceBadges(weather, context);
         evidenceBadges.addAll(candidate.evidenceBadges().stream()
@@ -119,6 +119,10 @@ public class AiRoutePlanComposer {
                 toElevationSummaryResponse(candidate.elevationSummary()),
                 AiRouteRoutingMetadataResponse.from(routePlan)
         );
+    }
+
+    private Optional<CurrentWeatherResponse> usableWeather(Optional<CurrentWeatherResponse> weather) {
+        return weather.filter(current -> current.weather() != null && current.wind() != null);
     }
 
     private String buildSummary(AiRoutePlanRequest request, Optional<CurrentWeatherResponse> weather) {

--- a/src/main/java/com/bikeprojectminji/bikeback/airoute/service/AiRoutePlanComposer.java
+++ b/src/main/java/com/bikeprojectminji/bikeback/airoute/service/AiRoutePlanComposer.java
@@ -9,6 +9,7 @@ import com.bikeprojectminji.bikeback.airoute.dto.AiRouteRoutingMetadataResponse;
 import com.bikeprojectminji.bikeback.airoute.dto.ProviderEvidenceBadgeResponse;
 import com.bikeprojectminji.bikeback.routing.service.BicycleRouteCandidate;
 import com.bikeprojectminji.bikeback.routing.service.BicycleRoutePlan;
+import com.bikeprojectminji.bikeback.routing.service.BicycleRoutePreference;
 import com.bikeprojectminji.bikeback.routing.service.ElevationSummary;
 import com.bikeprojectminji.bikeback.weather.dto.CurrentWeatherResponse;
 import com.bikeprojectminji.bikeback.weather.dto.WeatherData;
@@ -63,7 +64,11 @@ public class AiRoutePlanComposer {
                 detailsFactory.buildExplanation(request, score, evidenceBadges),
                 evidenceBadges,
                 false,
-                null
+                null,
+                null,
+                preferenceSummary(request),
+                "UNAVAILABLE",
+                sceneryEvidenceStatus(request, evidenceBadges)
         );
     }
 
@@ -117,7 +122,10 @@ public class AiRoutePlanComposer {
                 evidenceBadges,
                 false,
                 toElevationSummaryResponse(candidate.elevationSummary()),
-                AiRouteRoutingMetadataResponse.from(routePlan)
+                AiRouteRoutingMetadataResponse.from(routePlan),
+                preferenceSummary(request),
+                elevationStatus(candidate.elevationSummary()),
+                sceneryEvidenceStatus(request, evidenceBadges)
         );
     }
 
@@ -184,6 +192,36 @@ public class AiRoutePlanComposer {
             return request.elevationPreference();
         }
         return request.rideStyle();
+    }
+
+    private String preferenceSummary(AiRoutePlanRequest request) {
+        return BicycleRoutePreference.from(request.rideStyle(), request.elevationPreference(), request.textIntent())
+                .preferenceSummary();
+    }
+
+    private String elevationStatus(ElevationSummary elevationSummary) {
+        if (elevationSummary == null || !elevationSummary.hasElevation()) {
+            return "UNAVAILABLE";
+        }
+        return "VERIFIED";
+    }
+
+    private String sceneryEvidenceStatus(AiRoutePlanRequest request, List<ProviderEvidenceBadgeResponse> evidenceBadges) {
+        if (!isSceneryRequested(request)) {
+            return "NOT_REQUESTED";
+        }
+        boolean hasRouteEvidence = evidenceBadges.stream()
+                .anyMatch(badge -> badge.source().startsWith("graphhopper.") || "canonical-route".equals(badge.source()));
+        if (hasRouteEvidence) {
+            return "PARTIAL";
+        }
+        return "UNKNOWN";
+    }
+
+    private boolean isSceneryRequested(AiRoutePlanRequest request) {
+        return "SCENERY_FIRST".equals(request.rideStyle())
+                || "TEXT_RIVER_VIEW".equals(request.textIntent())
+                || "TEXT_FLAT_RIVERSIDE".equals(request.textIntent());
     }
 
     private String normalizeText(String value, String fallback) {

--- a/src/main/java/com/bikeprojectminji/bikeback/airoute/service/AiRoutePlanDetailsFactory.java
+++ b/src/main/java/com/bikeprojectminji/bikeback/airoute/service/AiRoutePlanDetailsFactory.java
@@ -15,7 +15,7 @@ class AiRoutePlanDetailsFactory {
 
     List<AiRouteRiskResponse> buildRisks(Optional<CurrentWeatherResponse> weather, AiRouteConditionContext context) {
         List<AiRouteRiskResponse> risks = new ArrayList<>();
-        weather.ifPresent(current -> {
+        usableWeather(weather).ifPresent(current -> {
             if (current.wind().speedKmh() >= 18) {
                 risks.add(new AiRouteRiskResponse("weather", "강한 바람", "medium", "측풍이 강해 한강변 직선 구간은 피하는 편이 좋습니다."));
             }
@@ -30,8 +30,9 @@ class AiRoutePlanDetailsFactory {
 
     List<ProviderEvidenceBadgeResponse> buildEvidenceBadges(Optional<CurrentWeatherResponse> weather, AiRouteConditionContext context) {
         List<ProviderEvidenceBadgeResponse> badges = new ArrayList<>();
-        if (weather.isPresent()) {
-            CurrentWeatherResponse current = weather.get();
+        Optional<CurrentWeatherResponse> currentWeather = usableWeather(weather);
+        if (currentWeather.isPresent()) {
+            CurrentWeatherResponse current = currentWeather.get();
             boolean weatherRisk = current.wind().speedKmh() >= 18 || !"none".equals(current.weather().precipType());
             badges.add(new ProviderEvidenceBadgeResponse(
                     "weather",
@@ -66,7 +67,7 @@ class AiRoutePlanDetailsFactory {
     List<String> buildActions(Optional<CurrentWeatherResponse> weather, List<AiRouteRiskResponse> risks) {
         List<String> actions = new ArrayList<>();
         actions.add("출발 전 브레이크와 라이트를 확인하세요.");
-        if (weather.isEmpty()) {
+        if (usableWeather(weather).isEmpty()) {
             actions.add("날씨 데이터가 없으므로 출발 전 외부 날씨를 한 번 더 확인하세요.");
         }
         if (risks.stream().anyMatch(risk -> "high".equals(risk.severity()))) {
@@ -111,6 +112,10 @@ class AiRoutePlanDetailsFactory {
                 badge.summary(),
                 null
         );
+    }
+
+    private Optional<CurrentWeatherResponse> usableWeather(Optional<CurrentWeatherResponse> weather) {
+        return weather.filter(current -> current.weather() != null && current.wind() != null);
     }
 
     Optional<ProviderEvidenceBadgeResponse> canonicalRouteBadge(AiRoutePlanRequest request) {

--- a/src/main/java/com/bikeprojectminji/bikeback/airoute/service/AiRoutePlannerService.java
+++ b/src/main/java/com/bikeprojectminji/bikeback/airoute/service/AiRoutePlannerService.java
@@ -124,7 +124,8 @@ public class AiRoutePlannerService {
                 request.destinationLat(),
                 request.destinationLon(),
                 request.rideStyle(),
-                request.elevationPreference()
+                request.elevationPreference(),
+                request.textIntent()
         ));
         if (routePlan.candidates().isEmpty()) {
             throw new BadRequestException("GraphHopper 자전거 경로를 생성할 수 없습니다. self-host 또는 hosted GraphHopper 설정을 확인하세요.");

--- a/src/main/java/com/bikeprojectminji/bikeback/airoute/service/HttpAiRouteWorkerClient.java
+++ b/src/main/java/com/bikeprojectminji/bikeback/airoute/service/HttpAiRouteWorkerClient.java
@@ -15,7 +15,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Primary;
 import org.springframework.http.MediaType;
 import org.springframework.http.client.SimpleClientHttpRequestFactory;
@@ -26,7 +26,7 @@ import org.springframework.web.client.RestClientException;
 
 @Component
 @Primary
-@ConditionalOnProperty(name = "ai-route.worker.base-url")
+@Conditional(NonBlankAiRouteWorkerBaseUrlCondition.class)
 public class HttpAiRouteWorkerClient implements AiRouteWorkerClient {
 
     private static final Logger log = LoggerFactory.getLogger(HttpAiRouteWorkerClient.class);

--- a/src/main/java/com/bikeprojectminji/bikeback/airoute/service/HttpAiRouteWorkerClient.java
+++ b/src/main/java/com/bikeprojectminji/bikeback/airoute/service/HttpAiRouteWorkerClient.java
@@ -3,6 +3,7 @@ package com.bikeprojectminji.bikeback.airoute.service;
 import com.bikeprojectminji.bikeback.airoute.dto.AiRoutePlanRequest;
 import com.bikeprojectminji.bikeback.airoute.dto.AiRoutePlanResponse;
 import com.bikeprojectminji.bikeback.airoute.dto.AiRouteElevationSummaryResponse;
+import com.bikeprojectminji.bikeback.airoute.dto.AiRouteRoutingMetadataResponse;
 import com.bikeprojectminji.bikeback.airoute.dto.ProviderEvidenceBadgeResponse;
 import com.bikeprojectminji.bikeback.airoute.dto.RecommendationScoreResponse;
 import com.bikeprojectminji.bikeback.weather.dto.CurrentWeatherResponse;
@@ -115,6 +116,7 @@ public class HttpAiRouteWorkerClient implements AiRouteWorkerClient {
             int recommendationScore,
             RecommendationScoreResponse scoreBreakdown,
             AiRouteElevationSummaryResponse elevationSummary,
+            AiRouteRoutingMetadataResponse routingMetadata,
             List<ProviderEvidenceBadgeResponse> evidenceBadges,
             String preferenceSummary,
             String elevationStatus,
@@ -142,6 +144,7 @@ public class HttpAiRouteWorkerClient implements AiRouteWorkerClient {
                     fallbackPlan.recommendationScore(),
                     fallbackPlan.scoreBreakdown(),
                     fallbackPlan.elevationSummary(),
+                    fallbackPlan.routingMetadata(),
                     fallbackPlan.evidenceBadges(),
                     fallbackPlan.preferenceSummary(),
                     fallbackPlan.elevationStatus(),

--- a/src/main/java/com/bikeprojectminji/bikeback/airoute/service/HttpAiRouteWorkerClient.java
+++ b/src/main/java/com/bikeprojectminji/bikeback/airoute/service/HttpAiRouteWorkerClient.java
@@ -116,6 +116,9 @@ public class HttpAiRouteWorkerClient implements AiRouteWorkerClient {
             RecommendationScoreResponse scoreBreakdown,
             AiRouteElevationSummaryResponse elevationSummary,
             List<ProviderEvidenceBadgeResponse> evidenceBadges,
+            String preferenceSummary,
+            String elevationStatus,
+            String sceneryEvidenceStatus,
             AiRoutePlanResponse fallbackPlan
     ) {
 
@@ -140,6 +143,9 @@ public class HttpAiRouteWorkerClient implements AiRouteWorkerClient {
                     fallbackPlan.scoreBreakdown(),
                     fallbackPlan.elevationSummary(),
                     fallbackPlan.evidenceBadges(),
+                    fallbackPlan.preferenceSummary(),
+                    fallbackPlan.elevationStatus(),
+                    fallbackPlan.sceneryEvidenceStatus(),
                     fallbackPlan
             );
         }

--- a/src/main/java/com/bikeprojectminji/bikeback/airoute/service/NonBlankAiRouteWorkerBaseUrlCondition.java
+++ b/src/main/java/com/bikeprojectminji/bikeback/airoute/service/NonBlankAiRouteWorkerBaseUrlCondition.java
@@ -1,0 +1,14 @@
+package com.bikeprojectminji.bikeback.airoute.service;
+
+import org.springframework.context.annotation.Condition;
+import org.springframework.context.annotation.ConditionContext;
+import org.springframework.core.type.AnnotatedTypeMetadata;
+
+class NonBlankAiRouteWorkerBaseUrlCondition implements Condition {
+
+    @Override
+    public boolean matches(ConditionContext context, AnnotatedTypeMetadata metadata) {
+        String baseUrl = context.getEnvironment().getProperty("ai-route.worker.base-url");
+        return baseUrl != null && !baseUrl.isBlank();
+    }
+}

--- a/src/main/java/com/bikeprojectminji/bikeback/airoute/service/WeatherCurrentWeatherLookup.java
+++ b/src/main/java/com/bikeprojectminji/bikeback/airoute/service/WeatherCurrentWeatherLookup.java
@@ -18,7 +18,11 @@ public class WeatherCurrentWeatherLookup implements CurrentWeatherLookup {
     @Override
     public Optional<CurrentWeatherResponse> find(BigDecimal lat, BigDecimal lon) {
         try {
-            return Optional.of(weatherService.getCurrent(lat, lon));
+            CurrentWeatherResponse current = weatherService.getCurrent(lat, lon);
+            if (current.weather() == null || current.wind() == null) {
+                return Optional.empty();
+            }
+            return Optional.of(current);
         } catch (RuntimeException exception) {
             return Optional.empty();
         }

--- a/src/main/java/com/bikeprojectminji/bikeback/global/metrics/BikeMetricsRecorder.java
+++ b/src/main/java/com/bikeprojectminji/bikeback/global/metrics/BikeMetricsRecorder.java
@@ -32,6 +32,10 @@ public class BikeMetricsRecorder {
         meterRegistry.counter("bike_weather_cache_miss_total").increment();
     }
 
+    public void recordWeatherCacheFailure(String operation) {
+        meterRegistry.counter("bike_weather_cache_failure_total", "operation", normalize(operation)).increment();
+    }
+
     public void recordWeatherProviderResult(String source, String outcome) {
         meterRegistry.counter(
                 "bike_weather_provider_result_total",

--- a/src/main/java/com/bikeprojectminji/bikeback/routing/infrastructure/GraphHopperBicycleRoutingClient.java
+++ b/src/main/java/com/bikeprojectminji/bikeback/routing/infrastructure/GraphHopperBicycleRoutingClient.java
@@ -9,6 +9,7 @@ import java.math.BigDecimal;
 import java.time.Duration;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -112,6 +113,8 @@ public class GraphHopperBicycleRoutingClient implements BicycleRoutingClient {
                                 .queryParam("details", "bike_network")
                                 .queryParam("details", "average_slope")
                                 .queryParam("details", "max_slope");
+                        Optional.ofNullable(request.routePreference().graphHopperCustomModelJson())
+                                .ifPresent(customModel -> builder.queryParam("custom_model", customModel));
                         if (!apiKey.isBlank()) {
                             builder.queryParam("key", apiKey);
                         }

--- a/src/main/java/com/bikeprojectminji/bikeback/routing/service/BicycleRoutePreference.java
+++ b/src/main/java/com/bikeprojectminji/bikeback/routing/service/BicycleRoutePreference.java
@@ -1,0 +1,96 @@
+package com.bikeprojectminji.bikeback.routing.service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public record BicycleRoutePreference(
+        String routePriority,
+        String elevationPreference,
+        String textIntent
+) {
+
+    public static BicycleRoutePreference from(String routePriority, String elevationPreference, String textIntent) {
+        return new BicycleRoutePreference(
+                normalize(routePriority, "BALANCED"),
+                normalize(elevationPreference, null),
+                normalize(textIntent, null)
+        );
+    }
+
+    public String preferenceSummary() {
+        List<String> parts = new ArrayList<>();
+        parts.add(labelForRoutePriority(routePriority));
+        if (elevationPreference != null) {
+            parts.add(labelForElevation(elevationPreference));
+        }
+        if (textIntent != null) {
+            parts.add(labelForTextIntent(textIntent));
+        }
+        return String.join(" + ", parts);
+    }
+
+    public String graphHopperCustomModelJson() {
+        List<String> priorityRules = new ArrayList<>();
+        if ("BIKE_PATH_FIRST".equals(routePriority)) {
+            priorityRules.add(rule("road_class == CYCLEWAY", "1.35"));
+            priorityRules.add(rule("road_class == PRIMARY", "0.80"));
+        }
+        if ("SCENERY_FIRST".equals(routePriority) || "TEXT_RIVER_VIEW".equals(textIntent) || "TEXT_FLAT_RIVERSIDE".equals(textIntent)) {
+            priorityRules.add(rule("bike_network == LOCAL", "1.12"));
+            priorityRules.add(rule("road_environment == BRIDGE", "1.05"));
+        }
+        if ("FLAT_FIRST".equals(elevationPreference) || "TEXT_FLAT_RIVERSIDE".equals(textIntent)) {
+            priorityRules.add(rule("max_slope > 8", "0.65"));
+            priorityRules.add(rule("average_slope > 5", "0.75"));
+        }
+        if ("CLIMB_FIRST".equals(elevationPreference) || "CANONICAL_NAMSAN_NATIONAL_THEATER".equals(textIntent)) {
+            priorityRules.add(rule("max_slope > 4", "1.08"));
+        }
+        if (priorityRules.isEmpty()) {
+            return null;
+        }
+        return """
+                {"priority":[%s],"distance_influence":70}
+                """.formatted(String.join(",", priorityRules)).trim();
+    }
+
+    private static String rule(String condition, String multiplyBy) {
+        return """
+                {"if":"%s","multiply_by":"%s"}
+                """.formatted(condition, multiplyBy).trim();
+    }
+
+    private static String labelForRoutePriority(String routePriority) {
+        return switch (routePriority) {
+            case "SCENERY_FIRST" -> "경치 우선";
+            case "BIKE_PATH_FIRST" -> "자전거도로 우선";
+            case "SAFE_FIRST" -> "안전 우선";
+            default -> "균형형";
+        };
+    }
+
+    private static String labelForElevation(String elevationPreference) {
+        return switch (elevationPreference) {
+            case "FLAT_FIRST" -> "평지 우선";
+            case "CLIMB_FIRST" -> "업힐 선호";
+            case "BALANCED_ELEVATION" -> "고도 균형";
+            default -> "고도 조건 " + elevationPreference;
+        };
+    }
+
+    private static String labelForTextIntent(String textIntent) {
+        return switch (textIntent) {
+            case "TEXT_RIVER_VIEW" -> "강변 조망";
+            case "TEXT_FLAT_RIVERSIDE" -> "평지형 하천";
+            case "CANONICAL_NAMSAN_NATIONAL_THEATER" -> "남산 정석 접근";
+            default -> "텍스트 조건 " + textIntent;
+        };
+    }
+
+    private static String normalize(String value, String fallback) {
+        if (value == null || value.isBlank()) {
+            return fallback;
+        }
+        return value.trim().toUpperCase();
+    }
+}

--- a/src/main/java/com/bikeprojectminji/bikeback/routing/service/BicycleRouteRequest.java
+++ b/src/main/java/com/bikeprojectminji/bikeback/routing/service/BicycleRouteRequest.java
@@ -8,7 +8,8 @@ public record BicycleRouteRequest(
         BigDecimal destinationLat,
         BigDecimal destinationLon,
         String preference,
-        String elevationPreference
+        String elevationPreference,
+        String textIntent
 ) {
 
     public BicycleRouteRequest(
@@ -18,6 +19,21 @@ public record BicycleRouteRequest(
             BigDecimal destinationLon,
             String preference
     ) {
-        this(originLat, originLon, destinationLat, destinationLon, preference, null);
+        this(originLat, originLon, destinationLat, destinationLon, preference, null, null);
+    }
+
+    public BicycleRouteRequest(
+            BigDecimal originLat,
+            BigDecimal originLon,
+            BigDecimal destinationLat,
+            BigDecimal destinationLon,
+            String preference,
+            String elevationPreference
+    ) {
+        this(originLat, originLon, destinationLat, destinationLon, preference, elevationPreference, null);
+    }
+
+    public BicycleRoutePreference routePreference() {
+        return BicycleRoutePreference.from(preference, elevationPreference, textIntent);
     }
 }

--- a/src/main/java/com/bikeprojectminji/bikeback/weather/infrastructure/WeatherExecutionConfig.java
+++ b/src/main/java/com/bikeprojectminji/bikeback/weather/infrastructure/WeatherExecutionConfig.java
@@ -1,7 +1,10 @@
 package com.bikeprojectminji.bikeback.weather.infrastructure;
 
+import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -9,12 +12,15 @@ import org.springframework.context.annotation.Configuration;
 public class WeatherExecutionConfig {
 
     @Bean(destroyMethod = "shutdown")
-    public ExecutorService weatherProviderExecutor() {
-        return Executors.newFixedThreadPool(4, runnable -> {
+    public ExecutorService weatherProviderExecutor(
+            @Value("${weather.provider.executor.pool-size:4}") int poolSize,
+            @Value("${weather.provider.executor.queue-capacity:32}") int queueCapacity
+    ) {
+        return new ThreadPoolExecutor(poolSize, poolSize, 0L, TimeUnit.MILLISECONDS, new ArrayBlockingQueue<>(queueCapacity), runnable -> {
             Thread thread = new Thread(runnable);
             thread.setName("weather-provider-executor");
             thread.setDaemon(true);
             return thread;
-        });
+        }, new ThreadPoolExecutor.AbortPolicy());
     }
 }

--- a/src/main/java/com/bikeprojectminji/bikeback/weather/service/WeatherLocationKey.java
+++ b/src/main/java/com/bikeprojectminji/bikeback/weather/service/WeatherLocationKey.java
@@ -2,17 +2,36 @@ package com.bikeprojectminji.bikeback.weather.service;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
+import java.util.ArrayList;
+import java.util.List;
 
 public record WeatherLocationKey(
         BigDecimal lat,
         BigDecimal lon
 ) {
     private static final int WEATHER_GRID_SCALE = 2;
+    private static final BigDecimal GRID_STEP = new BigDecimal("0.01");
 
     public static WeatherLocationKey from(BigDecimal lat, BigDecimal lon) {
         return new WeatherLocationKey(
                 lat.setScale(WEATHER_GRID_SCALE, RoundingMode.HALF_UP),
                 lon.setScale(WEATHER_GRID_SCALE, RoundingMode.HALF_UP)
         );
+    }
+
+    public List<WeatherLocationKey> adjacentKeys() {
+        List<WeatherLocationKey> keys = new ArrayList<>(8);
+        for (int latOffset = -1; latOffset <= 1; latOffset++) {
+            for (int lonOffset = -1; lonOffset <= 1; lonOffset++) {
+                if (latOffset == 0 && lonOffset == 0) {
+                    continue;
+                }
+                keys.add(new WeatherLocationKey(
+                        lat.add(GRID_STEP.multiply(BigDecimal.valueOf(latOffset))).setScale(WEATHER_GRID_SCALE, RoundingMode.HALF_UP),
+                        lon.add(GRID_STEP.multiply(BigDecimal.valueOf(lonOffset))).setScale(WEATHER_GRID_SCALE, RoundingMode.HALF_UP)
+                ));
+            }
+        }
+        return List.copyOf(keys);
     }
 }

--- a/src/main/java/com/bikeprojectminji/bikeback/weather/service/WeatherService.java
+++ b/src/main/java/com/bikeprojectminji/bikeback/weather/service/WeatherService.java
@@ -1,6 +1,5 @@
 package com.bikeprojectminji.bikeback.weather.service;
 
-import com.bikeprojectminji.bikeback.global.exception.NotFoundException;
 import com.bikeprojectminji.bikeback.global.metrics.BikeMetricsRecorder;
 import com.bikeprojectminji.bikeback.weather.dto.CurrentWeatherResponse;
 import java.math.BigDecimal;
@@ -28,8 +27,8 @@ import org.springframework.stereotype.Service;
 public class WeatherService {
 
     private static final Logger log = LoggerFactory.getLogger(WeatherService.class);
+    private static final Duration FRESH_CACHE_TTL = Duration.ofMinutes(5);
     private static final Duration LAST_SUCCESS_TTL = Duration.ofMinutes(60);
-    private static final String WEATHER_UNAVAILABLE_MESSAGE = "현재 날씨 정보를 사용할 수 없습니다.";
     private static final long DEFAULT_TOTAL_TIMEOUT_MS = 900;
     private static final long PROVIDER_TIMEOUT_GRACE_MS = 300;
 
@@ -61,14 +60,26 @@ public class WeatherService {
     }
 
     public CurrentWeatherResponse getCurrent(BigDecimal lat, BigDecimal lon) {
-        // 현재 날씨 조회는 provider 성공을 우선 사용하고,
-        // 실패 시에는 last-success 캐시를 60분 범위 안에서만 fallback으로 허용한다.
+        // 현재 날씨는 구역 단위 캐시를 우선 사용한다.
+        // 5분 이내 fresh cache는 외부 provider를 호출하지 않고, 60분 이내 값은 stale fallback으로 즉시 반환한다.
         long startedAtNanos = System.nanoTime();
         WeatherLocationKey locationKey = WeatherLocationKey.from(lat, lon);
-        Optional<WeatherSnapshot> fallback = lastSuccessWeatherStore.find(locationKey)
+        Optional<WeatherSnapshot> cached = lastSuccessWeatherStore.find(locationKey)
                 .filter(this::isWithinLastSuccessTtl);
 
-        if (fallback.isPresent()) {
+        if (cached.isPresent() && isWithinFreshCacheTtl(cached.get())) {
+            bikeMetricsRecorder.recordWeatherCacheHit("fresh_grid");
+            log.info(
+                    "weather_cache_hit request_id={} location_key={} total_duration_ms={} cache_age_ms={} mode=fresh_grid",
+                    RequestLogContext.currentRequestId(),
+                    locationKey,
+                    toDurationMs(startedAtNanos),
+                    cacheAgeMs(cached.get())
+            );
+            return toResponse(cached.get(), false, "FRESH_CACHE", null);
+        }
+
+        if (cached.isPresent()) {
             bikeMetricsRecorder.recordWeatherCacheHit("last_success_stale");
             bikeMetricsRecorder.recordWeatherStaleServed();
             bikeMetricsRecorder.recordWeatherFallback();
@@ -79,10 +90,10 @@ public class WeatherService {
                     locationKey,
                     0,
                     toDurationMs(startedAtNanos),
-                    cacheAgeMs(fallback.get()),
-                    fallback.get().forecastFallbackUsed()
+                    cacheAgeMs(cached.get()),
+                    cached.get().forecastFallbackUsed()
             );
-            return toResponse(fallback.get(), true);
+            return toResponse(cached.get(), true, "STALE_LAST_SUCCESS", "LAST_SUCCESS_CACHE");
         }
 
         bikeMetricsRecorder.recordWeatherCacheMiss();
@@ -109,7 +120,7 @@ public class WeatherService {
                     toDurationMs(startedAtNanos),
                     providerResult.snapshot().forecastFallbackUsed()
             );
-            return toResponse(providerResult.snapshot(), false);
+            return toResponse(providerResult.snapshot(), false, "FRESH_PROVIDER", null);
         }
 
         log.info(
@@ -120,7 +131,12 @@ public class WeatherService {
                 toDurationMs(startedAtNanos)
         );
         bikeMetricsRecorder.recordWeatherUnavailable("provider_failure");
-        throw new NotFoundException(WEATHER_UNAVAILABLE_MESSAGE);
+        return unavailableResponse();
+    }
+
+    private boolean isWithinFreshCacheTtl(WeatherSnapshot snapshot) {
+        OffsetDateTime now = OffsetDateTime.ofInstant(clock.instant(), ZoneOffset.UTC);
+        return Duration.between(snapshot.lastSucceededAt(), now).compareTo(FRESH_CACHE_TTL) <= 0;
     }
 
     private boolean isWithinLastSuccessTtl(WeatherSnapshot snapshot) {
@@ -129,7 +145,12 @@ public class WeatherService {
         return Duration.between(snapshot.lastSucceededAt(), now).compareTo(LAST_SUCCESS_TTL) <= 0;
     }
 
-    private CurrentWeatherResponse toResponse(WeatherSnapshot snapshot, boolean stale) {
+    private CurrentWeatherResponse toResponse(
+            WeatherSnapshot snapshot,
+            boolean stale,
+            String freshnessStatus,
+            String staleReason
+    ) {
         // 외부 응답에서는 snapshot 내부 구조를 그대로 노출하지 않고,
         // stale 여부와 forecast fallback 사용 여부만 함께 풀어서 전달한다.
         return new CurrentWeatherResponse(
@@ -137,10 +158,23 @@ public class WeatherService {
                 snapshot.wind(),
                 stale,
                 snapshot.forecastFallbackUsed(),
-                stale ? "STALE_LAST_SUCCESS" : "FRESH_PROVIDER",
-                stale ? "LAST_SUCCESS_CACHE" : null,
+                freshnessStatus,
+                staleReason,
                 snapshot.observedAt(),
-                stale ? Math.max(0L, cacheAgeMs(snapshot) / 1000L) : 0L
+                "FRESH_PROVIDER".equals(freshnessStatus) ? 0L : Math.max(0L, cacheAgeMs(snapshot) / 1000L)
+        );
+    }
+
+    private CurrentWeatherResponse unavailableResponse() {
+        return new CurrentWeatherResponse(
+                null,
+                null,
+                false,
+                false,
+                "UNAVAILABLE",
+                "PROVIDER_FAILURE",
+                null,
+                0L
         );
     }
 
@@ -226,6 +260,7 @@ public class WeatherService {
         } catch (TimeoutException graceTimeoutException) {
             bikeMetricsRecorder.recordWeatherProviderTimeout("grace");
             bikeMetricsRecorder.recordWeatherProviderFailure("grace_timeout");
+            cacheLateProviderSuccess(future, locationKey, RequestLogContext.currentRequestId());
             return WeatherProviderResult.failure();
         } catch (InterruptedException interruptedException) {
             Thread.currentThread().interrupt();
@@ -247,6 +282,33 @@ public class WeatherService {
             );
             return WeatherProviderResult.failure();
         }
+    }
+
+    private void cacheLateProviderSuccess(Future<WeatherProviderResult> future, WeatherLocationKey locationKey, String requestId) {
+        if (!(future instanceof CompletableFuture<?> rawFuture)) {
+            return;
+        }
+        @SuppressWarnings("unchecked")
+        CompletableFuture<WeatherProviderResult> completableFuture = (CompletableFuture<WeatherProviderResult>) rawFuture;
+        completableFuture.thenAccept(result -> {
+            if (result == null || !result.success() || result.snapshot() == null) {
+                return;
+            }
+            bikeMetricsRecorder.recordWeatherProviderResult(
+                    result.snapshot().forecastFallbackUsed() ? "hourly_fallback" : "current",
+                    "late_success"
+            );
+            if (result.snapshot().forecastFallbackUsed()) {
+                bikeMetricsRecorder.recordWeatherFallback();
+            }
+            lastSuccessWeatherStore.save(locationKey, result.snapshot());
+            log.info(
+                    "weather_late_success_cached request_id={} location_key={} forecast_fallback_used={}",
+                    requestId,
+                    locationKey,
+                    result.snapshot().forecastFallbackUsed()
+            );
+        });
     }
 
     private void refreshWeatherAsync(WeatherLocationKey locationKey, String requestId) {

--- a/src/main/java/com/bikeprojectminji/bikeback/weather/service/WeatherService.java
+++ b/src/main/java/com/bikeprojectminji/bikeback/weather/service/WeatherService.java
@@ -30,6 +30,7 @@ public class WeatherService {
     private static final Logger log = LoggerFactory.getLogger(WeatherService.class);
     private static final Duration FRESH_CACHE_TTL = Duration.ofMinutes(5);
     private static final Duration LAST_SUCCESS_TTL = Duration.ofMinutes(60);
+    private static final Duration PREWARM_ATTEMPT_TTL = Duration.ofMinutes(5);
     private static final long DEFAULT_TOTAL_TIMEOUT_MS = 900;
     private static final long PROVIDER_TIMEOUT_GRACE_MS = 300;
 
@@ -40,6 +41,7 @@ public class WeatherService {
     private final long weatherProviderTotalTimeoutMs;
     private final Clock clock;
     private final ConcurrentMap<WeatherLocationKey, CompletableFuture<WeatherProviderResult>> inFlightProviderRequests;
+    private final ConcurrentMap<WeatherLocationKey, OffsetDateTime> prewarmAttemptedAt;
     private final Set<WeatherLocationKey> refreshingLocations;
 
     public WeatherService(
@@ -57,6 +59,7 @@ public class WeatherService {
         this.weatherProviderTotalTimeoutMs = weatherProviderTotalTimeoutMs;
         this.clock = clock;
         this.inFlightProviderRequests = new ConcurrentHashMap<>();
+        this.prewarmAttemptedAt = new ConcurrentHashMap<>();
         this.refreshingLocations = ConcurrentHashMap.newKeySet();
     }
 
@@ -77,6 +80,7 @@ public class WeatherService {
                     toDurationMs(startedAtNanos),
                     cacheAgeMs(cached.get())
             );
+            prewarmAdjacentLocations(locationKey, RequestLogContext.currentRequestId());
             return toResponse(cached.get(), false, "FRESH_CACHE", null);
         }
 
@@ -94,6 +98,7 @@ public class WeatherService {
                     cacheAgeMs(cached.get()),
                     cached.get().forecastFallbackUsed()
             );
+            prewarmAdjacentLocations(locationKey, RequestLogContext.currentRequestId());
             return toResponse(cached.get(), true, "STALE_LAST_SUCCESS", "LAST_SUCCESS_CACHE");
         }
 
@@ -121,6 +126,7 @@ public class WeatherService {
                     toDurationMs(startedAtNanos),
                     providerResult.snapshot().forecastFallbackUsed()
             );
+            prewarmAdjacentLocations(locationKey, RequestLogContext.currentRequestId());
             return toResponse(providerResult.snapshot(), false, "FRESH_PROVIDER", null);
         }
 
@@ -397,5 +403,51 @@ public class WeatherService {
                     refreshed.snapshot().forecastFallbackUsed()
             );
         });
+    }
+
+    private void prewarmAdjacentLocations(WeatherLocationKey locationKey, String requestId) {
+        try {
+            CompletableFuture.runAsync(
+                    () -> locationKey.adjacentKeys().forEach(adjacentKey -> prewarmLocation(adjacentKey, requestId)),
+                    weatherProviderExecutor
+            );
+        } catch (RejectedExecutionException rejectedExecutionException) {
+            bikeMetricsRecorder.recordWeatherRefreshSkipped("prewarm_bulkhead_rejected");
+            log.info(
+                    "weather_prewarm_skipped request_id={} location_key={} reason=bulkhead_rejected",
+                    requestId,
+                    locationKey,
+                    rejectedExecutionException
+            );
+        }
+    }
+
+    private void prewarmLocation(WeatherLocationKey locationKey, String requestId) {
+        if (wasRecentlyPrewarmed(locationKey)) {
+            bikeMetricsRecorder.recordWeatherRefreshSkipped("prewarm_recent_attempt");
+            return;
+        }
+        prewarmAttemptedAt.put(locationKey, OffsetDateTime.ofInstant(clock.instant(), ZoneOffset.UTC));
+
+        Optional<WeatherSnapshot> cached = findCachedSnapshot(locationKey);
+        if (cached.isPresent() && isWithinFreshCacheTtl(cached.get())) {
+            bikeMetricsRecorder.recordWeatherRefreshSkipped("prewarm_fresh_cache");
+            return;
+        }
+
+        refreshWeatherAsync(locationKey, requestId);
+    }
+
+    private boolean wasRecentlyPrewarmed(WeatherLocationKey locationKey) {
+        OffsetDateTime now = OffsetDateTime.ofInstant(clock.instant(), ZoneOffset.UTC);
+        OffsetDateTime attemptedAt = prewarmAttemptedAt.get(locationKey);
+        if (attemptedAt == null) {
+            return false;
+        }
+        if (Duration.between(attemptedAt, now).compareTo(PREWARM_ATTEMPT_TTL) <= 0) {
+            return true;
+        }
+        prewarmAttemptedAt.remove(locationKey, attemptedAt);
+        return false;
     }
 }

--- a/src/main/java/com/bikeprojectminji/bikeback/weather/service/WeatherService.java
+++ b/src/main/java/com/bikeprojectminji/bikeback/weather/service/WeatherService.java
@@ -18,6 +18,7 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.Optional;
+import java.util.concurrent.RejectedExecutionException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
@@ -64,7 +65,7 @@ public class WeatherService {
         // 5분 이내 fresh cache는 외부 provider를 호출하지 않고, 60분 이내 값은 stale fallback으로 즉시 반환한다.
         long startedAtNanos = System.nanoTime();
         WeatherLocationKey locationKey = WeatherLocationKey.from(lat, lon);
-        Optional<WeatherSnapshot> cached = lastSuccessWeatherStore.find(locationKey)
+        Optional<WeatherSnapshot> cached = findCachedSnapshot(locationKey)
                 .filter(this::isWithinLastSuccessTtl);
 
         if (cached.isPresent() && isWithinFreshCacheTtl(cached.get())) {
@@ -111,7 +112,7 @@ public class WeatherService {
                 bikeMetricsRecorder.recordWeatherFallback();
             }
             bikeMetricsRecorder.recordWeatherCacheHit("provider_success");
-            lastSuccessWeatherStore.save(locationKey, providerResult.snapshot());
+            saveSnapshot(locationKey, providerResult.snapshot(), "provider_success");
             log.info(
                     "weather_served request_id={} location_key={} source=provider provider_duration_ms={} total_duration_ms={} forecast_fallback_used={}",
                     RequestLogContext.currentRequestId(),
@@ -137,6 +138,36 @@ public class WeatherService {
     private boolean isWithinFreshCacheTtl(WeatherSnapshot snapshot) {
         OffsetDateTime now = OffsetDateTime.ofInstant(clock.instant(), ZoneOffset.UTC);
         return Duration.between(snapshot.lastSucceededAt(), now).compareTo(FRESH_CACHE_TTL) <= 0;
+    }
+
+    private Optional<WeatherSnapshot> findCachedSnapshot(WeatherLocationKey locationKey) {
+        try {
+            return lastSuccessWeatherStore.find(locationKey);
+        } catch (RuntimeException exception) {
+            bikeMetricsRecorder.recordWeatherCacheFailure("read");
+            log.warn(
+                    "weather_cache_failure request_id={} location_key={} operation=read",
+                    RequestLogContext.currentRequestId(),
+                    locationKey,
+                    exception
+            );
+            return Optional.empty();
+        }
+    }
+
+    private void saveSnapshot(WeatherLocationKey locationKey, WeatherSnapshot snapshot, String operation) {
+        try {
+            lastSuccessWeatherStore.save(locationKey, snapshot);
+        } catch (RuntimeException exception) {
+            bikeMetricsRecorder.recordWeatherCacheFailure("write_" + operation);
+            log.warn(
+                    "weather_cache_failure request_id={} location_key={} operation=write_{}",
+                    RequestLogContext.currentRequestId(),
+                    locationKey,
+                    operation,
+                    exception
+            );
+        }
     }
 
     private boolean isWithinLastSuccessTtl(WeatherSnapshot snapshot) {
@@ -212,6 +243,10 @@ public class WeatherService {
                     executionException.getCause()
             );
             return WeatherProviderResult.failure();
+        } finally {
+            if (future.isDone()) {
+                inFlightProviderRequests.remove(locationKey, future);
+            }
         }
     }
 
@@ -225,10 +260,22 @@ public class WeatherService {
     }
 
     private CompletableFuture<WeatherProviderResult> submitProviderRequest(WeatherLocationKey locationKey) {
-        CompletableFuture<WeatherProviderResult> future = CompletableFuture.supplyAsync(
-                () -> weatherProviderPort.getCurrent(locationKey),
-                weatherProviderExecutor
-        );
+        CompletableFuture<WeatherProviderResult> future;
+        try {
+            future = CompletableFuture.supplyAsync(
+                    () -> weatherProviderPort.getCurrent(locationKey),
+                    weatherProviderExecutor
+            );
+        } catch (RejectedExecutionException rejectedExecutionException) {
+            bikeMetricsRecorder.recordWeatherProviderFailure("bulkhead_rejected");
+            log.warn(
+                    "weather_provider_bulkhead_rejected request_id={} location_key={}",
+                    RequestLogContext.currentRequestId(),
+                    locationKey,
+                    rejectedExecutionException
+            );
+            return CompletableFuture.completedFuture(WeatherProviderResult.failure());
+        }
         future.whenComplete((result, throwable) -> inFlightProviderRequests.remove(locationKey, future));
         return future;
     }
@@ -301,7 +348,7 @@ public class WeatherService {
             if (result.snapshot().forecastFallbackUsed()) {
                 bikeMetricsRecorder.recordWeatherFallback();
             }
-            lastSuccessWeatherStore.save(locationKey, result.snapshot());
+            saveSnapshot(locationKey, result.snapshot(), "late_success");
             log.info(
                     "weather_late_success_cached request_id={} location_key={} forecast_fallback_used={}",
                     requestId,
@@ -342,7 +389,7 @@ public class WeatherService {
             if (refreshed.snapshot().forecastFallbackUsed()) {
                 bikeMetricsRecorder.recordWeatherFallback();
             }
-            lastSuccessWeatherStore.save(locationKey, refreshed.snapshot());
+            saveSnapshot(locationKey, refreshed.snapshot(), "refresh_success");
             log.info(
                     "weather_refresh_completed request_id={} location_key={} source=provider forecast_fallback_used={}",
                     requestId,

--- a/src/test/java/com/bikeprojectminji/bikeback/address/controller/AddressSearchControllerTest.java
+++ b/src/test/java/com/bikeprojectminji/bikeback/address/controller/AddressSearchControllerTest.java
@@ -89,4 +89,49 @@ class AddressSearchControllerTest {
 
         verify(addressSearchRateLimitService).checkAllowed("127.0.0.1");
     }
+
+    @Test
+    @DisplayName("주소 검색 API는 provider fallback metadata를 프론트 계약으로 보존한다")
+    void searchKeepsFallbackMetadataInWrappedResponse() throws Exception {
+        given(addressSearchService.search("여의나루역", 1, 5))
+                .willReturn(new AddressSearchResponse(
+                        "SUCCESS",
+                        1,
+                        5,
+                        1,
+                        "NOMINATIM",
+                        "KAKAO_LOCAL",
+                        true,
+                        "KAKAO_LOCAL_PROVIDER_FAILURE",
+                        "주소 후보를 찾았습니다.",
+                        List.of(
+                                new AddressCandidateResponse(
+                                        "nominatim-1",
+                                        "여의나루역",
+                                        "서울 영등포구 여의도동",
+                                        BigDecimal.valueOf(37.5271),
+                                        BigDecimal.valueOf(126.9328),
+                                        "NOMINATIM",
+                                        "STATION",
+                                        "MEDIUM"
+                                )
+                        )
+                ));
+
+        mockMvc.perform(get("/api/v1/addresses/search")
+                        .param("query", "여의나루역")
+                        .param("page", "1")
+                        .param("size", "5"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(200))
+                .andExpect(jsonPath("$.data.status").value("SUCCESS"))
+                .andExpect(jsonPath("$.data.provider").value("NOMINATIM"))
+                .andExpect(jsonPath("$.data.primaryProvider").value("KAKAO_LOCAL"))
+                .andExpect(jsonPath("$.data.fallbackUsed").value(true))
+                .andExpect(jsonPath("$.data.fallbackReason").value("KAKAO_LOCAL_PROVIDER_FAILURE"))
+                .andExpect(jsonPath("$.data.candidates[0].source").value("NOMINATIM"))
+                .andExpect(jsonPath("$.data.candidates[0].confidence").value("MEDIUM"));
+
+        verify(addressSearchRateLimitService).checkAllowed("127.0.0.1");
+    }
 }

--- a/src/test/java/com/bikeprojectminji/bikeback/airoute/service/AiRoutePlanComposerTest.java
+++ b/src/test/java/com/bikeprojectminji/bikeback/airoute/service/AiRoutePlanComposerTest.java
@@ -71,6 +71,49 @@ class AiRoutePlanComposerTest {
     }
 
     @Test
+    @DisplayName("날씨가 UNAVAILABLE이면 날씨 없음으로 보고 fallback 경로를 정상 생성한다")
+    void composeFallbackTreatsUnavailableWeatherAsUnknown() {
+        AiRoutePlanRequest request = new AiRoutePlanRequest(
+                BigDecimal.valueOf(37.48),
+                BigDecimal.valueOf(126.95),
+                null,
+                null,
+                "관악 순환",
+                "balanced"
+        );
+        CurrentWeatherResponse unavailableWeather = new CurrentWeatherResponse(
+                null,
+                null,
+                false,
+                false,
+                "UNAVAILABLE",
+                "PROVIDER_FAILURE",
+                null,
+                0
+        );
+
+        AiRoutePlanResponse response = composer.composeFallback(
+                request,
+                new AiRouteConditionContext(
+                        Optional.of(unavailableWeather),
+                        "공사 정보 미확인",
+                        "노면 정보 미확인"
+                )
+        );
+
+        assertThat(response.status()).isEqualTo("READY");
+        assertThat(response.weather()).isNull();
+        assertThat(response.wind()).isNull();
+        assertThat(response.confidence()).isEqualTo("low");
+        assertThat(response.summary()).contains("날씨와 노면 데이터는 다시 확인");
+        assertThat(response.actions()).contains("날씨 데이터가 없으므로 출발 전 외부 날씨를 한 번 더 확인하세요.");
+        assertThat(response.evidenceBadges())
+                .filteredOn(badge -> "weather".equals(badge.source()))
+                .extracting("status")
+                .containsExactly("UNKNOWN");
+    }
+
+    @Test
     @DisplayName("route candidate evidence는 AI route badge와 score breakdown에 반영된다")
     void composeRouteCandidateIncludesRouteEvidenceBadgesAndScore() {
         AiRoutePlanRequest request = new AiRoutePlanRequest(

--- a/src/test/java/com/bikeprojectminji/bikeback/airoute/service/AiRoutePlanComposerTest.java
+++ b/src/test/java/com/bikeprojectminji/bikeback/airoute/service/AiRoutePlanComposerTest.java
@@ -164,6 +164,9 @@ class AiRoutePlanComposerTest {
         assertThat(response.scoreBreakdown().unknownPenalty()).isGreaterThan(0);
         assertThat(response.evidenceBadges()).extracting("source")
                 .contains("graphhopper.road_class", "graphhopper.surface", "graphhopper.elevation");
+        assertThat(response.preferenceSummary()).isEqualTo("자전거도로 우선");
+        assertThat(response.elevationStatus()).isEqualTo("VERIFIED");
+        assertThat(response.sceneryEvidenceStatus()).isEqualTo("NOT_REQUESTED");
     }
 
     @Test
@@ -223,6 +226,9 @@ class AiRoutePlanComposerTest {
 
         assertThat(response.scoreBreakdown().elevation()).isGreaterThan(80);
         assertThat(response.evidenceBadges()).extracting("source").contains("canonical-route");
+        assertThat(response.preferenceSummary()).isEqualTo("경치 우선 + 업힐 선호 + 남산 정석 접근");
+        assertThat(response.elevationStatus()).isEqualTo("VERIFIED");
+        assertThat(response.sceneryEvidenceStatus()).isEqualTo("PARTIAL");
     }
 
     private BicycleRouteCandidate climbCandidate() {

--- a/src/test/java/com/bikeprojectminji/bikeback/airoute/service/AiRouteWorkerClientConditionTest.java
+++ b/src/test/java/com/bikeprojectminji/bikeback/airoute/service/AiRouteWorkerClientConditionTest.java
@@ -1,0 +1,42 @@
+package com.bikeprojectminji.bikeback.airoute.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.bikeprojectminji.bikeback.global.metrics.BikeMetricsRecorder;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Import;
+
+class AiRouteWorkerClientConditionTest {
+
+    private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+            .withBean(BikeMetricsRecorder.class, () -> new BikeMetricsRecorder(new SimpleMeterRegistry()))
+            .withUserConfiguration(TestWorkerClientConfiguration.class);
+
+    @Test
+    @DisplayName("AI worker base URL이 비어 있으면 disabled worker를 사용한다")
+    void useDisabledWorkerWhenBaseUrlIsBlank() {
+        contextRunner
+                .withPropertyValues("ai-route.worker.base-url=")
+                .run(context -> assertThat(context.getBean(AiRouteWorkerClient.class))
+                        .isInstanceOf(DisabledAiRouteWorkerClient.class));
+    }
+
+    @Test
+    @DisplayName("AI worker base URL이 있으면 HTTP worker를 우선 사용한다")
+    void useHttpWorkerWhenBaseUrlIsPresent() {
+        contextRunner
+                .withPropertyValues("ai-route.worker.base-url=http://localhost:8091")
+                .run(context -> assertThat(context.getBean(AiRouteWorkerClient.class))
+                        .isInstanceOf(HttpAiRouteWorkerClient.class));
+    }
+
+    @Import({
+            DisabledAiRouteWorkerClient.class,
+            HttpAiRouteWorkerClient.class
+    })
+    private static class TestWorkerClientConfiguration {
+    }
+}

--- a/src/test/java/com/bikeprojectminji/bikeback/airoute/service/HttpAiRouteWorkerClientTest.java
+++ b/src/test/java/com/bikeprojectminji/bikeback/airoute/service/HttpAiRouteWorkerClientTest.java
@@ -58,6 +58,9 @@ class HttpAiRouteWorkerClientTest {
                 .contains("VERIFIED", "UNKNOWN");
         assertThat(payload.path("fallbackPlan").path("explanation").path("caution").asText())
                 .contains("확인");
+        assertThat(payload.path("preferenceSummary").asText()).isEqualTo(fallbackPlan.preferenceSummary());
+        assertThat(payload.path("elevationStatus").asText()).isEqualTo(fallbackPlan.elevationStatus());
+        assertThat(payload.path("sceneryEvidenceStatus").asText()).isEqualTo(fallbackPlan.sceneryEvidenceStatus());
     }
 
     @Test

--- a/src/test/java/com/bikeprojectminji/bikeback/airoute/service/HttpAiRouteWorkerClientTest.java
+++ b/src/test/java/com/bikeprojectminji/bikeback/airoute/service/HttpAiRouteWorkerClientTest.java
@@ -58,6 +58,8 @@ class HttpAiRouteWorkerClientTest {
                 .contains("VERIFIED", "UNKNOWN");
         assertThat(payload.path("fallbackPlan").path("explanation").path("caution").asText())
                 .contains("확인");
+        assertThat(payload.path("routingMetadata").path("routingStatus").asText())
+                .isEqualTo(fallbackPlan.routingMetadata() == null ? "" : fallbackPlan.routingMetadata().routingStatus());
         assertThat(payload.path("preferenceSummary").asText()).isEqualTo(fallbackPlan.preferenceSummary());
         assertThat(payload.path("elevationStatus").asText()).isEqualTo(fallbackPlan.elevationStatus());
         assertThat(payload.path("sceneryEvidenceStatus").asText()).isEqualTo(fallbackPlan.sceneryEvidenceStatus());

--- a/src/test/java/com/bikeprojectminji/bikeback/airoute/service/WeatherCurrentWeatherLookupTest.java
+++ b/src/test/java/com/bikeprojectminji/bikeback/airoute/service/WeatherCurrentWeatherLookupTest.java
@@ -1,0 +1,62 @@
+package com.bikeprojectminji.bikeback.airoute.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+import com.bikeprojectminji.bikeback.weather.dto.CurrentWeatherResponse;
+import com.bikeprojectminji.bikeback.weather.dto.WeatherData;
+import com.bikeprojectminji.bikeback.weather.dto.WindData;
+import com.bikeprojectminji.bikeback.weather.service.WeatherService;
+import java.math.BigDecimal;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class WeatherCurrentWeatherLookupTest {
+
+    @Mock
+    private WeatherService weatherService;
+
+    @Test
+    @DisplayName("UNAVAILABLE 날씨 응답은 AI route에서 날씨 없음으로 취급한다")
+    void findReturnsEmptyWhenWeatherUnavailable() {
+        WeatherCurrentWeatherLookup lookup = new WeatherCurrentWeatherLookup(weatherService);
+        given(weatherService.getCurrent(BigDecimal.valueOf(37.5665), BigDecimal.valueOf(126.9780)))
+                .willReturn(new CurrentWeatherResponse(
+                        null,
+                        null,
+                        false,
+                        false,
+                        "UNAVAILABLE",
+                        "PROVIDER_FAILURE",
+                        null,
+                        0
+                ));
+
+        Optional<CurrentWeatherResponse> result = lookup.find(BigDecimal.valueOf(37.5665), BigDecimal.valueOf(126.9780));
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("사용 가능한 날씨 응답은 그대로 전달한다")
+    void findReturnsCurrentWeatherWhenUsable() {
+        WeatherCurrentWeatherLookup lookup = new WeatherCurrentWeatherLookup(weatherService);
+        CurrentWeatherResponse weather = new CurrentWeatherResponse(
+                new WeatherData(21, "clear", "none"),
+                new WindData(10, "북동", 45),
+                false,
+                false
+        );
+        given(weatherService.getCurrent(BigDecimal.valueOf(37.5665), BigDecimal.valueOf(126.9780)))
+                .willReturn(weather);
+
+        Optional<CurrentWeatherResponse> result = lookup.find(BigDecimal.valueOf(37.5665), BigDecimal.valueOf(126.9780));
+
+        assertThat(result).contains(weather);
+    }
+}

--- a/src/test/java/com/bikeprojectminji/bikeback/ops/GraphHopperReadinessScriptTest.java
+++ b/src/test/java/com/bikeprojectminji/bikeback/ops/GraphHopperReadinessScriptTest.java
@@ -41,8 +41,8 @@ class GraphHopperReadinessScriptTest {
         String script = Files.readString(Path.of("ops/loadtest/run-aws-compose-k6.sh"));
 
         assertThat(script).contains("RESET_GRAPHHOPPER_CACHE=\"${RESET_GRAPHHOPPER_CACHE:-false}\"");
-        assertThat(script).contains("docker compose --env-file .env.test -f docker-compose.test.yml down");
-        assertThat(script).contains("docker compose --env-file .env.test -f docker-compose.test.yml down -v");
+        assertThat(script).contains("docker compose --env-file .env.test $COMPOSE_FILES down");
+        assertThat(script).contains("docker compose --env-file .env.test $COMPOSE_FILES down -v");
     }
 
     @Test

--- a/src/test/java/com/bikeprojectminji/bikeback/routing/infrastructure/GraphHopperBicycleRoutingClientTest.java
+++ b/src/test/java/com/bikeprojectminji/bikeback/routing/infrastructure/GraphHopperBicycleRoutingClientTest.java
@@ -10,10 +10,12 @@ import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.net.InetSocketAddress;
+import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -222,14 +224,69 @@ class GraphHopperBicycleRoutingClientTest {
         assertThat(result.candidates().get(0).polyline()).hasSize(2);
     }
 
+    @Test
+    @DisplayName("GraphHopper provider는 선호도에 맞춘 custom_model 힌트를 요청에 포함한다")
+    void routeIncludesPreferenceCustomModel() throws IOException {
+        AtomicReference<String> capturedQuery = new AtomicReference<>();
+        startServer(200, """
+                {
+                  "paths": [
+                    {
+                      "distance": 2100.0,
+                      "time": 600000,
+                      "points": {
+                        "type": "LineString",
+                        "coordinates": [
+                          [126.9500000, 37.4800000],
+                          [126.9600000, 37.4900000]
+                        ]
+                      },
+                      "details": {
+                        "road_class": [[0, 1, "cycleway"]],
+                        "surface": [[0, 1, "asphalt"]]
+                      }
+                    }
+                  ]
+                }
+                """, new AtomicInteger(), capturedQuery);
+
+        GraphHopperBicycleRoutingClient client = new GraphHopperBicycleRoutingClient(baseUrl(), "");
+
+        BicycleRoutingProviderResult result = client.route(new BicycleRouteRequest(
+                BigDecimal.valueOf(37.4800),
+                BigDecimal.valueOf(126.9500),
+                BigDecimal.valueOf(37.4900),
+                BigDecimal.valueOf(126.9600),
+                "SCENERY_FIRST",
+                "FLAT_FIRST",
+                "TEXT_FLAT_RIVERSIDE"
+        ));
+
+        String decodedQuery = URLDecoder.decode(capturedQuery.get(), StandardCharsets.UTF_8);
+        assertThat(result.status()).isEqualTo("SUCCESS");
+        assertThat(decodedQuery).contains("custom_model");
+        assertThat(decodedQuery).contains("bike_network == LOCAL");
+        assertThat(decodedQuery).contains("max_slope > 8");
+    }
+
     private HttpServer startServer(int statusCode, String body) throws IOException {
         return startServer(statusCode, body, new AtomicInteger());
     }
 
     private HttpServer startServer(int statusCode, String body, AtomicInteger hitCounter) throws IOException {
+        return startServer(statusCode, body, hitCounter, new AtomicReference<>());
+    }
+
+    private HttpServer startServer(
+            int statusCode,
+            String body,
+            AtomicInteger hitCounter,
+            AtomicReference<String> queryCapture
+    ) throws IOException {
         HttpServer httpServer = HttpServer.create(new InetSocketAddress(0), 0);
         httpServer.createContext("/route", exchange -> {
             hitCounter.incrementAndGet();
+            queryCapture.set(exchange.getRequestURI().getRawQuery());
             byte[] response = body.getBytes(StandardCharsets.UTF_8);
             exchange.getResponseHeaders().add("Content-Type", "application/json");
             exchange.sendResponseHeaders(statusCode, response.length);

--- a/src/test/java/com/bikeprojectminji/bikeback/weather/controller/WeatherControllerTest.java
+++ b/src/test/java/com/bikeprojectminji/bikeback/weather/controller/WeatherControllerTest.java
@@ -7,7 +7,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.bikeprojectminji.bikeback.global.config.SecurityConfig;
-import com.bikeprojectminji.bikeback.global.exception.NotFoundException;
 import com.bikeprojectminji.bikeback.weather.dto.CurrentWeatherResponse;
 import com.bikeprojectminji.bikeback.weather.dto.WeatherData;
 import com.bikeprojectminji.bikeback.weather.dto.WindData;
@@ -68,17 +67,31 @@ class WeatherControllerTest {
     }
 
     @Test
-    @DisplayName("현재 날씨를 사용할 수 없으면 명시적 실패 응답을 반환한다")
-    void getCurrentReturnsNotFoundWhenWeatherUnavailable() throws Exception {
-        given(weatherService.getCurrent(any(), any())).willThrow(new NotFoundException("현재 날씨 정보를 사용할 수 없습니다."));
+    @DisplayName("현재 날씨를 사용할 수 없으면 unavailable metadata를 success wrapper로 반환한다")
+    void getCurrentReturnsUnavailableMetadataWhenWeatherUnavailable() throws Exception {
+        CurrentWeatherResponse response = new CurrentWeatherResponse(
+                null,
+                null,
+                false,
+                false,
+                "UNAVAILABLE",
+                "PROVIDER_FAILURE",
+                null,
+                0
+        );
+        given(weatherService.getCurrent(any(), any())).willReturn(response);
 
         mockMvc.perform(get("/api/v1/weather/current")
                         .param("lat", "37.5665")
                         .param("lon", "126.9780"))
-                .andExpect(status().isNotFound())
-                .andExpect(jsonPath("$.code").value(404))
-                .andExpect(jsonPath("$.message").value("현재 날씨 정보를 사용할 수 없습니다."))
-                .andExpect(jsonPath("$.data").doesNotExist());
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(200))
+                .andExpect(jsonPath("$.message").value("success"))
+                .andExpect(jsonPath("$.data.weather").doesNotExist())
+                .andExpect(jsonPath("$.data.wind").doesNotExist())
+                .andExpect(jsonPath("$.data.stale").value(false))
+                .andExpect(jsonPath("$.data.freshnessStatus").value("UNAVAILABLE"))
+                .andExpect(jsonPath("$.data.staleReason").value("PROVIDER_FAILURE"));
     }
 
     @Test

--- a/src/test/java/com/bikeprojectminji/bikeback/weather/service/WeatherLocationKeyTest.java
+++ b/src/test/java/com/bikeprojectminji/bikeback/weather/service/WeatherLocationKeyTest.java
@@ -34,4 +34,22 @@ class WeatherLocationKeyTest {
 
         assertThat(first).isEqualTo(second);
     }
+
+    @Test
+    @DisplayName("인접 권역은 현재 권역을 제외한 3x3 주변 8개 key다")
+    void adjacentKeysReturnsEightNeighborKeys() {
+        WeatherLocationKey key = WeatherLocationKey.from(BigDecimal.valueOf(37.5665), BigDecimal.valueOf(126.9780));
+
+        assertThat(key.adjacentKeys())
+                .containsExactlyInAnyOrder(
+                        new WeatherLocationKey(new BigDecimal("37.56"), new BigDecimal("126.97")),
+                        new WeatherLocationKey(new BigDecimal("37.56"), new BigDecimal("126.98")),
+                        new WeatherLocationKey(new BigDecimal("37.56"), new BigDecimal("126.99")),
+                        new WeatherLocationKey(new BigDecimal("37.57"), new BigDecimal("126.97")),
+                        new WeatherLocationKey(new BigDecimal("37.57"), new BigDecimal("126.99")),
+                        new WeatherLocationKey(new BigDecimal("37.58"), new BigDecimal("126.97")),
+                        new WeatherLocationKey(new BigDecimal("37.58"), new BigDecimal("126.98")),
+                        new WeatherLocationKey(new BigDecimal("37.58"), new BigDecimal("126.99"))
+                );
+    }
 }

--- a/src/test/java/com/bikeprojectminji/bikeback/weather/service/WeatherServiceTest.java
+++ b/src/test/java/com/bikeprojectminji/bikeback/weather/service/WeatherServiceTest.java
@@ -414,6 +414,60 @@ class WeatherServiceTest {
         verify(bikeMetricsRecorder, timeout(1000)).recordWeatherProviderResult("current", "late_success");
     }
 
+    @Test
+    @DisplayName("현재 권역 조회 성공 후 인접 권역을 사용자 응답과 분리해 prewarm한다")
+    void getCurrentPrewarmsAdjacentLocationsAfterProviderSuccess() {
+        weatherProviderExecutor = Executors.newFixedThreadPool(4);
+        weatherService = new WeatherService(
+                weatherProviderPort,
+                lastSuccessWeatherStore,
+                bikeMetricsRecorder,
+                weatherProviderExecutor,
+                900,
+                Clock.fixed(Instant.parse("2026-03-29T01:20:00Z"), ZoneOffset.UTC)
+        );
+        WeatherLocationKey currentKey = WeatherLocationKey.from(BigDecimal.valueOf(37.5665), BigDecimal.valueOf(126.9780));
+        WeatherSnapshot snapshot = snapshot(false, "2026-03-29T10:19:00+09:00");
+        given(lastSuccessWeatherStore.find(currentKey)).willReturn(Optional.empty());
+        given(weatherProviderPort.getCurrent(org.mockito.ArgumentMatchers.any(WeatherLocationKey.class)))
+                .willReturn(WeatherProviderResult.success(snapshot));
+
+        CurrentWeatherResponse response = weatherService.getCurrent(BigDecimal.valueOf(37.5665), BigDecimal.valueOf(126.9780));
+
+        assertThat(response.freshnessStatus()).isEqualTo("FRESH_PROVIDER");
+        for (WeatherLocationKey adjacentKey : currentKey.adjacentKeys()) {
+            verify(lastSuccessWeatherStore, timeout(1500)).find(adjacentKey);
+            verify(lastSuccessWeatherStore, timeout(1500)).save(adjacentKey, snapshot);
+        }
+    }
+
+    @Test
+    @DisplayName("fresh cache가 있는 인접 권역은 prewarm provider 호출을 건너뛴다")
+    void getCurrentSkipsAdjacentPrewarmWhenFreshCacheExists() {
+        weatherProviderExecutor = Executors.newFixedThreadPool(4);
+        weatherService = new WeatherService(
+                weatherProviderPort,
+                lastSuccessWeatherStore,
+                bikeMetricsRecorder,
+                weatherProviderExecutor,
+                900,
+                Clock.fixed(Instant.parse("2026-03-29T01:20:00Z"), ZoneOffset.UTC)
+        );
+        WeatherLocationKey currentKey = WeatherLocationKey.from(BigDecimal.valueOf(37.5665), BigDecimal.valueOf(126.9780));
+        WeatherLocationKey freshAdjacentKey = currentKey.adjacentKeys().get(0);
+        WeatherSnapshot snapshot = snapshot(false, "2026-03-29T10:19:00+09:00");
+        given(lastSuccessWeatherStore.find(currentKey)).willReturn(Optional.empty());
+        given(lastSuccessWeatherStore.find(freshAdjacentKey)).willReturn(Optional.of(snapshot(false, "2026-03-29T10:18:00+09:00")));
+        given(weatherProviderPort.getCurrent(org.mockito.ArgumentMatchers.any(WeatherLocationKey.class)))
+                .willReturn(WeatherProviderResult.success(snapshot));
+
+        CurrentWeatherResponse response = weatherService.getCurrent(BigDecimal.valueOf(37.5665), BigDecimal.valueOf(126.9780));
+
+        assertThat(response.freshnessStatus()).isEqualTo("FRESH_PROVIDER");
+        verify(bikeMetricsRecorder, timeout(1500)).recordWeatherRefreshSkipped("prewarm_fresh_cache");
+        verify(weatherProviderPort, timeout(1500).atLeastOnce()).getCurrent(org.mockito.ArgumentMatchers.argThat(key -> !freshAdjacentKey.equals(key)));
+    }
+
     private WeatherSnapshot snapshot(boolean forecastFallbackUsed, String lastSucceededAt) {
         return new WeatherSnapshot(
                 new WeatherData(12, "clear", "none"),

--- a/src/test/java/com/bikeprojectminji/bikeback/weather/service/WeatherServiceTest.java
+++ b/src/test/java/com/bikeprojectminji/bikeback/weather/service/WeatherServiceTest.java
@@ -1,14 +1,12 @@
 package com.bikeprojectminji.bikeback.weather.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
 
-import com.bikeprojectminji.bikeback.global.exception.NotFoundException;
 import com.bikeprojectminji.bikeback.global.metrics.BikeMetricsRecorder;
 import com.bikeprojectminji.bikeback.weather.dto.CurrentWeatherResponse;
 import com.bikeprojectminji.bikeback.weather.dto.WeatherData;
@@ -86,7 +84,23 @@ class WeatherServiceTest {
     }
 
     @Test
-    @DisplayName("provider 실패 시 60분 이내 마지막 성공값이 있으면 stale=true로 응답한다")
+    @DisplayName("5분 이내 구역 캐시가 있으면 provider를 호출하지 않고 fresh cache로 응답한다")
+    void getCurrentReturnsFreshGridCacheResponse() {
+        WeatherLocationKey key = WeatherLocationKey.from(BigDecimal.valueOf(37.5665), BigDecimal.valueOf(126.9780));
+        given(lastSuccessWeatherStore.find(key)).willReturn(Optional.of(snapshot(false, "2026-03-29T10:16:00+09:00")));
+
+        CurrentWeatherResponse response = weatherService.getCurrent(BigDecimal.valueOf(37.5665), BigDecimal.valueOf(126.9780));
+
+        assertThat(response.stale()).isFalse();
+        assertThat(response.freshnessStatus()).isEqualTo("FRESH_CACHE");
+        assertThat(response.staleReason()).isNull();
+        assertThat(response.cacheAgeSec()).isEqualTo(240);
+        verify(weatherProviderPort, never()).getCurrent(key);
+        verify(bikeMetricsRecorder).recordWeatherCacheHit("fresh_grid");
+    }
+
+    @Test
+    @DisplayName("5분을 넘고 60분 이내 구역 캐시가 있으면 stale=true로 응답하고 비동기 refresh를 건다")
     void getCurrentReturnsStaleFallbackResponse() {
         WeatherLocationKey key = WeatherLocationKey.from(BigDecimal.valueOf(37.5665), BigDecimal.valueOf(126.9780));
         lenient().when(weatherProviderPort.getCurrent(key)).thenReturn(WeatherProviderResult.failure());
@@ -104,7 +118,7 @@ class WeatherServiceTest {
     }
 
     @Test
-    @DisplayName("유효한 last-success가 있으면 stale 응답을 먼저 반환하고 provider refresh는 비동기로 수행한다")
+    @DisplayName("5분을 넘고 60분 이내 구역 캐시가 있으면 stale 응답을 먼저 반환하고 provider refresh는 비동기로 수행한다")
     void getCurrentReturnsStaleFirstAndRefreshesAsync() {
         WeatherLocationKey key = WeatherLocationKey.from(BigDecimal.valueOf(37.5665), BigDecimal.valueOf(126.9780));
         WeatherSnapshot staleSnapshot = snapshot(true, "2026-03-29T09:40:00+09:00");
@@ -222,27 +236,37 @@ class WeatherServiceTest {
     }
 
     @Test
-    @DisplayName("provider 실패 시 마지막 성공값이 60분을 넘기면 명시적 실패로 처리한다")
-    void getCurrentThrowsWhenLastSuccessExpired() {
+    @DisplayName("provider 실패 시 마지막 성공값이 60분을 넘기면 unavailable metadata로 응답한다")
+    void getCurrentReturnsUnavailableWhenLastSuccessExpired() {
         WeatherLocationKey key = WeatherLocationKey.from(BigDecimal.valueOf(37.5665), BigDecimal.valueOf(126.9780));
         given(weatherProviderPort.getCurrent(key)).willReturn(WeatherProviderResult.failure());
         given(lastSuccessWeatherStore.find(key)).willReturn(Optional.of(snapshot(false, "2026-03-29T09:10:00+09:00")));
 
-        assertThatThrownBy(() -> weatherService.getCurrent(BigDecimal.valueOf(37.5665), BigDecimal.valueOf(126.9780)))
-                .isInstanceOf(NotFoundException.class)
-                .hasMessage("현재 날씨 정보를 사용할 수 없습니다.");
+        CurrentWeatherResponse response = weatherService.getCurrent(BigDecimal.valueOf(37.5665), BigDecimal.valueOf(126.9780));
+
+        assertThat(response.weather()).isNull();
+        assertThat(response.wind()).isNull();
+        assertThat(response.stale()).isFalse();
+        assertThat(response.freshnessStatus()).isEqualTo("UNAVAILABLE");
+        assertThat(response.staleReason()).isEqualTo("PROVIDER_FAILURE");
+        verify(bikeMetricsRecorder).recordWeatherUnavailable("provider_failure");
     }
 
     @Test
-    @DisplayName("provider 실패 시 마지막 성공값이 없으면 명시적 실패로 처리한다")
-    void getCurrentThrowsWhenLastSuccessMissing() {
+    @DisplayName("provider 실패 시 마지막 성공값이 없으면 unavailable metadata로 응답한다")
+    void getCurrentReturnsUnavailableWhenLastSuccessMissing() {
         WeatherLocationKey key = WeatherLocationKey.from(BigDecimal.valueOf(37.5665), BigDecimal.valueOf(126.9780));
         given(weatherProviderPort.getCurrent(key)).willReturn(WeatherProviderResult.failure());
         given(lastSuccessWeatherStore.find(key)).willReturn(Optional.empty());
 
-        assertThatThrownBy(() -> weatherService.getCurrent(BigDecimal.valueOf(37.5665), BigDecimal.valueOf(126.9780)))
-                .isInstanceOf(NotFoundException.class)
-                .hasMessage("현재 날씨 정보를 사용할 수 없습니다.");
+        CurrentWeatherResponse response = weatherService.getCurrent(BigDecimal.valueOf(37.5665), BigDecimal.valueOf(126.9780));
+
+        assertThat(response.weather()).isNull();
+        assertThat(response.wind()).isNull();
+        assertThat(response.stale()).isFalse();
+        assertThat(response.freshnessStatus()).isEqualTo("UNAVAILABLE");
+        assertThat(response.staleReason()).isEqualTo("PROVIDER_FAILURE");
+        verify(bikeMetricsRecorder).recordWeatherUnavailable("provider_failure");
     }
 
     @Test
@@ -302,6 +326,36 @@ class WeatherServiceTest {
         assertThat(response.stale()).isFalse();
         assertThat(response.forecastFallbackUsed()).isFalse();
         verify(lastSuccessWeatherStore).save(key, snapshot(false, "2026-03-29T10:19:00+09:00"));
+    }
+
+    @Test
+    @DisplayName("cold 요청이 grace timeout 이후 성공해도 늦은 성공값을 구역 캐시에 저장한다")
+    void getCurrentWarmsCacheWhenProviderCompletesAfterGraceTimeout() {
+        WeatherLocationKey key = WeatherLocationKey.from(BigDecimal.valueOf(37.5665), BigDecimal.valueOf(126.9780));
+        WeatherSnapshot snapshot = snapshot(false, "2026-03-29T10:19:00+09:00");
+        weatherService = new WeatherService(
+                locationKey -> {
+                    try {
+                        Thread.sleep(500);
+                    } catch (InterruptedException exception) {
+                        Thread.currentThread().interrupt();
+                        return WeatherProviderResult.failure();
+                    }
+                    return WeatherProviderResult.success(snapshot);
+                },
+                lastSuccessWeatherStore,
+                bikeMetricsRecorder,
+                weatherProviderExecutor,
+                50,
+                Clock.fixed(Instant.parse("2026-03-29T01:20:00Z"), ZoneOffset.UTC)
+        );
+        given(lastSuccessWeatherStore.find(key)).willReturn(Optional.empty());
+
+        CurrentWeatherResponse response = weatherService.getCurrent(BigDecimal.valueOf(37.5665), BigDecimal.valueOf(126.9780));
+
+        assertThat(response.freshnessStatus()).isEqualTo("UNAVAILABLE");
+        verify(lastSuccessWeatherStore, timeout(1000)).save(key, snapshot);
+        verify(bikeMetricsRecorder, timeout(1000)).recordWeatherProviderResult("current", "late_success");
     }
 
     private WeatherSnapshot snapshot(boolean forecastFallbackUsed, String lastSucceededAt) {

--- a/src/test/java/com/bikeprojectminji/bikeback/weather/service/WeatherServiceTest.java
+++ b/src/test/java/com/bikeprojectminji/bikeback/weather/service/WeatherServiceTest.java
@@ -16,11 +16,14 @@ import java.time.Clock;
 import java.time.Instant;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
+import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.AbstractExecutorService;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.BeforeEach;
@@ -270,6 +273,59 @@ class WeatherServiceTest {
     }
 
     @Test
+    @DisplayName("Redis cache read 실패는 provider 조회로 복구하고 raw 500으로 전파하지 않는다")
+    void getCurrentFallsBackToProviderWhenCacheReadFails() {
+        WeatherLocationKey key = WeatherLocationKey.from(BigDecimal.valueOf(37.5665), BigDecimal.valueOf(126.9780));
+        WeatherSnapshot snapshot = snapshot(false, "2026-03-29T10:19:00+09:00");
+        given(lastSuccessWeatherStore.find(key)).willThrow(new IllegalStateException("redis down"));
+        given(weatherProviderPort.getCurrent(key)).willReturn(WeatherProviderResult.success(snapshot));
+
+        CurrentWeatherResponse response = weatherService.getCurrent(BigDecimal.valueOf(37.5665), BigDecimal.valueOf(126.9780));
+
+        assertThat(response.freshnessStatus()).isEqualTo("FRESH_PROVIDER");
+        assertThat(response.weather()).isNotNull();
+        verify(bikeMetricsRecorder).recordWeatherCacheFailure("read");
+    }
+
+    @Test
+    @DisplayName("Redis cache write 실패는 provider 성공 응답을 실패시키지 않는다")
+    void getCurrentKeepsProviderResponseWhenCacheWriteFails() {
+        WeatherLocationKey key = WeatherLocationKey.from(BigDecimal.valueOf(37.5665), BigDecimal.valueOf(126.9780));
+        WeatherSnapshot snapshot = snapshot(false, "2026-03-29T10:19:00+09:00");
+        given(lastSuccessWeatherStore.find(key)).willReturn(Optional.empty());
+        given(weatherProviderPort.getCurrent(key)).willReturn(WeatherProviderResult.success(snapshot));
+        org.mockito.BDDMockito.willThrow(new IllegalStateException("redis down"))
+                .given(lastSuccessWeatherStore).save(key, snapshot);
+
+        CurrentWeatherResponse response = weatherService.getCurrent(BigDecimal.valueOf(37.5665), BigDecimal.valueOf(126.9780));
+
+        assertThat(response.freshnessStatus()).isEqualTo("FRESH_PROVIDER");
+        assertThat(response.weather()).isNotNull();
+        verify(bikeMetricsRecorder).recordWeatherCacheFailure("write_provider_success");
+    }
+
+    @Test
+    @DisplayName("provider executor가 포화되어 reject되면 unavailable metadata로 응답한다")
+    void getCurrentReturnsUnavailableWhenProviderBulkheadRejects() {
+        WeatherLocationKey key = WeatherLocationKey.from(BigDecimal.valueOf(37.5665), BigDecimal.valueOf(126.9780));
+        weatherService = new WeatherService(
+                weatherProviderPort,
+                lastSuccessWeatherStore,
+                bikeMetricsRecorder,
+                new RejectingExecutorService(),
+                50,
+                Clock.fixed(Instant.parse("2026-03-29T01:20:00Z"), ZoneOffset.UTC)
+        );
+        given(lastSuccessWeatherStore.find(key)).willReturn(Optional.empty());
+
+        CurrentWeatherResponse response = weatherService.getCurrent(BigDecimal.valueOf(37.5665), BigDecimal.valueOf(126.9780));
+
+        assertThat(response.freshnessStatus()).isEqualTo("UNAVAILABLE");
+        verify(bikeMetricsRecorder).recordWeatherProviderFailure("bulkhead_rejected");
+        verify(bikeMetricsRecorder).recordWeatherUnavailable("provider_failure");
+    }
+
+    @Test
     @DisplayName("provider 총 요청 시간이 초과되면 60분 이내 마지막 성공값으로 fallback한다")
     void getCurrentReturnsStaleFallbackWhenProviderTimesOut() {
         WeatherLocationKey key = WeatherLocationKey.from(BigDecimal.valueOf(37.5665), BigDecimal.valueOf(126.9780));
@@ -366,5 +422,37 @@ class WeatherServiceTest {
                 OffsetDateTime.parse(lastSucceededAt),
                 OffsetDateTime.parse(lastSucceededAt)
         );
+    }
+
+    private static class RejectingExecutorService extends AbstractExecutorService {
+
+        @Override
+        public void shutdown() {
+        }
+
+        @Override
+        public List<Runnable> shutdownNow() {
+            return List.of();
+        }
+
+        @Override
+        public boolean isShutdown() {
+            return false;
+        }
+
+        @Override
+        public boolean isTerminated() {
+            return false;
+        }
+
+        @Override
+        public boolean awaitTermination(long timeout, TimeUnit unit) {
+            return false;
+        }
+
+        @Override
+        public void execute(Runnable command) {
+            throw new RejectedExecutionException("weather provider executor rejected");
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Add hybrid/device HTTP smoke support and a focused AI route/GraphHopper evidence smoke script.
- Preserve GraphHopper routing metadata through the backend -> AI worker -> backend response path.
- Document backend runbook notes for AI route evidence smoke and Flyway checksum mismatch handling.
- Verify local real GraphHopper custom-model routing, OpenAPI contract fields, AI route E2E, and worker fallback behavior.

## Scope
- Backend PR branch: `ops/hybrid-device-smoke`
- Related AI worker repo update: `BIKE-PROJECT-MINJI/bike-ai-route@bd271f6`
- Latest backend commit: `132d140 chore: add ai route evidence smoke`
- This PR remains draft until final merge/release decision.

## Key Fix
The AI worker response path previously dropped `routingMetadata` when the worker was enabled. That hid GraphHopper provider/status/quality evidence from AI course-generation responses. This PR now passes typed routing metadata through the worker payload and response mapping.

## Added Smoke Gate
- `ops/smoke/run-ai-route-evidence-smoke.sh`
- Checks direct GraphHopper baseline route.
- Checks direct GraphHopper `custom_model` route.
- Checks OpenAPI AI route metadata fields.
- Checks `/api/v1/ai-routes/plan/from-text` preserves `routingMetadata`, `aiWorkerMetadata`, and `evidenceBadges`.

## Validation
- `bash -n ops/smoke/run-hybrid-device-smoke.sh`
- `VALIDATE_ONLY=true ./ops/smoke/run-hybrid-device-smoke.sh`
- `bash -n ops/smoke/run-ai-route-evidence-smoke.sh`
- `VALIDATE_ONLY=true ./ops/smoke/run-ai-route-evidence-smoke.sh`
- `RUN_OPENAPI_CONTRACT=false RUN_AI_ROUTE_SMOKE=false ./ops/smoke/run-ai-route-evidence-smoke.sh` -> GraphHopper baseline/custom-model direct checks passed
- `git diff --check`
- `uv run pytest` in `bike-ai-route` -> 12 passed
- `./gradlew --no-daemon test --tests 'com.bikeprojectminji.bikeback.airoute.service.HttpAiRouteWorkerClientTest' --tests 'com.bikeprojectminji.bikeback.airoute.service.AiRoutePlanComposerTest'` -> BUILD SUCCESSFUL\n- `./gradlew --no-daemon test --tests '*AiRoute*' --tests '*GraphHopper*'` -> BUILD SUCCESSFUL\n\n## Manual Evidence\n- GraphHopper custom-model direct drill: `ops/smoke/results/graphhopper-custom-model-20260629-011639`\n- API AI route E2E smoke: `ops/smoke/results/api-ai-route-e2e-20260629-012921`\n- AI worker fallback smoke: `ops/smoke/results/api-ai-route-worker-fallback-20260629-012957`\n- New script direct GraphHopper run: `ops/smoke/results/ai-route-evidence-smoke-20260629-015425`\n\n## Verified API/Contract Signals\n- `/health` returned 200 during E2E smoke.\n- `/v3/api-docs` returned 200.\n- OpenAPI contains `preferenceSummary`, `elevationStatus`, `sceneryEvidenceStatus`, `routingMetadata`, `aiWorkerMetadata`, `evidenceBadges`.\n- Destination and no-destination AI course-generation paths returned `routingMetadata.provider=GRAPHHOPPER` and `routingStatus=SUCCESS` in local smoke.\n- Worker-down fallback returned HTTP 200 with `aiWorkerMetadata.fallbackUsed=true` and preserved GraphHopper routing metadata.\n\n## Notes / Remaining Risk\n- GitHub status checks are currently empty for this PR, so validation is local/manual evidence only.\n- The existing local `bike` database has a Flyway checksum mismatch on V16; E2E validation used an isolated smoke DB and dropped it after the run. DB repair/recreate is now documented in the root development docs, but those root docs are outside this backend Git repository.\n- This is local real GraphHopper validation, not AWS parity validation. AWS load/failure runs remain separate work.