### PR TITLE
feat: harden distributed party websocket delivery

### DIFF
--- a/src/main/java/com/bikeprojectminji/bikeback/party/websocket/RidePartyDistributedEvent.java
+++ b/src/main/java/com/bikeprojectminji/bikeback/party/websocket/RidePartyDistributedEvent.java
@@ -1,0 +1,25 @@
+package com.bikeprojectminji.bikeback.party.websocket;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.time.OffsetDateTime;
+
+/** Versioned payload exchanged by party WebSocket nodes over Redis Pub/Sub. */
+public record RidePartyDistributedEvent(
+        int version,
+        String eventId,
+        String sourceNodeId,
+        EventType eventType,
+        Long partyId,
+        Long userId,
+        JsonNode payload,
+        OffsetDateTime emittedAt
+) {
+
+    public static final int VERSION = 1;
+
+    public enum EventType {
+        LOCATION,
+        MEMBER_REVOKED,
+        PARTY_CANCELED
+    }
+}

--- a/src/main/java/com/bikeprojectminji/bikeback/party/websocket/RidePartyDistributedEventPublisher.java
+++ b/src/main/java/com/bikeprojectminji/bikeback/party/websocket/RidePartyDistributedEventPublisher.java
@@ -1,0 +1,10 @@
+package com.bikeprojectminji.bikeback.party.websocket;
+
+public interface RidePartyDistributedEventPublisher {
+
+    void publish(RidePartyDistributedEvent event);
+
+    static RidePartyDistributedEventPublisher noOp() {
+        return event -> { };
+    }
+}

--- a/src/main/java/com/bikeprojectminji/bikeback/party/websocket/RidePartyDistributedPublishException.java
+++ b/src/main/java/com/bikeprojectminji/bikeback/party/websocket/RidePartyDistributedPublishException.java
@@ -1,0 +1,8 @@
+package com.bikeprojectminji.bikeback.party.websocket;
+
+public class RidePartyDistributedPublishException extends RuntimeException {
+
+    public RidePartyDistributedPublishException(String eventType, Throwable cause) {
+        super("Party WebSocket distributed publish failed for " + eventType + ".", cause);
+    }
+}

--- a/src/main/java/com/bikeprojectminji/bikeback/party/websocket/RidePartyDistributedStateService.java
+++ b/src/main/java/com/bikeprojectminji/bikeback/party/websocket/RidePartyDistributedStateService.java
@@ -1,0 +1,226 @@
+package com.bikeprojectminji.bikeback.party.websocket;
+
+import com.bikeprojectminji.bikeback.party.service.RidePartyLocationAccessService;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.NullNode;
+import java.math.BigDecimal;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.OffsetDateTime;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.UnaryOperator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.CloseStatus;
+import org.springframework.web.socket.TextMessage;
+
+@Component
+public class RidePartyDistributedStateService {
+    private static final Logger log = LoggerFactory.getLogger(RidePartyDistributedStateService.class);
+    private static final int MAX_RAW_BYTES = 8_192;
+    private static final int MAX_EVENT_ID_BYTES = 64;
+    private static final int MAX_NODE_ID_BYTES = 160;
+    private static final int MAX_SEEN_EVENTS = 10_000;
+    private static final Duration SEEN_EVENT_TTL = Duration.ofMinutes(10);
+    private static final Duration MAX_EVENT_AGE = Duration.ofMinutes(5);
+    private static final String NODE_ID = System.getenv("HOSTNAME") == null || System.getenv("HOSTNAME").isBlank()
+            ? "party-" + UUID.randomUUID() : System.getenv("HOSTNAME") + "-" + UUID.randomUUID();
+
+    private final ObjectMapper objectMapper;
+    private final RidePartySocketSessionRegistry sessionRegistry;
+    private final RidePartyLocationAccessService locationAccessService;
+    private final RidePartyDistributedEventPublisher publisher;
+    private final String nodeId;
+    private final Clock clock;
+    private final Map<String, OffsetDateTime> seen = new ConcurrentHashMap<>();
+    private final AtomicReference<RuntimeState> runtimeState =
+            new AtomicReference<>(new RuntimeState(RidePartySubscriberState.STARTING, true, null));
+
+    public RidePartyDistributedStateService(ObjectMapper mapper, RidePartySocketSessionRegistry registry,
+            RidePartyLocationAccessService access, RidePartyRedisPubSubEventBus publisher,
+            @Value("${HOSTNAME:}") String ignoredHostName) {
+        this(mapper, registry, access, publisher, NODE_ID, Clock.systemUTC());
+    }
+
+    RidePartyDistributedStateService(ObjectMapper mapper, RidePartySocketSessionRegistry registry,
+            RidePartyLocationAccessService access, RidePartyDistributedEventPublisher publisher, String nodeId, Clock clock) {
+        if (!nodeId.matches("[A-Za-z0-9][A-Za-z0-9._:-]{2,159}")) throw new IllegalArgumentException("Unsafe node id.");
+        this.objectMapper = mapper; this.sessionRegistry = registry; this.locationAccessService = access;
+        this.publisher = publisher; this.nodeId = nodeId; this.clock = clock;
+    }
+
+    public void publishLocation(Long partyId, Long userId, Object payload) { publish(RidePartyDistributedEvent.EventType.LOCATION, partyId, userId, objectMapper.valueToTree(payload)); }
+    public void publishMemberRevoked(Long partyId, Long userId) {
+        sessionRegistry.closeMemberBefore(partyId, userId, OffsetDateTime.now(clock));
+        publish(RidePartyDistributedEvent.EventType.MEMBER_REVOKED, partyId, userId, NullNode.instance);
+    }
+    public void publishPartyCanceled(Long partyId) {
+        sessionRegistry.closePartyBefore(partyId, OffsetDateTime.now(clock));
+        publish(RidePartyDistributedEvent.EventType.PARTY_CANCELED, partyId, null, NullNode.instance);
+    }
+
+    public void receive(String raw) {
+        try {
+            if (raw == null || raw.getBytes(java.nio.charset.StandardCharsets.UTF_8).length > MAX_RAW_BYTES) throw new IllegalArgumentException("Oversized envelope.");
+            JsonNode root = objectMapper.readTree(raw);
+            requireFields(root, Set.of("version", "eventId", "sourceNodeId", "eventType", "partyId", "userId", "payload", "emittedAt"));
+            validateEnvelopeShape(root);
+            RidePartyDistributedEvent event = objectMapper.treeToValue(root, RidePartyDistributedEvent.class);
+            validate(event);
+            if (nodeId.equals(event.sourceNodeId())) {
+                if (duplicate(event.eventId())) return;
+                throw new IllegalArgumentException("Unknown same-source event.");
+            }
+            if (duplicate(event.eventId())) return;
+            apply(event);
+        } catch (Exception exception) {
+            degradeAndDrain("receive");
+            log.warn("party websocket redis event rejected failureType={}", exception.getClass().getSimpleName());
+        }
+    }
+
+    public synchronized void onBusFailure(String operation) { degradeAndDrain(operation); }
+    public synchronized void onSubscriptionStarting() {
+        transition(current -> current.withSubscriber(RidePartySubscriberState.RECOVERING, null));
+    }
+    public synchronized void onSubscriptionConfirmed() {
+        if (revalidateAllSessions()) {
+            transition(current -> current.subscriberState() == RidePartySubscriberState.STOPPED
+                    ? current : current.withSubscriber(RidePartySubscriberState.HEALTHY, null));
+        }
+    }
+    public synchronized void onBusStopped() {
+        transition(current -> current.withSubscriber(RidePartySubscriberState.STOPPED, "stopped"));
+        sessionRegistry.closeAll();
+    }
+    public boolean subscriberHealthy() { return runtimeState.get().subscriberState() == RidePartySubscriberState.HEALTHY; }
+    public RidePartySubscriberState subscriberState() { return runtimeState.get().subscriberState(); }
+    public DistributedBusStatus status() {
+        RuntimeState current = runtimeState.get();
+        return new DistributedBusStatus(current.publishHealthy(), subscriberHealthy(), current.lastFailureOperation());
+    }
+
+    private void publish(RidePartyDistributedEvent.EventType type, Long partyId, Long userId, JsonNode payload) {
+        RidePartyDistributedEvent event = new RidePartyDistributedEvent(1, UUID.randomUUID().toString(), nodeId, type, partyId, userId, payload, OffsetDateTime.now(clock));
+        try {
+            rememberLocal(event.eventId());
+            publisher.publish(event);
+            transition(current -> current.withPublish(true, subscriberHealthy() ? null : "subscriber"));
+        } catch (RidePartyDistributedPublishException exception) {
+            transition(current -> current.withPublish(false, "publish"));
+            sessionRegistry.closeAll();
+            throw exception;
+        }
+    }
+
+    private void apply(RidePartyDistributedEvent event) throws Exception {
+        switch (event.eventType()) {
+            case LOCATION -> broadcast(event.partyId(), event.userId(), event.payload());
+            case MEMBER_REVOKED -> sessionRegistry.closeMemberBefore(event.partyId(), event.userId(), event.emittedAt());
+            case PARTY_CANCELED -> sessionRegistry.closePartyBefore(event.partyId(), event.emittedAt());
+        }
+    }
+    void revalidateMember(Long partyId, Long userId) {
+        try {
+            for (RidePartySocketSessionRegistry.PartySocketSession entry : sessionRegistry.sessionsForParty(partyId))
+                if (entry.userId().equals(userId) && !locationAccessService.canShare(partyId, userId)) sessionRegistry.close(entry.session(), CloseStatus.POLICY_VIOLATION.withReason("member-left"));
+        } catch (RuntimeException exception) { degradeAndDrain("revalidation"); throw exception; }
+    }
+    void revalidateParty(Long partyId) {
+        try {
+            for (RidePartySocketSessionRegistry.PartySocketSession entry : sessionRegistry.sessionsForParty(partyId))
+                if (!locationAccessService.canShare(partyId, entry.userId())) sessionRegistry.close(entry.session(), CloseStatus.POLICY_VIOLATION.withReason("party-canceled"));
+        } catch (RuntimeException exception) { degradeAndDrain("revalidation"); throw exception; }
+    }
+    private void broadcast(Long partyId, Long senderUserId, JsonNode payload) throws Exception {
+        if (!locationAccessService.canShare(partyId, senderUserId)) return;
+        TextMessage message = new TextMessage(objectMapper.writeValueAsString(Map.of("type", "location", "data", payload)));
+        for (RidePartySocketSessionRegistry.PartySocketSession entry : sessionRegistry.sessionsForParty(partyId)) {
+            if (!locationAccessService.canShare(entry.partyId(), entry.userId())) sessionRegistry.close(entry.session(), CloseStatus.POLICY_VIOLATION);
+            else sessionRegistry.send(entry, message);
+        }
+    }
+    public synchronized void revalidateAllSessionsOrDrain() {
+        revalidateAllSessions();
+    }
+    private boolean revalidateAllSessions() {
+        try {
+        for (RidePartySocketSessionRegistry.PartySocketSession entry : sessionRegistry.sessionsForParty(null)) {
+            if (!locationAccessService.canShare(entry.partyId(), entry.userId())) sessionRegistry.close(entry.session(), CloseStatus.POLICY_VIOLATION);
+        }
+        return true;
+        } catch (RuntimeException exception) { onBusFailure("revalidation"); }
+        return false;
+    }
+    private synchronized void degradeAndDrain(String operation) {
+        transition(current -> current.subscriberState() == RidePartySubscriberState.STOPPED
+                ? current : current.withSubscriber(RidePartySubscriberState.DEGRADED, operation));
+        sessionRegistry.closeAll();
+    }
+    private boolean duplicate(String id) {
+        OffsetDateTime now = OffsetDateTime.now(clock); seen.entrySet().removeIf(e -> e.getValue().plus(SEEN_EVENT_TTL).isBefore(now));
+        if (seen.putIfAbsent(id, now) != null) return true;
+        if (seen.size() > MAX_SEEN_EVENTS) seen.keySet().stream().limit(seen.size() - MAX_SEEN_EVENTS).forEach(seen::remove);
+        return false;
+    }
+    private void rememberLocal(String id) { duplicate(id); }
+    private void validate(RidePartyDistributedEvent e) throws Exception {
+        if (e.eventType()==null || e.version()!=1 || e.eventId()==null || e.eventId().getBytes(java.nio.charset.StandardCharsets.UTF_8).length>MAX_EVENT_ID_BYTES || !isUuid(e.eventId())
+                || e.sourceNodeId()==null || e.sourceNodeId().getBytes(java.nio.charset.StandardCharsets.UTF_8).length>MAX_NODE_ID_BYTES || !e.sourceNodeId().matches("[A-Za-z0-9][A-Za-z0-9._:-]{2,159}")
+                || e.partyId()==null || e.partyId()<=0 || e.payload()==null || e.emittedAt()==null || e.emittedAt().isBefore(OffsetDateTime.now(clock).minus(MAX_EVENT_AGE)) || e.emittedAt().isAfter(OffsetDateTime.now(clock).plusMinutes(1))) throw new IllegalArgumentException("Invalid envelope.");
+        if ((e.eventType()==RidePartyDistributedEvent.EventType.LOCATION || e.eventType()==RidePartyDistributedEvent.EventType.MEMBER_REVOKED) && (e.userId()==null || e.userId()<=0)) throw new IllegalArgumentException("Missing user.");
+        if (e.eventType()==RidePartyDistributedEvent.EventType.PARTY_CANCELED && e.userId()!=null) throw new IllegalArgumentException("Unexpected user.");
+        if (e.eventType()!=RidePartyDistributedEvent.EventType.LOCATION && !e.payload().isNull()) throw new IllegalArgumentException("Unexpected payload.");
+        if (e.eventType()==RidePartyDistributedEvent.EventType.LOCATION) {
+            requireFields(e.payload(), Set.of("partyId", "userId", "latitude", "longitude", "accuracyM", "speedMps", "bearingDeg", "capturedAt"));
+            if (!e.payload().path("partyId").isIntegralNumber() || !e.payload().path("userId").isIntegralNumber() || e.payload().path("partyId").asLong()!=e.partyId() || e.payload().path("userId").asLong()!=e.userId()) throw new IllegalArgumentException("Forged location identity.");
+            requireNumber(e.payload(), "latitude");
+            requireNumber(e.payload(), "longitude");
+            requireNullableNumber(e.payload(), "accuracyM");
+            requireNullableNumber(e.payload(), "speedMps");
+            requireNullableNumber(e.payload(), "bearingDeg");
+            if (!e.payload().path("capturedAt").isTextual()) throw new IllegalArgumentException("Invalid capturedAt.");
+            com.fasterxml.jackson.databind.node.ObjectNode telemetry = ((com.fasterxml.jackson.databind.node.ObjectNode) e.payload()).deepCopy();
+            telemetry.remove("partyId");
+            telemetry.remove("userId");
+            RidePartyLocationMessage location = objectMapper.treeToValue(telemetry, RidePartyLocationMessage.class);
+            location.validate();
+            location.validateCapturedAt(OffsetDateTime.now(clock));
+        }
+    }
+    private void validateEnvelopeShape(JsonNode root) {
+        if (!root.path("version").isIntegralNumber() || !root.path("eventId").isTextual()
+                || !root.path("sourceNodeId").isTextual() || !root.path("eventType").isTextual()
+                || !root.path("partyId").isIntegralNumber()
+                || !(root.path("userId").isNull() || root.path("userId").isIntegralNumber())
+                || !(root.path("emittedAt").isTextual() || root.path("emittedAt").isNumber())) throw new IllegalArgumentException("Invalid envelope shape.");
+    }
+    private void requireNumber(JsonNode payload, String field) {
+        if (!payload.path(field).isNumber()) throw new IllegalArgumentException("Invalid " + field + ".");
+    }
+    private void requireNullableNumber(JsonNode payload, String field) {
+        if (!(payload.path(field).isNull() || payload.path(field).isNumber())) throw new IllegalArgumentException("Invalid " + field + ".");
+    }
+    private void requireFields(JsonNode node, Set<String> fields) { if (!node.isObject() || node.size()!=fields.size()) throw new IllegalArgumentException("Malformed fields."); for (String f: fields) if (!node.has(f)) throw new IllegalArgumentException("Missing field."); node.fieldNames().forEachRemaining(f -> { if(!fields.contains(f)) throw new IllegalArgumentException("Unknown field."); }); }
+    private boolean isUuid(String value) { try { return UUID.fromString(value).toString().equals(value); } catch (IllegalArgumentException ex) { return false; } }
+    public record DistributedBusStatus(boolean publishHealthy, boolean subscriberHealthy, String lastFailureOperation) {
+        boolean healthy(){ return publishHealthy && subscriberHealthy; }
+        static DistributedBusStatus available(){return new DistributedBusStatus(true,true,null);}
+        static DistributedBusStatus failure(String op){return new DistributedBusStatus(false,false,op);}
+    }
+    private void transition(UnaryOperator<RuntimeState> transition) {
+        runtimeState.updateAndGet(transition);
+    }
+
+    private record RuntimeState(RidePartySubscriberState subscriberState, boolean publishHealthy, String lastFailureOperation) {
+        RuntimeState withSubscriber(RidePartySubscriberState next, String failure) { return new RuntimeState(next, publishHealthy, failure); }
+        RuntimeState withPublish(boolean next, String failure) { return new RuntimeState(subscriberState, next, failure); }
+    }
+}

--- a/src/main/java/com/bikeprojectminji/bikeback/party/websocket/RidePartyDistributedStateService.java
+++ b/src/main/java/com/bikeprojectminji/bikeback/party/websocket/RidePartyDistributedStateService.java
@@ -16,6 +16,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.UnaryOperator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.web.socket.CloseStatus;
@@ -39,10 +40,12 @@ public class RidePartyDistributedStateService {
     private final RidePartyDistributedEventPublisher publisher;
     private final String nodeId;
     private final Clock clock;
-    private final Map<String, OffsetDateTime> seen = new ConcurrentHashMap<>();
+    private final Map<String, OffsetDateTime> locallyPublishedEventIds = new ConcurrentHashMap<>();
+    private final Map<String, OffsetDateTime> remotelySeenEventIds = new ConcurrentHashMap<>();
     private final AtomicReference<RuntimeState> runtimeState =
-            new AtomicReference<>(new RuntimeState(RidePartySubscriberState.STARTING, true, null));
+            new AtomicReference<>(new RuntimeState(RidePartySubscriberState.STARTING, true, null, 0));
 
+    @Autowired
     public RidePartyDistributedStateService(ObjectMapper mapper, RidePartySocketSessionRegistry registry,
             RidePartyLocationAccessService access, RidePartyRedisPubSubEventBus publisher,
             @Value("${HOSTNAME:}") String ignoredHostName) {
@@ -58,11 +61,11 @@ public class RidePartyDistributedStateService {
 
     public void publishLocation(Long partyId, Long userId, Object payload) { publish(RidePartyDistributedEvent.EventType.LOCATION, partyId, userId, objectMapper.valueToTree(payload)); }
     public void publishMemberRevoked(Long partyId, Long userId) {
-        sessionRegistry.closeMemberBefore(partyId, userId, OffsetDateTime.now(clock));
+        revalidateMember(partyId, userId);
         publish(RidePartyDistributedEvent.EventType.MEMBER_REVOKED, partyId, userId, NullNode.instance);
     }
     public void publishPartyCanceled(Long partyId) {
-        sessionRegistry.closePartyBefore(partyId, OffsetDateTime.now(clock));
+        revalidateParty(partyId);
         publish(RidePartyDistributedEvent.EventType.PARTY_CANCELED, partyId, null, NullNode.instance);
     }
 
@@ -75,10 +78,10 @@ public class RidePartyDistributedStateService {
             RidePartyDistributedEvent event = objectMapper.treeToValue(root, RidePartyDistributedEvent.class);
             validate(event);
             if (nodeId.equals(event.sourceNodeId())) {
-                if (duplicate(event.eventId())) return;
+                if (isKnownLocalEvent(event.eventId())) return;
                 throw new IllegalArgumentException("Unknown same-source event.");
             }
-            if (duplicate(event.eventId())) return;
+            if (duplicateRemoteEvent(event.eventId())) return;
             apply(event);
         } catch (Exception exception) {
             degradeAndDrain("receive");
@@ -88,7 +91,7 @@ public class RidePartyDistributedStateService {
 
     public synchronized void onBusFailure(String operation) { degradeAndDrain(operation); }
     public synchronized void onSubscriptionStarting() {
-        transition(current -> current.withSubscriber(RidePartySubscriberState.RECOVERING, null));
+        transition(RuntimeState::beginRecovery);
     }
     public synchronized void onSubscriptionConfirmed() {
         if (revalidateAllSessions()) {
@@ -97,8 +100,18 @@ public class RidePartyDistributedStateService {
         }
     }
     public synchronized void onBusStopped() {
-        transition(current -> current.withSubscriber(RidePartySubscriberState.STOPPED, "stopped"));
+        transition(current -> current.closeAdmissions(RidePartySubscriberState.STOPPED, "stopped"));
         sessionRegistry.closeAll();
+    }
+    public synchronized boolean registerIfSubscriberHealthy(
+            Long partyId, Long userId, org.springframework.web.socket.WebSocketSession session
+    ) {
+        RuntimeState current = runtimeState.get();
+        if (current.subscriberState() != RidePartySubscriberState.HEALTHY) {
+            return false;
+        }
+        sessionRegistry.register(partyId, userId, session, current.admissionGeneration());
+        return true;
     }
     public boolean subscriberHealthy() { return runtimeState.get().subscriberState() == RidePartySubscriberState.HEALTHY; }
     public RidePartySubscriberState subscriberState() { return runtimeState.get().subscriberState(); }
@@ -110,7 +123,7 @@ public class RidePartyDistributedStateService {
     private void publish(RidePartyDistributedEvent.EventType type, Long partyId, Long userId, JsonNode payload) {
         RidePartyDistributedEvent event = new RidePartyDistributedEvent(1, UUID.randomUUID().toString(), nodeId, type, partyId, userId, payload, OffsetDateTime.now(clock));
         try {
-            rememberLocal(event.eventId());
+            rememberLocalEvent(event.eventId());
             publisher.publish(event);
             transition(current -> current.withPublish(true, subscriberHealthy() ? null : "subscriber"));
         } catch (RidePartyDistributedPublishException exception) {
@@ -123,20 +136,26 @@ public class RidePartyDistributedStateService {
     private void apply(RidePartyDistributedEvent event) throws Exception {
         switch (event.eventType()) {
             case LOCATION -> broadcast(event.partyId(), event.userId(), event.payload());
-            case MEMBER_REVOKED -> sessionRegistry.closeMemberBefore(event.partyId(), event.userId(), event.emittedAt());
-            case PARTY_CANCELED -> sessionRegistry.closePartyBefore(event.partyId(), event.emittedAt());
+            case MEMBER_REVOKED -> revalidateMember(event.partyId(), event.userId());
+            case PARTY_CANCELED -> revalidateParty(event.partyId());
         }
     }
     void revalidateMember(Long partyId, Long userId) {
         try {
-            for (RidePartySocketSessionRegistry.PartySocketSession entry : sessionRegistry.sessionsForParty(partyId))
-                if (entry.userId().equals(userId) && !locationAccessService.canShare(partyId, userId)) sessionRegistry.close(entry.session(), CloseStatus.POLICY_VIOLATION.withReason("member-left"));
+            for (RidePartySocketSessionRegistry.PartySocketSession entry : sessionRegistry.sessionsForParty(partyId)) {
+                if (entry.userId().equals(userId) && !locationAccessService.canShare(entry.partyId(), entry.userId())) {
+                    sessionRegistry.close(entry.session(), CloseStatus.POLICY_VIOLATION.withReason("member-left"));
+                }
+            }
         } catch (RuntimeException exception) { degradeAndDrain("revalidation"); throw exception; }
     }
     void revalidateParty(Long partyId) {
         try {
-            for (RidePartySocketSessionRegistry.PartySocketSession entry : sessionRegistry.sessionsForParty(partyId))
-                if (!locationAccessService.canShare(partyId, entry.userId())) sessionRegistry.close(entry.session(), CloseStatus.POLICY_VIOLATION.withReason("party-canceled"));
+            for (RidePartySocketSessionRegistry.PartySocketSession entry : sessionRegistry.sessionsForParty(partyId)) {
+                if (!locationAccessService.canShare(entry.partyId(), entry.userId())) {
+                    sessionRegistry.close(entry.session(), CloseStatus.POLICY_VIOLATION.withReason("party-canceled"));
+                }
+            }
         } catch (RuntimeException exception) { degradeAndDrain("revalidation"); throw exception; }
     }
     private void broadcast(Long partyId, Long senderUserId, JsonNode payload) throws Exception {
@@ -161,16 +180,30 @@ public class RidePartyDistributedStateService {
     }
     private synchronized void degradeAndDrain(String operation) {
         transition(current -> current.subscriberState() == RidePartySubscriberState.STOPPED
-                ? current : current.withSubscriber(RidePartySubscriberState.DEGRADED, operation));
+                ? current : current.closeAdmissions(RidePartySubscriberState.DEGRADED, operation));
         sessionRegistry.closeAll();
     }
-    private boolean duplicate(String id) {
-        OffsetDateTime now = OffsetDateTime.now(clock); seen.entrySet().removeIf(e -> e.getValue().plus(SEEN_EVENT_TTL).isBefore(now));
-        if (seen.putIfAbsent(id, now) != null) return true;
-        if (seen.size() > MAX_SEEN_EVENTS) seen.keySet().stream().limit(seen.size() - MAX_SEEN_EVENTS).forEach(seen::remove);
+    private boolean duplicateRemoteEvent(String id) {
+        return recordEvent(remotelySeenEventIds, id);
+    }
+    private boolean isKnownLocalEvent(String id) {
+        expireEvents(locallyPublishedEventIds);
+        return locallyPublishedEventIds.containsKey(id);
+    }
+    private void rememberLocalEvent(String id) {
+        recordEvent(locallyPublishedEventIds, id);
+    }
+    private boolean recordEvent(Map<String, OffsetDateTime> events, String id) {
+        OffsetDateTime now = OffsetDateTime.now(clock);
+        expireEvents(events);
+        if (events.putIfAbsent(id, now) != null) return true;
+        if (events.size() > MAX_SEEN_EVENTS) events.keySet().stream().limit(events.size() - MAX_SEEN_EVENTS).forEach(events::remove);
         return false;
     }
-    private void rememberLocal(String id) { duplicate(id); }
+    private void expireEvents(Map<String, OffsetDateTime> events) {
+        OffsetDateTime now = OffsetDateTime.now(clock);
+        events.entrySet().removeIf(e -> e.getValue().plus(SEEN_EVENT_TTL).isBefore(now));
+    }
     private void validate(RidePartyDistributedEvent e) throws Exception {
         if (e.eventType()==null || e.version()!=1 || e.eventId()==null || e.eventId().getBytes(java.nio.charset.StandardCharsets.UTF_8).length>MAX_EVENT_ID_BYTES || !isUuid(e.eventId())
                 || e.sourceNodeId()==null || e.sourceNodeId().getBytes(java.nio.charset.StandardCharsets.UTF_8).length>MAX_NODE_ID_BYTES || !e.sourceNodeId().matches("[A-Za-z0-9][A-Za-z0-9._:-]{2,159}")
@@ -219,8 +252,11 @@ public class RidePartyDistributedStateService {
         runtimeState.updateAndGet(transition);
     }
 
-    private record RuntimeState(RidePartySubscriberState subscriberState, boolean publishHealthy, String lastFailureOperation) {
-        RuntimeState withSubscriber(RidePartySubscriberState next, String failure) { return new RuntimeState(next, publishHealthy, failure); }
-        RuntimeState withPublish(boolean next, String failure) { return new RuntimeState(subscriberState, next, failure); }
+    private record RuntimeState(RidePartySubscriberState subscriberState, boolean publishHealthy, String lastFailureOperation,
+                                long admissionGeneration) {
+        RuntimeState beginRecovery() { return new RuntimeState(RidePartySubscriberState.RECOVERING, publishHealthy, null, admissionGeneration + 1); }
+        RuntimeState closeAdmissions(RidePartySubscriberState next, String failure) { return new RuntimeState(next, publishHealthy, failure, admissionGeneration + 1); }
+        RuntimeState withSubscriber(RidePartySubscriberState next, String failure) { return new RuntimeState(next, publishHealthy, failure, admissionGeneration); }
+        RuntimeState withPublish(boolean next, String failure) { return new RuntimeState(subscriberState, next, failure, admissionGeneration); }
     }
 }

--- a/src/main/java/com/bikeprojectminji/bikeback/party/websocket/RidePartyDistributedSubscriptionException.java
+++ b/src/main/java/com/bikeprojectminji/bikeback/party/websocket/RidePartyDistributedSubscriptionException.java
@@ -1,0 +1,8 @@
+package com.bikeprojectminji.bikeback.party.websocket;
+
+public class RidePartyDistributedSubscriptionException extends RuntimeException {
+
+    public RidePartyDistributedSubscriptionException(Throwable cause) {
+        super("Party WebSocket Redis subscription is unavailable.", cause);
+    }
+}

--- a/src/main/java/com/bikeprojectminji/bikeback/party/websocket/RidePartyLocationMessage.java
+++ b/src/main/java/com/bikeprojectminji/bikeback/party/websocket/RidePartyLocationMessage.java
@@ -2,6 +2,9 @@ package com.bikeprojectminji.bikeback.party.websocket;
 
 import java.math.BigDecimal;
 import java.time.OffsetDateTime;
+import java.time.Duration;
+import com.bikeprojectminji.bikeback.global.exception.BadRequestException;
+import com.bikeprojectminji.bikeback.global.validation.CoordinateValidator;
 
 public record RidePartyLocationMessage(
         BigDecimal latitude,
@@ -11,4 +14,24 @@ public record RidePartyLocationMessage(
         BigDecimal bearingDeg,
         OffsetDateTime capturedAt
 ) {
+    public void validate() {
+        CoordinateValidator.validateLatLon("latitude", latitude, "longitude", longitude);
+        validateNonNegative("accuracyM", accuracyM);
+        validateNonNegative("speedMps", speedMps);
+        if (bearingDeg != null && (bearingDeg.signum() < 0 || bearingDeg.compareTo(BigDecimal.valueOf(360)) >= 0)) {
+            throw new BadRequestException("bearingDeg는 0 이상 360 미만이어야 합니다.");
+        }
+    }
+
+    public void validateCapturedAt(OffsetDateTime now) {
+        if (capturedAt == null || capturedAt.isBefore(now.minus(Duration.ofMinutes(5))) || capturedAt.isAfter(now.plusMinutes(1))) {
+            throw new BadRequestException("capturedAt 범위가 올바르지 않습니다.");
+        }
+    }
+
+    private static void validateNonNegative(String field, BigDecimal value) {
+        if (value != null && value.signum() < 0) {
+            throw new BadRequestException(field + "은 0 이상이어야 합니다.");
+        }
+    }
 }

--- a/src/main/java/com/bikeprojectminji/bikeback/party/websocket/RidePartyLocationWebSocketHandler.java
+++ b/src/main/java/com/bikeprojectminji/bikeback/party/websocket/RidePartyLocationWebSocketHandler.java
@@ -1,7 +1,6 @@
 package com.bikeprojectminji.bikeback.party.websocket;
 
 import com.bikeprojectminji.bikeback.global.exception.BadRequestException;
-import com.bikeprojectminji.bikeback.global.validation.CoordinateValidator;
 import com.bikeprojectminji.bikeback.party.service.RidePartyLocationService;
 import com.bikeprojectminji.bikeback.party.service.RidePartyLocationAccessService;
 import com.bikeprojectminji.bikeback.party.service.RidePartySocketTokenPayload;
@@ -31,37 +30,55 @@ public class RidePartyLocationWebSocketHandler extends TextWebSocketHandler {
     private final RidePartyLocationService locationService;
     private final RidePartyLocationAccessService locationAccessService;
     private final RidePartySocketSessionRegistry sessionRegistry;
+    private final RidePartyDistributedStateService distributedStateService;
 
     public RidePartyLocationWebSocketHandler(
             ObjectMapper objectMapper,
             RidePartySocketTokenService socketTokenService,
             RidePartyLocationService locationService,
             RidePartyLocationAccessService locationAccessService,
-            RidePartySocketSessionRegistry sessionRegistry
+            RidePartySocketSessionRegistry sessionRegistry,
+            RidePartyDistributedStateService distributedStateService
     ) {
         this.objectMapper = objectMapper;
         this.socketTokenService = socketTokenService;
         this.locationService = locationService;
         this.locationAccessService = locationAccessService;
         this.sessionRegistry = sessionRegistry;
+        this.distributedStateService = distributedStateService;
+    }
+
+    RidePartyLocationWebSocketHandler(
+            ObjectMapper objectMapper,
+            RidePartySocketTokenService socketTokenService,
+            RidePartyLocationService locationService,
+            RidePartyLocationAccessService locationAccessService,
+            RidePartySocketSessionRegistry sessionRegistry
+    ) {
+        this(objectMapper, socketTokenService, locationService, locationAccessService, sessionRegistry, null);
     }
 
     @Override
     public void afterConnectionEstablished(WebSocketSession session) throws Exception {
         Long partyId = extractPartyId(session.getUri());
+        if (distributedStateService != null && !distributedStateService.subscriberHealthy()) {
+            sessionRegistry.close(session, CloseStatus.POLICY_VIOLATION.withReason("distributed subscriber unavailable"));
+            return;
+        }
         Optional<RidePartySocketTokenPayload> token = socketTokenService.consume(socketToken(session.getUri()), partyId);
         if (token.isEmpty()) {
-            session.close(CloseStatus.POLICY_VIOLATION.withReason("invalid party socket token"));
+            sessionRegistry.close(session, CloseStatus.POLICY_VIOLATION.withReason("invalid party socket token"));
             return;
         }
         if (!locationAccessService.canShare(partyId, token.get().userId())) {
-            session.close(CloseStatus.POLICY_VIOLATION.withReason("party location access denied"));
+            sessionRegistry.close(session, CloseStatus.POLICY_VIOLATION.withReason("party location access denied"));
             return;
         }
         session.getAttributes().put(PARTY_ID_ATTRIBUTE, partyId);
         session.getAttributes().put(USER_ID_ATTRIBUTE, token.get().userId());
         sessionRegistry.register(partyId, token.get().userId(), session);
-        session.sendMessage(toMessage(Map.of("type", "connected", "partyId", partyId)));
+        sessionRegistry.sessionsForParty(partyId).stream().filter(entry -> entry.session().equals(session)).findFirst()
+                .ifPresent(entry -> sessionRegistry.send(entry, uncheckedMessage(Map.of("type", "connected", "partyId", partyId))));
     }
 
     @Override
@@ -69,14 +86,14 @@ public class RidePartyLocationWebSocketHandler extends TextWebSocketHandler {
         Long partyId = attribute(session, PARTY_ID_ATTRIBUTE);
         Long userId = attribute(session, USER_ID_ATTRIBUTE);
         if (partyId == null || userId == null || !locationAccessService.canShare(partyId, userId)) {
-            session.close(CloseStatus.POLICY_VIOLATION);
-            sessionRegistry.unregister(session);
+            sessionRegistry.close(session, CloseStatus.POLICY_VIOLATION);
             return;
         }
         try {
             RidePartyLocationMessage location = objectMapper.readValue(message.getPayload(), RidePartyLocationMessage.class);
-            CoordinateValidator.validateLatLon("latitude", location.latitude(), "longitude", location.longitude());
-            locationService.saveLocation(partyId, userId, location);
+            location.validate();
+            OffsetDateTime capturedAt = location.capturedAt() == null ? OffsetDateTime.now() : location.capturedAt();
+            new RidePartyLocationMessage(location.latitude(), location.longitude(), location.accuracyM(), location.speedMps(), location.bearingDeg(), capturedAt).validateCapturedAt(OffsetDateTime.now());
             Map<String, Object> data = new LinkedHashMap<>();
             data.put("partyId", partyId);
             data.put("userId", userId);
@@ -85,15 +102,18 @@ public class RidePartyLocationWebSocketHandler extends TextWebSocketHandler {
             data.put("accuracyM", location.accuracyM());
             data.put("speedMps", location.speedMps());
             data.put("bearingDeg", location.bearingDeg());
-            data.put("capturedAt", location.capturedAt() == null ? OffsetDateTime.now() : location.capturedAt());
-            broadcast(partyId, Map.of(
-                    "type", "location",
-                    "data", data
-            ));
+            data.put("capturedAt", capturedAt);
+            if (distributedStateService != null) {
+                distributedStateService.publishLocation(partyId, userId, data);
+            }
+            locationService.saveLocation(partyId, userId, location);
+            broadcast(partyId, Map.of("type", "location", "data", data));
         } catch (BadRequestException exception) {
-            session.sendMessage(toMessage(Map.of("type", "error", "code", "BAD_LOCATION", "message", exception.getMessage())));
+            sessionRegistry.send(session, toMessage(Map.of("type", "error", "code", "BAD_LOCATION", "message", exception.getMessage())));
+        } catch (RidePartyDistributedPublishException exception) {
+            sessionRegistry.send(session, toMessage(Map.of("type", "error", "code", "DISTRIBUTED_DELIVERY_UNAVAILABLE")));
         } catch (RuntimeException exception) {
-            session.sendMessage(toMessage(Map.of("type", "error", "message", "파티 위치를 처리하지 못했습니다.")));
+            sessionRegistry.send(session, toMessage(Map.of("type", "error", "message", "파티 위치를 처리하지 못했습니다.")));
         }
     }
 
@@ -105,18 +125,25 @@ public class RidePartyLocationWebSocketHandler extends TextWebSocketHandler {
     private void broadcast(Long partyId, Object payload) throws Exception {
         TextMessage message = toMessage(payload);
         for (RidePartySocketSessionRegistry.PartySocketSession entry : sessionRegistry.sessionsForParty(partyId)) {
-            WebSocketSession session = entry.session();
-            if (!locationAccessService.canShare(entry.partyId(), entry.userId())) {
-                session.close(CloseStatus.POLICY_VIOLATION);
-                sessionRegistry.unregister(session);
-            } else if (session.isOpen()) {
-                session.sendMessage(message);
+            try {
+                WebSocketSession session = entry.session();
+                if (!locationAccessService.canShare(entry.partyId(), entry.userId())) {
+                    sessionRegistry.close(session, CloseStatus.POLICY_VIOLATION);
+                } else {
+                    sessionRegistry.send(entry, message);
+                }
+            } catch (RuntimeException exception) {
+                sessionRegistry.close(entry.session(), CloseStatus.POLICY_VIOLATION);
             }
         }
     }
 
     private TextMessage toMessage(Object payload) throws Exception {
         return new TextMessage(objectMapper.writeValueAsString(payload));
+    }
+
+    private TextMessage uncheckedMessage(Object payload) {
+        try { return toMessage(payload); } catch (Exception exception) { throw new IllegalStateException(exception); }
     }
 
     private String socketToken(URI uri) {

--- a/src/main/java/com/bikeprojectminji/bikeback/party/websocket/RidePartyLocationWebSocketHandler.java
+++ b/src/main/java/com/bikeprojectminji/bikeback/party/websocket/RidePartyLocationWebSocketHandler.java
@@ -61,10 +61,6 @@ public class RidePartyLocationWebSocketHandler extends TextWebSocketHandler {
     @Override
     public void afterConnectionEstablished(WebSocketSession session) throws Exception {
         Long partyId = extractPartyId(session.getUri());
-        if (distributedStateService != null && !distributedStateService.subscriberHealthy()) {
-            sessionRegistry.close(session, CloseStatus.POLICY_VIOLATION.withReason("distributed subscriber unavailable"));
-            return;
-        }
         Optional<RidePartySocketTokenPayload> token = socketTokenService.consume(socketToken(session.getUri()), partyId);
         if (token.isEmpty()) {
             sessionRegistry.close(session, CloseStatus.POLICY_VIOLATION.withReason("invalid party socket token"));
@@ -76,7 +72,13 @@ public class RidePartyLocationWebSocketHandler extends TextWebSocketHandler {
         }
         session.getAttributes().put(PARTY_ID_ATTRIBUTE, partyId);
         session.getAttributes().put(USER_ID_ATTRIBUTE, token.get().userId());
-        sessionRegistry.register(partyId, token.get().userId(), session);
+        boolean registered = distributedStateService == null
+                ? registerLocally(partyId, token.get().userId(), session)
+                : distributedStateService.registerIfSubscriberHealthy(partyId, token.get().userId(), session);
+        if (!registered) {
+            sessionRegistry.close(session, CloseStatus.POLICY_VIOLATION.withReason("distributed subscriber unavailable"));
+            return;
+        }
         sessionRegistry.sessionsForParty(partyId).stream().filter(entry -> entry.session().equals(session)).findFirst()
                 .ifPresent(entry -> sessionRegistry.send(entry, uncheckedMessage(Map.of("type", "connected", "partyId", partyId))));
     }
@@ -122,6 +124,10 @@ public class RidePartyLocationWebSocketHandler extends TextWebSocketHandler {
         sessionRegistry.unregister(session);
     }
 
+    private boolean registerLocally(Long partyId, Long userId, WebSocketSession session) {
+        sessionRegistry.register(partyId, userId, session);
+        return true;
+    }
     private void broadcast(Long partyId, Object payload) throws Exception {
         TextMessage message = toMessage(payload);
         for (RidePartySocketSessionRegistry.PartySocketSession entry : sessionRegistry.sessionsForParty(partyId)) {

--- a/src/main/java/com/bikeprojectminji/bikeback/party/websocket/RidePartyRedisPubSubConfiguration.java
+++ b/src/main/java/com/bikeprojectminji/bikeback/party/websocket/RidePartyRedisPubSubConfiguration.java
@@ -1,0 +1,19 @@
+package com.bikeprojectminji.bikeback.party.websocket;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+
+@Configuration
+@EnableScheduling
+class RidePartyRedisPubSubConfiguration {
+
+    @Bean(name = "ridePartyRedisMessageListenerContainer")
+    RedisMessageListenerContainer ridePartyRedisMessageListenerContainer(RedisConnectionFactory connectionFactory) {
+        RedisMessageListenerContainer container = new RedisMessageListenerContainer();
+        container.setConnectionFactory(connectionFactory);
+        return container;
+    }
+}

--- a/src/main/java/com/bikeprojectminji/bikeback/party/websocket/RidePartyRedisPubSubEventBus.java
+++ b/src/main/java/com/bikeprojectminji/bikeback/party/websocket/RidePartyRedisPubSubEventBus.java
@@ -2,14 +2,17 @@ package com.bikeprojectminji.bikeback.party.websocket;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import java.util.function.Consumer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.SmartLifecycle;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.data.redis.connection.Message;
 import org.springframework.data.redis.connection.MessageListener;
+import org.springframework.data.redis.connection.SubscriptionListener;
 import org.springframework.data.redis.listener.ChannelTopic;
 import org.springframework.data.redis.listener.RedisMessageListenerContainer;
 import org.springframework.data.redis.core.StringRedisTemplate;
@@ -32,10 +35,13 @@ public class RidePartyRedisPubSubEventBus implements RidePartyDistributedEventPu
     private final Runnable stoppedConsumer;
     private volatile boolean running;
     private volatile long generation;
+    private volatile long confirmedGeneration = -1;
+    private volatile long subscriptionStartedAtNanos;
     private volatile MessageListener activeListener;
     private volatile boolean listenerRegistered;
     private volatile boolean recoveryAllowed = true;
 
+    @Autowired
     public RidePartyRedisPubSubEventBus(
             StringRedisTemplate redisTemplate,
             @Qualifier("ridePartyRedisMessageListenerContainer") RedisMessageListenerContainer listenerContainer,
@@ -84,6 +90,7 @@ public class RidePartyRedisPubSubEventBus implements RidePartyDistributedEventPu
         this.recoveringConsumer = recoveringConsumer;
         this.readyConsumer = readyConsumer;
         this.stoppedConsumer = stoppedConsumer;
+        this.listenerContainer.setErrorHandler(error -> fail("listener"));
     }
 
     @Override
@@ -136,7 +143,9 @@ public class RidePartyRedisPubSubEventBus implements RidePartyDistributedEventPu
                 listenerContainer.start();
             }
             long registeredGeneration = ++generation;
-            activeListener = (message, pattern) -> receive(registeredGeneration, message);
+            confirmedGeneration = -1;
+            subscriptionStartedAtNanos = System.nanoTime();
+            activeListener = new SubscriptionAwareListener(registeredGeneration);
             listenerContainer.addMessageListener(activeListener, new ChannelTopic(TOPIC));
             listenerRegistered = true;
             running = true;
@@ -176,17 +185,34 @@ public class RidePartyRedisPubSubEventBus implements RidePartyDistributedEventPu
     @Scheduled(fixedDelay = 1_000)
     synchronized void confirmSubscriptionOrFail() {
         if (!running) return;
-        if (!listenerContainer.isRunning() || !listenerContainer.isListening()) {
-            fail("disconnect");
-            return;
+        try {
+            String response = redisTemplate.execute(
+                    (org.springframework.data.redis.core.RedisCallback<String>) connection -> connection.ping());
+            if (!"PONG".equalsIgnoreCase(response)) {
+                throw new IllegalStateException("Redis ping did not return PONG.");
+            }
+            if (confirmedGeneration != generation
+                    && System.nanoTime() - subscriptionStartedAtNanos >= java.util.concurrent.TimeUnit.SECONDS.toNanos(30)) {
+                fail("subscribe-timeout");
+            }
+        } catch (RuntimeException exception) {
+            fail("ping");
         }
-        readyConsumer.run();
     }
 
     @Override
     public void onMessage(Message message, byte[] pattern) {
         receive(generation, message);
     }
+
+    private synchronized void subscriptionConfirmed(long callbackGeneration) {
+        if (!running || callbackGeneration != generation) {
+            return;
+        }
+        confirmedGeneration = callbackGeneration;
+        readyConsumer.run();
+    }
+
     private void receive(long callbackGeneration, Message message) {
         if (!running || callbackGeneration != generation) {
             return;
@@ -195,6 +221,26 @@ public class RidePartyRedisPubSubEventBus implements RidePartyDistributedEventPu
             inboundMessageConsumer.accept(new String(message.getBody(), StandardCharsets.UTF_8));
         } catch (RuntimeException exception) {
             fail("listener");
+        }
+    }
+
+    private final class SubscriptionAwareListener implements MessageListener, SubscriptionListener {
+        private final long callbackGeneration;
+
+        private SubscriptionAwareListener(long callbackGeneration) {
+            this.callbackGeneration = callbackGeneration;
+        }
+
+        @Override
+        public void onMessage(Message message, byte[] pattern) {
+            receive(callbackGeneration, message);
+        }
+
+        @Override
+        public void onChannelSubscribed(byte[] channel, long count) {
+            if (Arrays.equals(channel, TOPIC.getBytes(StandardCharsets.UTF_8))) {
+                subscriptionConfirmed(callbackGeneration);
+            }
         }
     }
 

--- a/src/main/java/com/bikeprojectminji/bikeback/party/websocket/RidePartyRedisPubSubEventBus.java
+++ b/src/main/java/com/bikeprojectminji/bikeback/party/websocket/RidePartyRedisPubSubEventBus.java
@@ -47,7 +47,8 @@ public class RidePartyRedisPubSubEventBus implements RidePartyDistributedEventPu
     private volatile long readyGeneration = -1;
     private volatile long subscriptionStartedAtNanos;
     private volatile long lastHeartbeatEchoAtNanos;
-    private volatile String heartbeatNonce;
+    private volatile String pendingHeartbeatNonce;
+    private volatile long pendingHeartbeatSentAtNanos;
     private volatile MessageListener activeListener;
     private volatile boolean listenerRegistered;
     private volatile boolean recoveryAllowed = true;
@@ -139,6 +140,7 @@ public class RidePartyRedisPubSubEventBus implements RidePartyDistributedEventPu
         boolean removeListener = listenerRegistered;
         listenerRegistered = false;
         activeListener = null;
+        pendingHeartbeatNonce = null;
         running = false;
         generation++;
         try {
@@ -169,11 +171,12 @@ public class RidePartyRedisPubSubEventBus implements RidePartyDistributedEventPu
             readyGeneration = -1;
             subscriptionStartedAtNanos = nanoTime.getAsLong();
             lastHeartbeatEchoAtNanos = 0;
-            heartbeatNonce = UUID.randomUUID().toString();
+            pendingHeartbeatNonce = null;
+            pendingHeartbeatSentAtNanos = 0;
             activeListener = new SubscriptionAwareListener(registeredGeneration);
-            listenerContainer.addMessageListener(activeListener, topics());
             listenerRegistered = true;
             running = true;
+            listenerContainer.addMessageListener(activeListener, topics());
             recoveringConsumer.run();
         } catch (RuntimeException exception) {
             fail("subscribe");
@@ -210,24 +213,36 @@ public class RidePartyRedisPubSubEventBus implements RidePartyDistributedEventPu
     @Scheduled(fixedDelay = 1_000)
     synchronized void confirmSubscriptionOrFail() {
         if (!running) return;
+        long now = nanoTime.getAsLong();
+        if ((pendingHeartbeatNonce != null && now - pendingHeartbeatSentAtNanos >= heartbeatTimeoutNanos)
+                || (lastHeartbeatEchoAtNanos != 0 && now - lastHeartbeatEchoAtNanos >= heartbeatTimeoutNanos)) {
+            fail("heartbeat");
+            return;
+        }
         try {
             String response = redisTemplate.execute(
                     (org.springframework.data.redis.core.RedisCallback<String>) connection -> connection.ping());
             if (!"PONG".equalsIgnoreCase(response)) {
                 throw new IllegalStateException("Redis ping did not return PONG.");
             }
-            Long recipients = redisTemplate.convertAndSend(HEALTH_TOPIC, heartbeatNonce);
+        } catch (RuntimeException exception) {
+            fail("ping");
+            return;
+        }
+        if (pendingHeartbeatNonce != null) {
+            return;
+        }
+        String nonce = UUID.randomUUID().toString();
+        pendingHeartbeatNonce = nonce;
+        pendingHeartbeatSentAtNanos = now;
+        try {
+            Long recipients = redisTemplate.convertAndSend(HEALTH_TOPIC, nonce);
             if (recipients == null || recipients <= 0) {
                 throw new IllegalStateException("Redis Pub/Sub health channel has no active recipients.");
             }
-            long now = nanoTime.getAsLong();
-            if (now - subscriptionStartedAtNanos >= heartbeatTimeoutNanos
-                    && (confirmedGeneration != generation || lastHeartbeatEchoAtNanos == 0
-                    || now - lastHeartbeatEchoAtNanos >= heartbeatTimeoutNanos)) {
-                fail("heartbeat");
-            }
         } catch (RuntimeException exception) {
-            fail("ping");
+            pendingHeartbeatNonce = null;
+            fail("heartbeat-publish");
         }
     }
 
@@ -249,7 +264,9 @@ public class RidePartyRedisPubSubEventBus implements RidePartyDistributedEventPu
             return;
         }
         if (Arrays.equals(message.getChannel(), HEALTH_TOPIC.getBytes(StandardCharsets.UTF_8))) {
-            if (heartbeatNonce.equals(new String(message.getBody(), StandardCharsets.UTF_8))) {
+            String receivedNonce = new String(message.getBody(), StandardCharsets.UTF_8);
+            if (receivedNonce.equals(pendingHeartbeatNonce)) {
+                pendingHeartbeatNonce = null;
                 lastHeartbeatEchoAtNanos = nanoTime.getAsLong();
                 completeReadiness(callbackGeneration);
             }
@@ -304,6 +321,7 @@ public class RidePartyRedisPubSubEventBus implements RidePartyDistributedEventPu
         MessageListener failedListener = activeListener;
         listenerRegistered = false;
         activeListener = null;
+        pendingHeartbeatNonce = null;
         running = false;
         generation++;
         if (failedListener != null) {

--- a/src/main/java/com/bikeprojectminji/bikeback/party/websocket/RidePartyRedisPubSubEventBus.java
+++ b/src/main/java/com/bikeprojectminji/bikeback/party/websocket/RidePartyRedisPubSubEventBus.java
@@ -3,7 +3,11 @@ package com.bikeprojectminji.bikeback.party.websocket;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
+import java.util.function.LongSupplier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -23,6 +27,8 @@ import org.springframework.scheduling.annotation.Scheduled;
 public class RidePartyRedisPubSubEventBus implements RidePartyDistributedEventPublisher, MessageListener, SmartLifecycle {
 
     public static final String TOPIC = "bike:party:websocket:v1";
+    public static final String HEALTH_TOPIC = TOPIC + ":health";
+    private static final long HEARTBEAT_TIMEOUT_NANOS = TimeUnit.SECONDS.toNanos(30);
     private static final Logger log = LoggerFactory.getLogger(RidePartyRedisPubSubEventBus.class);
 
     private final StringRedisTemplate redisTemplate;
@@ -33,10 +39,15 @@ public class RidePartyRedisPubSubEventBus implements RidePartyDistributedEventPu
     private final Runnable recoveringConsumer;
     private final Runnable readyConsumer;
     private final Runnable stoppedConsumer;
+    private final LongSupplier nanoTime;
+    private final long heartbeatTimeoutNanos;
     private volatile boolean running;
     private volatile long generation;
     private volatile long confirmedGeneration = -1;
+    private volatile long readyGeneration = -1;
     private volatile long subscriptionStartedAtNanos;
+    private volatile long lastHeartbeatEchoAtNanos;
+    private volatile String heartbeatNonce;
     private volatile MessageListener activeListener;
     private volatile boolean listenerRegistered;
     private volatile boolean recoveryAllowed = true;
@@ -81,7 +92,16 @@ public class RidePartyRedisPubSubEventBus implements RidePartyDistributedEventPu
     }
 
     RidePartyRedisPubSubEventBus(StringRedisTemplate redisTemplate, RedisMessageListenerContainer listenerContainer,
-            ObjectMapper objectMapper, Consumer<String> inboundMessageConsumer, Consumer<String> failureConsumer, Runnable recoveringConsumer, Runnable readyConsumer, Runnable stoppedConsumer) {
+            ObjectMapper objectMapper, Consumer<String> inboundMessageConsumer, Consumer<String> failureConsumer,
+            Runnable recoveringConsumer, Runnable readyConsumer, Runnable stoppedConsumer) {
+        this(redisTemplate, listenerContainer, objectMapper, inboundMessageConsumer, failureConsumer,
+                recoveringConsumer, readyConsumer, stoppedConsumer, System::nanoTime, HEARTBEAT_TIMEOUT_NANOS);
+    }
+
+    RidePartyRedisPubSubEventBus(StringRedisTemplate redisTemplate, RedisMessageListenerContainer listenerContainer,
+            ObjectMapper objectMapper, Consumer<String> inboundMessageConsumer, Consumer<String> failureConsumer,
+            Runnable recoveringConsumer, Runnable readyConsumer, Runnable stoppedConsumer,
+            LongSupplier nanoTime, long heartbeatTimeoutNanos) {
         this.redisTemplate = redisTemplate;
         this.listenerContainer = listenerContainer;
         this.objectMapper = objectMapper;
@@ -90,6 +110,8 @@ public class RidePartyRedisPubSubEventBus implements RidePartyDistributedEventPu
         this.recoveringConsumer = recoveringConsumer;
         this.readyConsumer = readyConsumer;
         this.stoppedConsumer = stoppedConsumer;
+        this.nanoTime = nanoTime;
+        this.heartbeatTimeoutNanos = heartbeatTimeoutNanos;
         this.listenerContainer.setErrorHandler(error -> fail("listener"));
     }
 
@@ -121,7 +143,7 @@ public class RidePartyRedisPubSubEventBus implements RidePartyDistributedEventPu
         generation++;
         try {
             if (removeListener) {
-                listenerContainer.removeMessageListener(listenerToRemove, new ChannelTopic(TOPIC));
+                listenerContainer.removeMessageListener(listenerToRemove, topics());
             }
         } catch (RuntimeException exception) {
             log.warn("party websocket redis listener removal failed during stop", exception);
@@ -144,9 +166,12 @@ public class RidePartyRedisPubSubEventBus implements RidePartyDistributedEventPu
             }
             long registeredGeneration = ++generation;
             confirmedGeneration = -1;
-            subscriptionStartedAtNanos = System.nanoTime();
+            readyGeneration = -1;
+            subscriptionStartedAtNanos = nanoTime.getAsLong();
+            lastHeartbeatEchoAtNanos = 0;
+            heartbeatNonce = UUID.randomUUID().toString();
             activeListener = new SubscriptionAwareListener(registeredGeneration);
-            listenerContainer.addMessageListener(activeListener, new ChannelTopic(TOPIC));
+            listenerContainer.addMessageListener(activeListener, topics());
             listenerRegistered = true;
             running = true;
             recoveringConsumer.run();
@@ -191,9 +216,15 @@ public class RidePartyRedisPubSubEventBus implements RidePartyDistributedEventPu
             if (!"PONG".equalsIgnoreCase(response)) {
                 throw new IllegalStateException("Redis ping did not return PONG.");
             }
-            if (confirmedGeneration != generation
-                    && System.nanoTime() - subscriptionStartedAtNanos >= java.util.concurrent.TimeUnit.SECONDS.toNanos(30)) {
-                fail("subscribe-timeout");
+            Long recipients = redisTemplate.convertAndSend(HEALTH_TOPIC, heartbeatNonce);
+            if (recipients == null || recipients <= 0) {
+                throw new IllegalStateException("Redis Pub/Sub health channel has no active recipients.");
+            }
+            long now = nanoTime.getAsLong();
+            if (now - subscriptionStartedAtNanos >= heartbeatTimeoutNanos
+                    && (confirmedGeneration != generation || lastHeartbeatEchoAtNanos == 0
+                    || now - lastHeartbeatEchoAtNanos >= heartbeatTimeoutNanos)) {
+                fail("heartbeat");
             }
         } catch (RuntimeException exception) {
             fail("ping");
@@ -206,22 +237,47 @@ public class RidePartyRedisPubSubEventBus implements RidePartyDistributedEventPu
     }
 
     private synchronized void subscriptionConfirmed(long callbackGeneration) {
-        if (!running || callbackGeneration != generation) {
+        if (!isCurrentGeneration(callbackGeneration)) {
             return;
         }
         confirmedGeneration = callbackGeneration;
-        readyConsumer.run();
+        completeReadiness(callbackGeneration);
     }
 
-    private void receive(long callbackGeneration, Message message) {
-        if (!running || callbackGeneration != generation) {
+    private synchronized void receive(long callbackGeneration, Message message) {
+        if (!isCurrentGeneration(callbackGeneration)) {
+            return;
+        }
+        if (Arrays.equals(message.getChannel(), HEALTH_TOPIC.getBytes(StandardCharsets.UTF_8))) {
+            if (heartbeatNonce.equals(new String(message.getBody(), StandardCharsets.UTF_8))) {
+                lastHeartbeatEchoAtNanos = nanoTime.getAsLong();
+                completeReadiness(callbackGeneration);
+            }
             return;
         }
         try {
             inboundMessageConsumer.accept(new String(message.getBody(), StandardCharsets.UTF_8));
         } catch (RuntimeException exception) {
-            fail("listener");
+            if (isCurrentGeneration(callbackGeneration)) {
+                fail("listener");
+            }
         }
+    }
+
+    private boolean isCurrentGeneration(long callbackGeneration) {
+        return running && callbackGeneration == generation;
+    }
+
+    private void completeReadiness(long callbackGeneration) {
+        if (confirmedGeneration == callbackGeneration && lastHeartbeatEchoAtNanos >= subscriptionStartedAtNanos
+                && readyGeneration != callbackGeneration) {
+            readyGeneration = callbackGeneration;
+            readyConsumer.run();
+        }
+    }
+
+    private List<ChannelTopic> topics() {
+        return List.of(new ChannelTopic(TOPIC), new ChannelTopic(HEALTH_TOPIC));
     }
 
     private final class SubscriptionAwareListener implements MessageListener, SubscriptionListener {
@@ -252,7 +308,7 @@ public class RidePartyRedisPubSubEventBus implements RidePartyDistributedEventPu
         generation++;
         if (failedListener != null) {
             try {
-                listenerContainer.removeMessageListener(failedListener, new ChannelTopic(TOPIC));
+                listenerContainer.removeMessageListener(failedListener, topics());
             } catch (RuntimeException ignored) {
                 // Redis may already have discarded the failed registration.
             }

--- a/src/main/java/com/bikeprojectminji/bikeback/party/websocket/RidePartyRedisPubSubEventBus.java
+++ b/src/main/java/com/bikeprojectminji/bikeback/party/websocket/RidePartyRedisPubSubEventBus.java
@@ -1,0 +1,221 @@
+package com.bikeprojectminji.bikeback.party.websocket;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.nio.charset.StandardCharsets;
+import java.util.function.Consumer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.SmartLifecycle;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.data.redis.connection.Message;
+import org.springframework.data.redis.connection.MessageListener;
+import org.springframework.data.redis.listener.ChannelTopic;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+import org.springframework.scheduling.annotation.Scheduled;
+
+@Component
+public class RidePartyRedisPubSubEventBus implements RidePartyDistributedEventPublisher, MessageListener, SmartLifecycle {
+
+    public static final String TOPIC = "bike:party:websocket:v1";
+    private static final Logger log = LoggerFactory.getLogger(RidePartyRedisPubSubEventBus.class);
+
+    private final StringRedisTemplate redisTemplate;
+    private final RedisMessageListenerContainer listenerContainer;
+    private final ObjectMapper objectMapper;
+    private final Consumer<String> inboundMessageConsumer;
+    private final Consumer<String> failureConsumer;
+    private final Runnable recoveringConsumer;
+    private final Runnable readyConsumer;
+    private final Runnable stoppedConsumer;
+    private volatile boolean running;
+    private volatile long generation;
+    private volatile MessageListener activeListener;
+    private volatile boolean listenerRegistered;
+    private volatile boolean recoveryAllowed = true;
+
+    public RidePartyRedisPubSubEventBus(
+            StringRedisTemplate redisTemplate,
+            @Qualifier("ridePartyRedisMessageListenerContainer") RedisMessageListenerContainer listenerContainer,
+            ObjectMapper objectMapper,
+            ObjectProvider<RidePartyDistributedStateService> distributedStateService
+    ) {
+        this(redisTemplate, listenerContainer, objectMapper,
+                rawMessage -> distributedStateService.getObject().receive(rawMessage),
+                operation -> distributedStateService.getObject().onBusFailure(operation),
+                () -> distributedStateService.getObject().onSubscriptionStarting(),
+                () -> distributedStateService.getObject().onSubscriptionConfirmed(),
+                () -> distributedStateService.getObject().onBusStopped());
+    }
+
+    RidePartyRedisPubSubEventBus(
+            StringRedisTemplate redisTemplate,
+            RedisMessageListenerContainer listenerContainer,
+            ObjectMapper objectMapper,
+            Consumer<String> inboundMessageConsumer
+    ) {
+        this(redisTemplate, listenerContainer, objectMapper, inboundMessageConsumer, ignored -> { }, () -> { }, () -> { }, () -> { });
+    }
+
+    RidePartyRedisPubSubEventBus(
+            StringRedisTemplate redisTemplate,
+            RedisMessageListenerContainer listenerContainer,
+            ObjectMapper objectMapper,
+            Consumer<String> inboundMessageConsumer,
+            Consumer<String> failureConsumer
+    ) {
+        this(redisTemplate, listenerContainer, objectMapper, inboundMessageConsumer, failureConsumer, () -> { }, () -> { }, () -> { });
+    }
+
+    RidePartyRedisPubSubEventBus(StringRedisTemplate redisTemplate, RedisMessageListenerContainer listenerContainer,
+            ObjectMapper objectMapper, Consumer<String> inboundMessageConsumer, Consumer<String> failureConsumer, Runnable readyConsumer) {
+        this(redisTemplate, listenerContainer, objectMapper, inboundMessageConsumer, failureConsumer, () -> { }, readyConsumer, () -> { });
+    }
+
+    RidePartyRedisPubSubEventBus(StringRedisTemplate redisTemplate, RedisMessageListenerContainer listenerContainer,
+            ObjectMapper objectMapper, Consumer<String> inboundMessageConsumer, Consumer<String> failureConsumer, Runnable recoveringConsumer, Runnable readyConsumer, Runnable stoppedConsumer) {
+        this.redisTemplate = redisTemplate;
+        this.listenerContainer = listenerContainer;
+        this.objectMapper = objectMapper;
+        this.inboundMessageConsumer = inboundMessageConsumer;
+        this.failureConsumer = failureConsumer;
+        this.recoveringConsumer = recoveringConsumer;
+        this.readyConsumer = readyConsumer;
+        this.stoppedConsumer = stoppedConsumer;
+    }
+
+    @Override
+    public void publish(RidePartyDistributedEvent event) {
+        try {
+            Long recipients = redisTemplate.convertAndSend(TOPIC, objectMapper.writeValueAsString(event));
+            if (recipients == null || recipients <= 0) throw new IllegalStateException("Redis Pub/Sub has no active recipients.");
+        } catch (Exception exception) {
+            log.warn("party websocket redis publish failed eventType={} eventId={}", event.eventType(), event.eventId(), exception);
+            throw new RidePartyDistributedPublishException(event.eventType().name(), exception);
+        }
+    }
+
+    @Override
+    public synchronized void start() {
+        recoveryAllowed = true;
+        startSubscription();
+    }
+
+    @Override
+    public synchronized void stop() {
+        recoveryAllowed = false;
+        MessageListener listenerToRemove = activeListener;
+        boolean removeListener = listenerRegistered;
+        listenerRegistered = false;
+        activeListener = null;
+        running = false;
+        generation++;
+        try {
+            if (removeListener) {
+                listenerContainer.removeMessageListener(listenerToRemove, new ChannelTopic(TOPIC));
+            }
+        } catch (RuntimeException exception) {
+            log.warn("party websocket redis listener removal failed during stop", exception);
+        } finally {
+            try {
+                stoppedConsumer.run();
+            } catch (RuntimeException exception) {
+                log.warn("party websocket stop drain callback failed", exception);
+            }
+        }
+    }
+
+    private synchronized void startSubscription() {
+        if (running) {
+            return;
+        }
+        try {
+            if (!listenerContainer.isRunning()) {
+                listenerContainer.start();
+            }
+            long registeredGeneration = ++generation;
+            activeListener = (message, pattern) -> receive(registeredGeneration, message);
+            listenerContainer.addMessageListener(activeListener, new ChannelTopic(TOPIC));
+            listenerRegistered = true;
+            running = true;
+            recoveringConsumer.run();
+        } catch (RuntimeException exception) {
+            fail("subscribe");
+            throw new RidePartyDistributedSubscriptionException(exception);
+        }
+    }
+
+    @Override
+    public boolean isRunning() {
+        return running;
+    }
+
+    @Override
+    public boolean isAutoStartup() {
+        return true;
+    }
+
+    @Override
+    public int getPhase() {
+        return 0;
+    }
+
+    @Scheduled(fixedDelay = 5_000)
+    synchronized void recoverIfNecessary() {
+        if (!running && recoveryAllowed) {
+            try {
+                startSubscription();
+            } catch (RidePartyDistributedSubscriptionException ignored) {
+                // Remain fail-closed; the next lifecycle-owned retry will try a fresh generation.
+            }
+        }
+    }
+
+    @Scheduled(fixedDelay = 1_000)
+    synchronized void confirmSubscriptionOrFail() {
+        if (!running) return;
+        if (!listenerContainer.isRunning() || !listenerContainer.isListening()) {
+            fail("disconnect");
+            return;
+        }
+        readyConsumer.run();
+    }
+
+    @Override
+    public void onMessage(Message message, byte[] pattern) {
+        receive(generation, message);
+    }
+    private void receive(long callbackGeneration, Message message) {
+        if (!running || callbackGeneration != generation) {
+            return;
+        }
+        try {
+            inboundMessageConsumer.accept(new String(message.getBody(), StandardCharsets.UTF_8));
+        } catch (RuntimeException exception) {
+            fail("listener");
+        }
+    }
+
+    private synchronized void fail(String operation) {
+        MessageListener failedListener = activeListener;
+        listenerRegistered = false;
+        activeListener = null;
+        running = false;
+        generation++;
+        if (failedListener != null) {
+            try {
+                listenerContainer.removeMessageListener(failedListener, new ChannelTopic(TOPIC));
+            } catch (RuntimeException ignored) {
+                // Redis may already have discarded the failed registration.
+            }
+        }
+        try {
+            failureConsumer.accept(operation);
+        } catch (RuntimeException exception) {
+            log.warn("party websocket failure drain callback failed operation={}", operation, exception);
+        }
+        log.warn("party websocket redis listener failure operation={}", operation);
+    }
+}

--- a/src/main/java/com/bikeprojectminji/bikeback/party/websocket/RidePartySocketAccessSweep.java
+++ b/src/main/java/com/bikeprojectminji/bikeback/party/websocket/RidePartySocketAccessSweep.java
@@ -1,0 +1,12 @@
+package com.bikeprojectminji.bikeback.party.websocket;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+class RidePartySocketAccessSweep {
+    private final RidePartyDistributedStateService stateService;
+    RidePartySocketAccessSweep(RidePartyDistributedStateService stateService) { this.stateService = stateService; }
+    @Scheduled(fixedDelay = 30_000)
+    void sweep() { stateService.revalidateAllSessionsOrDrain(); }
+}

--- a/src/main/java/com/bikeprojectminji/bikeback/party/websocket/RidePartySocketRevocationListener.java
+++ b/src/main/java/com/bikeprojectminji/bikeback/party/websocket/RidePartySocketRevocationListener.java
@@ -10,18 +10,35 @@ import org.springframework.transaction.event.TransactionalEventListener;
 public class RidePartySocketRevocationListener {
 
     private final RidePartySocketSessionRegistry sessionRegistry;
+    private final RidePartyDistributedStateService distributedStateService;
 
-    public RidePartySocketRevocationListener(RidePartySocketSessionRegistry sessionRegistry) {
+    public RidePartySocketRevocationListener(
+            RidePartySocketSessionRegistry sessionRegistry,
+            RidePartyDistributedStateService distributedStateService
+    ) {
         this.sessionRegistry = sessionRegistry;
+        this.distributedStateService = distributedStateService;
+    }
+
+    RidePartySocketRevocationListener(RidePartySocketSessionRegistry sessionRegistry) {
+        this(sessionRegistry, null);
     }
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void onMemberLeft(RidePartyMemberLeftEvent event) {
-        sessionRegistry.closeMember(event.partyId(), event.userId());
+        if (distributedStateService != null) {
+            distributedStateService.publishMemberRevoked(event.partyId(), event.userId());
+        } else {
+            sessionRegistry.closeMember(event.partyId(), event.userId());
+        }
     }
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void onPartyCanceled(RidePartyCanceledEvent event) {
-        sessionRegistry.closeParty(event.partyId());
+        if (distributedStateService != null) {
+            distributedStateService.publishPartyCanceled(event.partyId());
+        } else {
+            sessionRegistry.closeParty(event.partyId());
+        }
     }
 }

--- a/src/main/java/com/bikeprojectminji/bikeback/party/websocket/RidePartySocketSessionRegistry.java
+++ b/src/main/java/com/bikeprojectminji/bikeback/party/websocket/RidePartySocketSessionRegistry.java
@@ -19,7 +19,12 @@ public class RidePartySocketSessionRegistry {
     private final Set<WebSocketSession> closeStarted = ConcurrentHashMap.newKeySet();
 
     public void register(Long partyId, Long userId, WebSocketSession session) {
-        sessions.add(new PartySocketSession(partyId, userId, session, OffsetDateTime.now(), generations.incrementAndGet()));
+        register(partyId, userId, session, 0);
+    }
+
+    public void register(Long partyId, Long userId, WebSocketSession session, long admissionGeneration) {
+        sessions.add(new PartySocketSession(
+                partyId, userId, session, OffsetDateTime.now(), generations.incrementAndGet(), admissionGeneration));
     }
 
     public void unregister(WebSocketSession session) {
@@ -116,6 +121,6 @@ public class RidePartySocketSessionRegistry {
     }
 
     public record PartySocketSession(Long partyId, Long userId, WebSocketSession session,
-                                     OffsetDateTime connectedAt, long generation) {
+                                     OffsetDateTime connectedAt, long generation, long admissionGeneration) {
     }
 }

--- a/src/main/java/com/bikeprojectminji/bikeback/party/websocket/RidePartySocketSessionRegistry.java
+++ b/src/main/java/com/bikeprojectminji/bikeback/party/websocket/RidePartySocketSessionRegistry.java
@@ -1,9 +1,11 @@
 package com.bikeprojectminji.bikeback.party.websocket;
 
 import java.io.IOException;
+import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
 import org.springframework.stereotype.Component;
 import org.springframework.web.socket.CloseStatus;
 import org.springframework.web.socket.WebSocketSession;
@@ -12,17 +14,22 @@ import org.springframework.web.socket.WebSocketSession;
 public class RidePartySocketSessionRegistry {
 
     private final Set<PartySocketSession> sessions = ConcurrentHashMap.newKeySet();
+    private final ConcurrentHashMap<WebSocketSession, Object> writeLocks = new ConcurrentHashMap<>();
+    private final AtomicLong generations = new AtomicLong();
+    private final Set<WebSocketSession> closeStarted = ConcurrentHashMap.newKeySet();
 
     public void register(Long partyId, Long userId, WebSocketSession session) {
-        sessions.add(new PartySocketSession(partyId, userId, session));
+        sessions.add(new PartySocketSession(partyId, userId, session, OffsetDateTime.now(), generations.incrementAndGet()));
     }
 
     public void unregister(WebSocketSession session) {
         sessions.removeIf(entry -> entry.session().equals(session));
+        // Keep the lock for the lifetime of this session object: removing it while an old
+        // callback is in flight could split old/new writes across two locks.
     }
 
     public List<PartySocketSession> sessionsForParty(Long partyId) {
-        return sessions.stream().filter(entry -> entry.partyId().equals(partyId)).toList();
+        return sessions.stream().filter(entry -> partyId == null || entry.partyId().equals(partyId)).toList();
     }
 
     public void closeMember(Long partyId, Long userId) {
@@ -39,6 +46,42 @@ public class RidePartySocketSessionRegistry {
         );
     }
 
+    public void closeAll() {
+        closeMatching(entry -> true, CloseStatus.POLICY_VIOLATION.withReason("distributed-bus-unavailable"));
+    }
+
+    public void closeMemberBefore(Long partyId, Long userId, OffsetDateTime emittedAt) {
+        closeMatching(entry -> entry.partyId().equals(partyId) && entry.userId().equals(userId)
+                        && !entry.connectedAt().isAfter(emittedAt),
+                CloseStatus.POLICY_VIOLATION.withReason("member-left"));
+    }
+
+    public void closePartyBefore(Long partyId, OffsetDateTime emittedAt) {
+        closeMatching(entry -> entry.partyId().equals(partyId) && !entry.connectedAt().isAfter(emittedAt),
+                CloseStatus.POLICY_VIOLATION.withReason("party-canceled"));
+    }
+
+    public boolean send(PartySocketSession entry, org.springframework.web.socket.TextMessage message) {
+        return send(entry.session(), message);
+    }
+
+    public boolean send(WebSocketSession session, org.springframework.web.socket.TextMessage message) {
+        Object lock = writeLocks.computeIfAbsent(session, ignored -> new Object());
+        synchronized (lock) {
+            if (closeStarted.contains(session) || !session.isOpen()) {
+                unregister(session);
+                return false;
+            }
+            try {
+                session.sendMessage(message);
+                return true;
+            } catch (IOException | RuntimeException exception) {
+                closeLocked(session, CloseStatus.SERVER_ERROR);
+                return false;
+            }
+        }
+    }
+
     private void closeMatching(
             java.util.function.Predicate<PartySocketSession> predicate,
             CloseStatus closeStatus
@@ -49,16 +92,30 @@ public class RidePartySocketSessionRegistry {
         }
     }
 
-    private void close(WebSocketSession session, CloseStatus closeStatus) {
+    public void close(WebSocketSession session, CloseStatus closeStatus) {
+        Object lock = writeLocks.computeIfAbsent(session, ignored -> new Object());
+        synchronized (lock) {
+            closeLocked(session, closeStatus);
+        }
+    }
+
+    private void closeLocked(WebSocketSession session, CloseStatus closeStatus) {
+        if (!closeStarted.add(session)) {
+            unregister(session);
+            return;
+        }
         try {
             if (session.isOpen()) {
                 session.close(closeStatus);
             }
-        } catch (IOException ignored) {
-            // The registry still removes the revoked session even if the transport is already broken.
+        } catch (IOException | RuntimeException ignored) {
+            // A broken transport cannot prevent cleanup of this or another party session.
+        } finally {
+            unregister(session);
         }
     }
 
-    public record PartySocketSession(Long partyId, Long userId, WebSocketSession session) {
+    public record PartySocketSession(Long partyId, Long userId, WebSocketSession session,
+                                     OffsetDateTime connectedAt, long generation) {
     }
 }

--- a/src/main/java/com/bikeprojectminji/bikeback/party/websocket/RidePartySubscriberState.java
+++ b/src/main/java/com/bikeprojectminji/bikeback/party/websocket/RidePartySubscriberState.java
@@ -1,0 +1,3 @@
+package com.bikeprojectminji.bikeback.party.websocket;
+
+public enum RidePartySubscriberState { STARTING, HEALTHY, DEGRADED, RECOVERING, STOPPED }

--- a/src/test/java/com/bikeprojectminji/bikeback/party/websocket/RidePartyDistributedWebSocketTest.java
+++ b/src/test/java/com/bikeprojectminji/bikeback/party/websocket/RidePartyDistributedWebSocketTest.java
@@ -107,8 +107,8 @@ class RidePartyDistributedWebSocketTest {
         WebSocketSession canceled = openSession();
         nodeB.registry.register(20L, 2L, revoked);
         nodeB.registry.register(20L, 3L, canceled);
-        when(nodeB.access.canShare(20L, 2L)).thenReturn(true);
-        when(nodeB.access.canShare(20L, 3L)).thenReturn(true);
+        when(nodeB.access.canShare(20L, 2L)).thenReturn(false);
+        when(nodeB.access.canShare(20L, 3L)).thenReturn(false);
 
         nodeA.service.publishMemberRevoked(20L, 2L);
         nodeA.service.publishPartyCanceled(20L);
@@ -253,24 +253,34 @@ class RidePartyDistributedWebSocketTest {
         WebSocketSession session = openSession();
         registry.register(20L, 2L, session);
         RedisMessageListenerContainer container = mock(RedisMessageListenerContainer.class);
-        when(container.isRunning()).thenReturn(true);
-        when(container.isListening()).thenReturn(true, false, true);
+        StringRedisTemplate redis = mock(StringRedisTemplate.class);
+        when(redis.execute(org.mockito.ArgumentMatchers.<org.springframework.data.redis.core.RedisCallback<String>>any())).thenReturn("PONG")
+                .thenThrow(new IllegalStateException("redis disconnected"))
+                .thenReturn("PONG");
         RidePartyRedisPubSubEventBus bus = new RidePartyRedisPubSubEventBus(
-                mock(StringRedisTemplate.class), container, objectMapper, state::receive, state::onBusFailure,
+                redis, container, objectMapper, state::receive, state::onBusFailure,
                 state::onSubscriptionStarting, state::onSubscriptionConfirmed, state::onBusStopped);
 
         bus.start();
-        assertThat(state.subscriberState()).isEqualTo(RidePartySubscriberState.RECOVERING);
-        bus.confirmSubscriptionOrFail();
+        org.mockito.ArgumentCaptor<org.springframework.data.redis.connection.MessageListener> listener =
+                org.mockito.ArgumentCaptor.forClass(org.springframework.data.redis.connection.MessageListener.class);
+        verify(container).addMessageListener(listener.capture(), org.mockito.ArgumentMatchers.any(Topic.class));
+        ((org.springframework.data.redis.connection.SubscriptionListener) listener.getValue())
+                .onChannelSubscribed(RidePartyRedisPubSubEventBus.TOPIC.getBytes(java.nio.charset.StandardCharsets.UTF_8), 1);
         assertThat(state.subscriberState()).isEqualTo(RidePartySubscriberState.HEALTHY);
 
+        bus.confirmSubscriptionOrFail();
         bus.confirmSubscriptionOrFail();
         verify(session).close(CloseStatus.POLICY_VIOLATION.withReason("distributed-bus-unavailable"));
         assertThat(state.subscriberState()).isEqualTo(RidePartySubscriberState.DEGRADED);
 
         bus.recoverIfNecessary();
-        assertThat(state.subscriberState()).isEqualTo(RidePartySubscriberState.RECOVERING);
-        bus.confirmSubscriptionOrFail();
+        org.mockito.ArgumentCaptor<org.springframework.data.redis.connection.MessageListener> recoveredListener =
+                org.mockito.ArgumentCaptor.forClass(org.springframework.data.redis.connection.MessageListener.class);
+        verify(container, org.mockito.Mockito.times(2)).addMessageListener(
+                recoveredListener.capture(), org.mockito.ArgumentMatchers.any(Topic.class));
+        ((org.springframework.data.redis.connection.SubscriptionListener) recoveredListener.getAllValues().get(1))
+                .onChannelSubscribed(RidePartyRedisPubSubEventBus.TOPIC.getBytes(java.nio.charset.StandardCharsets.UTF_8), 1);
         assertThat(state.subscriberState()).isEqualTo(RidePartySubscriberState.HEALTHY);
 
         bus.stop();
@@ -279,9 +289,6 @@ class RidePartyDistributedWebSocketTest {
 
         assertThat(state.subscriberState()).isEqualTo(RidePartySubscriberState.STOPPED);
         assertThat(bus.isRunning()).isFalse();
-        verify(container, org.mockito.Mockito.times(2)).addMessageListener(
-                org.mockito.ArgumentMatchers.any(org.springframework.data.redis.connection.MessageListener.class),
-                org.mockito.ArgumentMatchers.any(Topic.class));
     }
 
     @Test
@@ -303,6 +310,62 @@ class RidePartyDistributedWebSocketTest {
         assertThat(bus.isRunning()).isTrue();
     }
 
+    @Test
+    @DisplayName("권한이 유지된 재가입 session은 revoke event timestamp 때문에 닫히지 않는다")
+    void preservesAuthorizedRejoinedSessionDuringRevoke() throws Exception {
+        FakeBus bus = new FakeBus();
+        Node nodeA = node("node-a", bus);
+        Node nodeB = node("node-b", bus);
+        WebSocketSession rejoined = openSession();
+        nodeB.registry.register(20L, 2L, rejoined);
+        when(nodeB.access.canShare(20L, 2L)).thenReturn(true);
+
+        nodeA.service.publishMemberRevoked(20L, 2L);
+
+        verify(rejoined, never()).close(org.mockito.ArgumentMatchers.any());
+        verify(nodeB.access).canShare(20L, 2L);
+    }
+
+    @Test
+    @DisplayName("remote eventId는 같은 local published ID여도 self echo로 무시하지 않는다")
+    void appliesRemoteEventWhoseIdMatchesLocalPublishedEvent() throws Exception {
+        RidePartyDistributedEvent[] published = new RidePartyDistributedEvent[1];
+        RidePartySocketSessionRegistry registry = new RidePartySocketSessionRegistry();
+        RidePartyLocationAccessService access = mock(RidePartyLocationAccessService.class);
+        RidePartyDistributedStateService state = new RidePartyDistributedStateService(
+                objectMapper, registry, access, event -> published[0] = event, "node-a", clock);
+        WebSocketSession rejoined = openSession();
+        registry.register(20L, 2L, rejoined);
+        when(access.canShare(20L, 2L)).thenReturn(true);
+
+        state.publishPartyCanceled(20L);
+        RidePartyDistributedEvent remote = new RidePartyDistributedEvent(
+                1, published[0].eventId(), "node-b", RidePartyDistributedEvent.EventType.PARTY_CANCELED,
+                20L, null, com.fasterxml.jackson.databind.node.NullNode.instance, java.time.OffsetDateTime.now(clock));
+        state.receive(objectMapper.writeValueAsString(remote));
+
+        verify(access, org.mockito.Mockito.times(2)).canShare(20L, 2L);
+        verify(rejoined, never()).close(org.mockito.ArgumentMatchers.any());
+    }
+
+    @Test
+    @DisplayName("admission lock은 HEALTHY register와 drain을 같은 generation에서 직렬화한다")
+    void atomicallyAdmitsOnlyHealthySessions() {
+        RidePartySocketSessionRegistry registry = new RidePartySocketSessionRegistry();
+        RidePartyDistributedStateService state = new RidePartyDistributedStateService(
+                objectMapper, registry, mock(RidePartyLocationAccessService.class),
+                RidePartyDistributedEventPublisher.noOp(), "node-a", clock);
+        WebSocketSession admitted = openSession();
+        WebSocketSession rejected = openSession();
+
+        state.onSubscriptionStarting();
+        state.onSubscriptionConfirmed();
+        assertThat(state.registerIfSubscriberHealthy(20L, 2L, admitted)).isTrue();
+        state.onBusFailure("ping");
+
+        assertThat(registry.sessionsForParty(20L)).isEmpty();
+        assertThat(state.registerIfSubscriberHealthy(20L, 3L, rejected)).isFalse();
+    }
     private Node node(String nodeId, FakeBus bus) {
         RidePartySocketSessionRegistry registry = new RidePartySocketSessionRegistry();
         RidePartyLocationAccessService access = mock(RidePartyLocationAccessService.class);

--- a/src/test/java/com/bikeprojectminji/bikeback/party/websocket/RidePartyDistributedWebSocketTest.java
+++ b/src/test/java/com/bikeprojectminji/bikeback/party/websocket/RidePartyDistributedWebSocketTest.java
@@ -1,0 +1,362 @@
+package com.bikeprojectminji.bikeback.party.websocket;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.bikeprojectminji.bikeback.party.service.RidePartyLocationAccessService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.socket.CloseStatus;
+import org.springframework.web.socket.TextMessage;
+import org.springframework.web.socket.WebSocketSession;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+import org.springframework.data.redis.listener.Topic;
+
+class RidePartyDistributedWebSocketTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper().findAndRegisterModules();
+    private final Clock clock = Clock.systemUTC();
+
+    @Test
+    @DisplayName("두 논리 노드는 Redis bus로 party 범위의 location만 fan-out한다")
+    void fansOutLocationToRemoteNodeWithoutCrossPartyLeak() throws Exception {
+        FakeBus bus = new FakeBus();
+        Node nodeA = node("node-a", bus);
+        Node nodeB = node("node-b", bus);
+        WebSocketSession eligible = openSession();
+        WebSocketSession differentParty = openSession();
+        nodeB.registry.register(20L, 3L, eligible);
+        nodeB.registry.register(21L, 4L, differentParty);
+        when(nodeB.access.canShare(20L, 2L)).thenReturn(true);
+        when(nodeB.access.canShare(20L, 3L)).thenReturn(true);
+
+        nodeA.service.publishLocation(20L, 2L, locationPayload());
+
+        verify(eligible).sendMessage(argThat(message -> ((TextMessage) message).getPayload().contains("\"type\":\"location\"")));
+        verify(differentParty, never()).sendMessage(org.mockito.ArgumentMatchers.any());
+    }
+
+    @Test
+    @DisplayName("self echo와 duplicate eventId는 remote WebSocket에 재적용하지 않는다")
+    void ignoresSelfEchoAndDuplicateEvent() throws Exception {
+        FakeBus bus = new FakeBus();
+        Node nodeA = node("node-a", bus);
+        Node nodeB = node("node-b", bus);
+        WebSocketSession own = openSession();
+        WebSocketSession remote = openSession();
+        nodeA.registry.register(20L, 2L, own);
+        nodeB.registry.register(20L, 3L, remote);
+        when(nodeA.access.canShare(20L, 2L)).thenReturn(true);
+        when(nodeB.access.canShare(20L, 2L)).thenReturn(true);
+        when(nodeB.access.canShare(20L, 3L)).thenReturn(true);
+        bus.duplicateNextDelivery = true;
+
+        nodeA.service.publishLocation(20L, 2L, locationPayload());
+
+        verify(own, never()).sendMessage(org.mockito.ArgumentMatchers.any());
+        verify(remote).sendMessage(org.mockito.ArgumentMatchers.any());
+        verify(remote, org.mockito.Mockito.times(1)).sendMessage(org.mockito.ArgumentMatchers.any());
+    }
+
+    @Test
+    @DisplayName("잘못된 envelope는 적용하지 않고 측정 가능한 receive failure를 남긴다")
+    void rejectsMalformedEnvelope() {
+        Node node = node("node-b", new FakeBus());
+        WebSocketSession session = openSession();
+        node.registry.register(20L, 2L, session);
+
+        node.service.receive("{\"version\":1,\"eventId\":\"x\"}");
+
+        assertThat(node.service.status().subscriberHealthy()).isFalse();
+        assertThat(node.service.subscriberState()).isEqualTo(RidePartySubscriberState.DEGRADED);
+        try { verify(session).close(CloseStatus.POLICY_VIOLATION.withReason("distributed-bus-unavailable")); } catch (Exception exception) { throw new AssertionError(exception); }
+    }
+
+    @Test
+    @DisplayName("unknown field와 forged location identity envelope는 거부한다")
+    void rejectsUnknownFieldAndForgedIdentity() throws Exception {
+        Node node = node("node-b", new FakeBus());
+        String unknown = """
+                {"version":1,"eventId":"f47ac10b-58cc-4372-a567-0e02b2c3d479","sourceNodeId":"node-a",
+                "eventType":"LOCATION","partyId":20,"userId":2,"payload":{},"emittedAt":"2026-07-22T07:32:00Z","extra":true}
+                """;
+        node.service.receive(unknown);
+
+        assertThat(node.service.status().healthy()).isFalse();
+    }
+
+    @Test
+    @DisplayName("원격 revoke와 cancel은 정책 위반 reason으로 해당 노드 세션을 닫는다")
+    void closesRemoteSessionsForRevokeAndCancel() throws Exception {
+        FakeBus bus = new FakeBus();
+        Node nodeA = node("node-a", bus);
+        Node nodeB = node("node-b", bus);
+        WebSocketSession revoked = openSession();
+        WebSocketSession canceled = openSession();
+        nodeB.registry.register(20L, 2L, revoked);
+        nodeB.registry.register(20L, 3L, canceled);
+        when(nodeB.access.canShare(20L, 2L)).thenReturn(true);
+        when(nodeB.access.canShare(20L, 3L)).thenReturn(true);
+
+        nodeA.service.publishMemberRevoked(20L, 2L);
+        nodeA.service.publishPartyCanceled(20L);
+
+        verify(revoked).close(CloseStatus.POLICY_VIOLATION.withReason("member-left"));
+        verify(canceled).close(CloseStatus.POLICY_VIOLATION.withReason("party-canceled"));
+    }
+
+    @Test
+    @DisplayName("권한이 사라진 원격 수신자는 위치 전달 전에 닫는다")
+    void closesUnauthorizedRemoteRecipientBeforeDelivery() throws Exception {
+        FakeBus bus = new FakeBus();
+        Node nodeA = node("node-a", bus);
+        Node nodeB = node("node-b", bus);
+        WebSocketSession recipient = openSession();
+        nodeB.registry.register(20L, 3L, recipient);
+        when(nodeB.access.canShare(20L, 2L)).thenReturn(true);
+        when(nodeB.access.canShare(20L, 3L)).thenReturn(false);
+
+        nodeA.service.publishLocation(20L, 2L, locationPayload());
+
+        verify(recipient).close(CloseStatus.POLICY_VIOLATION);
+        verify(recipient, never()).sendMessage(org.mockito.ArgumentMatchers.any());
+    }
+
+    @Test
+    @DisplayName("publish failure는 typed failure와 상태로 노출된다")
+    void recordsPublishFailure() {
+        RidePartyDistributedEventPublisher failing = event -> {
+            throw new RidePartyDistributedPublishException(event.eventType().name(), new IllegalStateException("down"));
+        };
+        RidePartyDistributedStateService service = new RidePartyDistributedStateService(
+                objectMapper, new RidePartySocketSessionRegistry(), mock(RidePartyLocationAccessService.class), failing, "node-a", clock);
+
+        org.assertj.core.api.Assertions.assertThatThrownBy(() -> service.publishPartyCanceled(20L))
+                .isInstanceOf(RidePartyDistributedPublishException.class);
+        assertThat(service.status().publishHealthy()).isFalse();
+    }
+
+    @Test
+    @DisplayName("publish 성공은 subscriber degraded 상태를 healthy로 바꾸지 않는다")
+    void publishDoesNotRecoverSubscriberHealth() {
+        Node node = node("node-a", new FakeBus());
+        node.service.onBusFailure("listener");
+
+        node.service.publishPartyCanceled(20L);
+
+        assertThat(node.service.subscriberHealthy()).isFalse();
+    }
+
+    @Test
+    @DisplayName("subscriber는 정상 callback 전까지 startup degraded다")
+    void startsSubscriberDegraded() {
+        Node node = node("node-a", new FakeBus());
+
+        assertThat(node.service.subscriberHealthy()).isFalse();
+    }
+
+    @Test
+    @DisplayName("zero recipient Redis publish는 typed failure다")
+    void zeroRecipientPublishFailsClosed() {
+        RidePartyRedisPubSubEventBus bus = new RidePartyRedisPubSubEventBus(mock(StringRedisTemplate.class),
+                mock(RedisMessageListenerContainer.class), objectMapper, raw -> { });
+        RidePartyDistributedEvent event = new RidePartyDistributedEvent(1, java.util.UUID.randomUUID().toString(), "node-a",
+                RidePartyDistributedEvent.EventType.PARTY_CANCELED, 20L, null, com.fasterxml.jackson.databind.node.NullNode.instance,
+                java.time.OffsetDateTime.now());
+
+        org.assertj.core.api.Assertions.assertThatThrownBy(() -> bus.publish(event))
+                .isInstanceOf(RidePartyDistributedPublishException.class);
+    }
+
+    @Test
+    @DisplayName("canonical UUID가 아닌 eventId는 거부한다")
+    void rejectsNonCanonicalEventId() {
+        Node node = node("node-b", new FakeBus());
+        node.service.receive("{\"version\":1,\"eventId\":\"not-a-uuid\"}");
+
+        assertThat(node.service.status().subscriberHealthy()).isFalse();
+    }
+
+    @Test
+    @DisplayName("기록되지 않은 same-source event는 self echo로 허용하지 않고 drain한다")
+    void rejectsUnknownSameSourceEvent() throws Exception {
+        Node node = node("node-a", new FakeBus());
+        WebSocketSession session = openSession();
+        node.registry.register(20L, 2L, session);
+        RidePartyDistributedEvent event = new RidePartyDistributedEvent(1, java.util.UUID.randomUUID().toString(), "node-a",
+                RidePartyDistributedEvent.EventType.PARTY_CANCELED, 20L, null, com.fasterxml.jackson.databind.node.NullNode.instance,
+                java.time.OffsetDateTime.now());
+
+        node.service.receive(objectMapper.writeValueAsString(event));
+
+        assertThat(node.service.subscriberState()).isEqualTo(RidePartySubscriberState.DEGRADED);
+        verify(session).close(CloseStatus.POLICY_VIOLATION.withReason("distributed-bus-unavailable"));
+    }
+
+    @Test
+    @DisplayName("production Redis listener failure는 active instance를 해제하고 다음 lifecycle retry에서 새 generation으로 복구한다")
+    void listenerFailureDrainsAndLifecycleRetryReregisters() {
+        StringRedisTemplate redis = mock(StringRedisTemplate.class);
+        RedisMessageListenerContainer container = mock(RedisMessageListenerContainer.class);
+        List<String> failures = new ArrayList<>();
+        RidePartyRedisPubSubEventBus bus = new RidePartyRedisPubSubEventBus(redis, container, objectMapper,
+                raw -> { throw new IllegalStateException("redis restart"); }, failures::add, () -> { });
+
+        bus.start();
+        org.mockito.ArgumentCaptor<org.springframework.data.redis.connection.MessageListener> listener = org.mockito.ArgumentCaptor.forClass(org.springframework.data.redis.connection.MessageListener.class);
+        verify(container).addMessageListener(listener.capture(), org.mockito.ArgumentMatchers.any(Topic.class));
+        listener.getValue().onMessage(mock(org.springframework.data.redis.connection.Message.class), null);
+        bus.recoverIfNecessary();
+
+        assertThat(failures).containsExactly("listener");
+        assertThat(bus.isRunning()).isTrue();
+        verify(container).removeMessageListener(org.mockito.ArgumentMatchers.same(listener.getValue()), org.mockito.ArgumentMatchers.any(Topic.class));
+        verify(container, org.mockito.Mockito.times(2)).addMessageListener(org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.any(Topic.class));
+    }
+
+    @Test
+    @DisplayName("publish failure는 등록된 local session을 fail-close한다")
+    void publishFailureClosesLocalSessions() throws Exception {
+        RidePartyDistributedEventPublisher failing = event -> { throw new RidePartyDistributedPublishException("LOCATION", new IllegalStateException()); };
+        RidePartySocketSessionRegistry registry = new RidePartySocketSessionRegistry();
+        WebSocketSession session = openSession();
+        registry.register(20L, 2L, session);
+        RidePartyDistributedStateService service = new RidePartyDistributedStateService(objectMapper, registry,
+                mock(RidePartyLocationAccessService.class), failing, "node-a", clock);
+
+        org.assertj.core.api.Assertions.assertThatThrownBy(() -> service.publishPartyCanceled(20L))
+                .isInstanceOf(RidePartyDistributedPublishException.class);
+
+        verify(session).close(CloseStatus.POLICY_VIOLATION.withReason("party-canceled"));
+    }
+
+    @Test
+    @DisplayName("production Redis lifecycle는 readiness, disconnect drain, recovery와 terminal stop을 state graph에 반영한다")
+    void productionLifecycleDrainsThenRecoversWithoutEscapingStopped() throws Exception {
+        RidePartySocketSessionRegistry registry = new RidePartySocketSessionRegistry();
+        RidePartyLocationAccessService access = mock(RidePartyLocationAccessService.class);
+        RidePartyDistributedStateService state = new RidePartyDistributedStateService(
+                objectMapper, registry, access, RidePartyDistributedEventPublisher.noOp(), "node-a", clock);
+        when(access.canShare(20L, 2L)).thenReturn(true);
+        WebSocketSession session = openSession();
+        registry.register(20L, 2L, session);
+        RedisMessageListenerContainer container = mock(RedisMessageListenerContainer.class);
+        when(container.isRunning()).thenReturn(true);
+        when(container.isListening()).thenReturn(true, false, true);
+        RidePartyRedisPubSubEventBus bus = new RidePartyRedisPubSubEventBus(
+                mock(StringRedisTemplate.class), container, objectMapper, state::receive, state::onBusFailure,
+                state::onSubscriptionStarting, state::onSubscriptionConfirmed, state::onBusStopped);
+
+        bus.start();
+        assertThat(state.subscriberState()).isEqualTo(RidePartySubscriberState.RECOVERING);
+        bus.confirmSubscriptionOrFail();
+        assertThat(state.subscriberState()).isEqualTo(RidePartySubscriberState.HEALTHY);
+
+        bus.confirmSubscriptionOrFail();
+        verify(session).close(CloseStatus.POLICY_VIOLATION.withReason("distributed-bus-unavailable"));
+        assertThat(state.subscriberState()).isEqualTo(RidePartySubscriberState.DEGRADED);
+
+        bus.recoverIfNecessary();
+        assertThat(state.subscriberState()).isEqualTo(RidePartySubscriberState.RECOVERING);
+        bus.confirmSubscriptionOrFail();
+        assertThat(state.subscriberState()).isEqualTo(RidePartySubscriberState.HEALTHY);
+
+        bus.stop();
+        state.onSubscriptionConfirmed();
+        bus.recoverIfNecessary();
+
+        assertThat(state.subscriberState()).isEqualTo(RidePartySubscriberState.STOPPED);
+        assertThat(bus.isRunning()).isFalse();
+        verify(container, org.mockito.Mockito.times(2)).addMessageListener(
+                org.mockito.ArgumentMatchers.any(org.springframework.data.redis.connection.MessageListener.class),
+                org.mockito.ArgumentMatchers.any(Topic.class));
+    }
+
+    @Test
+    @DisplayName("Redis listener는 reconnect drain 뒤 한 번만 다시 등록되고 stop에서 해제된다")
+    void registersOncePerLifecycleAndUnregistersDuringDrain() {
+        StringRedisTemplate redis = mock(StringRedisTemplate.class);
+        RedisMessageListenerContainer container = mock(RedisMessageListenerContainer.class);
+        RidePartyRedisPubSubEventBus bus = new RidePartyRedisPubSubEventBus(redis, container, objectMapper, raw -> { });
+
+        bus.start();
+        bus.start();
+        bus.stop();
+        bus.start();
+
+        verify(container, org.mockito.Mockito.times(2)).addMessageListener(
+                org.mockito.ArgumentMatchers.any(org.springframework.data.redis.connection.MessageListener.class), org.mockito.ArgumentMatchers.any(Topic.class));
+        verify(container).removeMessageListener(
+                org.mockito.ArgumentMatchers.any(org.springframework.data.redis.connection.MessageListener.class), org.mockito.ArgumentMatchers.any(Topic.class));
+        assertThat(bus.isRunning()).isTrue();
+    }
+
+    private Node node(String nodeId, FakeBus bus) {
+        RidePartySocketSessionRegistry registry = new RidePartySocketSessionRegistry();
+        RidePartyLocationAccessService access = mock(RidePartyLocationAccessService.class);
+        RidePartyDistributedStateService service = new RidePartyDistributedStateService(
+                objectMapper, registry, access, bus, nodeId, clock);
+        bus.subscribe(service::receive);
+        return new Node(registry, access, service);
+    }
+
+    private WebSocketSession openSession() {
+        WebSocketSession session = mock(WebSocketSession.class);
+        when(session.isOpen()).thenReturn(true);
+        return session;
+    }
+
+    private java.util.Map<String, Object> locationPayload() {
+        java.util.Map<String, Object> payload = new java.util.LinkedHashMap<>();
+        payload.put("partyId", 20L);
+        payload.put("userId", 2L);
+        payload.put("latitude", 37.5);
+        payload.put("longitude", 127.0);
+        payload.put("accuracyM", 8.0);
+        payload.put("speedMps", null);
+        payload.put("bearingDeg", null);
+        payload.put("capturedAt", java.time.OffsetDateTime.now(clock).toString());
+        return payload;
+    }
+
+    private record Node(RidePartySocketSessionRegistry registry, RidePartyLocationAccessService access,
+                        RidePartyDistributedStateService service) { }
+
+    private static class FakeBus implements RidePartyDistributedEventPublisher {
+        private final ObjectMapper mapper = new ObjectMapper().findAndRegisterModules();
+        private final List<Consumer<String>> subscribers = new ArrayList<>();
+        private boolean duplicateNextDelivery;
+
+        void subscribe(Consumer<String> subscriber) {
+            subscribers.add(subscriber);
+        }
+
+        @Override
+        public void publish(RidePartyDistributedEvent event) {
+            try {
+                String raw = mapper.writeValueAsString(event);
+                for (Consumer<String> subscriber : subscribers) {
+                    subscriber.accept(raw);
+                    if (duplicateNextDelivery) {
+                        subscriber.accept(raw);
+                    }
+                }
+                duplicateNextDelivery = false;
+            } catch (Exception exception) {
+                throw new AssertionError(exception);
+            }
+        }
+    }
+}

--- a/src/test/java/com/bikeprojectminji/bikeback/party/websocket/RidePartyDistributedWebSocketTest.java
+++ b/src/test/java/com/bikeprojectminji/bikeback/party/websocket/RidePartyDistributedWebSocketTest.java
@@ -14,6 +14,10 @@ import java.time.Instant;
 import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -216,14 +220,14 @@ class RidePartyDistributedWebSocketTest {
 
         bus.start();
         org.mockito.ArgumentCaptor<org.springframework.data.redis.connection.MessageListener> listener = org.mockito.ArgumentCaptor.forClass(org.springframework.data.redis.connection.MessageListener.class);
-        verify(container).addMessageListener(listener.capture(), org.mockito.ArgumentMatchers.any(Topic.class));
+        verify(container).addMessageListener(listener.capture(), anyTopics());
         listener.getValue().onMessage(mock(org.springframework.data.redis.connection.Message.class), null);
         bus.recoverIfNecessary();
 
         assertThat(failures).containsExactly("listener");
         assertThat(bus.isRunning()).isTrue();
-        verify(container).removeMessageListener(org.mockito.ArgumentMatchers.same(listener.getValue()), org.mockito.ArgumentMatchers.any(Topic.class));
-        verify(container, org.mockito.Mockito.times(2)).addMessageListener(org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.any(Topic.class));
+        verify(container).removeMessageListener(org.mockito.ArgumentMatchers.same(listener.getValue()), anyTopics());
+        verify(container, org.mockito.Mockito.times(2)).addMessageListener(org.mockito.ArgumentMatchers.any(), anyTopics());
     }
 
     @Test
@@ -257,6 +261,8 @@ class RidePartyDistributedWebSocketTest {
         when(redis.execute(org.mockito.ArgumentMatchers.<org.springframework.data.redis.core.RedisCallback<String>>any())).thenReturn("PONG")
                 .thenThrow(new IllegalStateException("redis disconnected"))
                 .thenReturn("PONG");
+        when(redis.convertAndSend(org.mockito.ArgumentMatchers.eq(RidePartyRedisPubSubEventBus.HEALTH_TOPIC),
+                org.mockito.ArgumentMatchers.anyString())).thenReturn(1L);
         RidePartyRedisPubSubEventBus bus = new RidePartyRedisPubSubEventBus(
                 redis, container, objectMapper, state::receive, state::onBusFailure,
                 state::onSubscriptionStarting, state::onSubscriptionConfirmed, state::onBusStopped);
@@ -264,12 +270,15 @@ class RidePartyDistributedWebSocketTest {
         bus.start();
         org.mockito.ArgumentCaptor<org.springframework.data.redis.connection.MessageListener> listener =
                 org.mockito.ArgumentCaptor.forClass(org.springframework.data.redis.connection.MessageListener.class);
-        verify(container).addMessageListener(listener.capture(), org.mockito.ArgumentMatchers.any(Topic.class));
+        verify(container).addMessageListener(listener.capture(), anyTopics());
         ((org.springframework.data.redis.connection.SubscriptionListener) listener.getValue())
                 .onChannelSubscribed(RidePartyRedisPubSubEventBus.TOPIC.getBytes(java.nio.charset.StandardCharsets.UTF_8), 1);
+        bus.confirmSubscriptionOrFail();
+        org.mockito.ArgumentCaptor<String> nonce = org.mockito.ArgumentCaptor.forClass(String.class);
+        verify(redis).convertAndSend(org.mockito.ArgumentMatchers.eq(RidePartyRedisPubSubEventBus.HEALTH_TOPIC), nonce.capture());
+        echoHealth(listener.getValue(), nonce.getValue());
         assertThat(state.subscriberState()).isEqualTo(RidePartySubscriberState.HEALTHY);
 
-        bus.confirmSubscriptionOrFail();
         bus.confirmSubscriptionOrFail();
         verify(session).close(CloseStatus.POLICY_VIOLATION.withReason("distributed-bus-unavailable"));
         assertThat(state.subscriberState()).isEqualTo(RidePartySubscriberState.DEGRADED);
@@ -278,9 +287,13 @@ class RidePartyDistributedWebSocketTest {
         org.mockito.ArgumentCaptor<org.springframework.data.redis.connection.MessageListener> recoveredListener =
                 org.mockito.ArgumentCaptor.forClass(org.springframework.data.redis.connection.MessageListener.class);
         verify(container, org.mockito.Mockito.times(2)).addMessageListener(
-                recoveredListener.capture(), org.mockito.ArgumentMatchers.any(Topic.class));
+                recoveredListener.capture(), anyTopics());
         ((org.springframework.data.redis.connection.SubscriptionListener) recoveredListener.getAllValues().get(1))
                 .onChannelSubscribed(RidePartyRedisPubSubEventBus.TOPIC.getBytes(java.nio.charset.StandardCharsets.UTF_8), 1);
+        bus.confirmSubscriptionOrFail();
+        verify(redis, org.mockito.Mockito.times(2)).convertAndSend(
+                org.mockito.ArgumentMatchers.eq(RidePartyRedisPubSubEventBus.HEALTH_TOPIC), nonce.capture());
+        echoHealth(recoveredListener.getAllValues().get(1), nonce.getAllValues().get(nonce.getAllValues().size() - 1));
         assertThat(state.subscriberState()).isEqualTo(RidePartySubscriberState.HEALTHY);
 
         bus.stop();
@@ -304,9 +317,9 @@ class RidePartyDistributedWebSocketTest {
         bus.start();
 
         verify(container, org.mockito.Mockito.times(2)).addMessageListener(
-                org.mockito.ArgumentMatchers.any(org.springframework.data.redis.connection.MessageListener.class), org.mockito.ArgumentMatchers.any(Topic.class));
+                org.mockito.ArgumentMatchers.any(org.springframework.data.redis.connection.MessageListener.class), anyTopics());
         verify(container).removeMessageListener(
-                org.mockito.ArgumentMatchers.any(org.springframework.data.redis.connection.MessageListener.class), org.mockito.ArgumentMatchers.any(Topic.class));
+                org.mockito.ArgumentMatchers.any(org.springframework.data.redis.connection.MessageListener.class), anyTopics());
         assertThat(bus.isRunning()).isTrue();
     }
 
@@ -365,6 +378,130 @@ class RidePartyDistributedWebSocketTest {
 
         assertThat(registry.sessionsForParty(20L)).isEmpty();
         assertThat(state.registerIfSubscriberHealthy(20L, 3L, rejected)).isFalse();
+    }
+    @Test
+    @DisplayName("subscription callback만으로는 ready가 아니며 self heartbeat echo가 admission을 연다")
+    void requiresHeartbeatEchoAfterSubscriptionCallback() {
+        StringRedisTemplate redis = mock(StringRedisTemplate.class);
+        RedisMessageListenerContainer container = mock(RedisMessageListenerContainer.class);
+        AtomicInteger ready = new AtomicInteger();
+        when(redis.execute(org.mockito.ArgumentMatchers.<org.springframework.data.redis.core.RedisCallback<String>>any())).thenReturn("PONG");
+        when(redis.convertAndSend(org.mockito.ArgumentMatchers.eq(RidePartyRedisPubSubEventBus.HEALTH_TOPIC),
+                org.mockito.ArgumentMatchers.anyString())).thenReturn(1L);
+        RidePartyRedisPubSubEventBus bus = new RidePartyRedisPubSubEventBus(
+                redis, container, objectMapper, raw -> { }, ignored -> { }, () -> { }, ready::incrementAndGet, () -> { });
+
+        bus.start();
+        org.mockito.ArgumentCaptor<org.springframework.data.redis.connection.MessageListener> listener =
+                org.mockito.ArgumentCaptor.forClass(org.springframework.data.redis.connection.MessageListener.class);
+        verify(container).addMessageListener(listener.capture(), anyTopics());
+        ((org.springframework.data.redis.connection.SubscriptionListener) listener.getValue())
+                .onChannelSubscribed(RidePartyRedisPubSubEventBus.TOPIC.getBytes(java.nio.charset.StandardCharsets.UTF_8), 1);
+        assertThat(ready.get()).isZero();
+
+        bus.confirmSubscriptionOrFail();
+        org.mockito.ArgumentCaptor<String> nonce = org.mockito.ArgumentCaptor.forClass(String.class);
+        verify(redis).convertAndSend(org.mockito.ArgumentMatchers.eq(RidePartyRedisPubSubEventBus.HEALTH_TOPIC), nonce.capture());
+        echoHealth(listener.getValue(), nonce.getValue());
+
+        assertThat(ready.get()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("PING이 PONG이어도 Pub/Sub heartbeat echo가 사라지면 drain하고 새 generation을 등록한다")
+    void drainsAndRecoversWhenPubSubHeartbeatIsLostWhilePingSucceeds() throws Exception {
+        AtomicLong now = new AtomicLong(1);
+        RidePartySocketSessionRegistry registry = new RidePartySocketSessionRegistry();
+        RidePartyLocationAccessService access = mock(RidePartyLocationAccessService.class);
+        RidePartyDistributedStateService state = new RidePartyDistributedStateService(
+                objectMapper, registry, access, RidePartyDistributedEventPublisher.noOp(), "node-a", clock);
+        when(access.canShare(20L, 2L)).thenReturn(true);
+        WebSocketSession session = openSession();
+        registry.register(20L, 2L, session);
+        StringRedisTemplate redis = mock(StringRedisTemplate.class);
+        RedisMessageListenerContainer container = mock(RedisMessageListenerContainer.class);
+        when(redis.execute(org.mockito.ArgumentMatchers.<org.springframework.data.redis.core.RedisCallback<String>>any())).thenReturn("PONG");
+        when(redis.convertAndSend(org.mockito.ArgumentMatchers.eq(RidePartyRedisPubSubEventBus.HEALTH_TOPIC),
+                org.mockito.ArgumentMatchers.anyString())).thenReturn(1L);
+        RidePartyRedisPubSubEventBus bus = new RidePartyRedisPubSubEventBus(
+                redis, container, objectMapper, state::receive, state::onBusFailure, state::onSubscriptionStarting,
+                state::onSubscriptionConfirmed, state::onBusStopped, now::get, TimeUnit.SECONDS.toNanos(30));
+
+        bus.start();
+        org.mockito.ArgumentCaptor<org.springframework.data.redis.connection.MessageListener> listener =
+                org.mockito.ArgumentCaptor.forClass(org.springframework.data.redis.connection.MessageListener.class);
+        verify(container).addMessageListener(listener.capture(), anyTopics());
+        ((org.springframework.data.redis.connection.SubscriptionListener) listener.getValue())
+                .onChannelSubscribed(RidePartyRedisPubSubEventBus.TOPIC.getBytes(java.nio.charset.StandardCharsets.UTF_8), 1);
+        bus.confirmSubscriptionOrFail();
+        org.mockito.ArgumentCaptor<String> nonce = org.mockito.ArgumentCaptor.forClass(String.class);
+        verify(redis).convertAndSend(org.mockito.ArgumentMatchers.eq(RidePartyRedisPubSubEventBus.HEALTH_TOPIC), nonce.capture());
+        echoHealth(listener.getValue(), nonce.getValue());
+        assertThat(state.subscriberState()).isEqualTo(RidePartySubscriberState.HEALTHY);
+
+        now.addAndGet(TimeUnit.SECONDS.toNanos(31));
+        bus.confirmSubscriptionOrFail();
+
+        verify(session).close(CloseStatus.POLICY_VIOLATION.withReason("distributed-bus-unavailable"));
+        assertThat(state.subscriberState()).isEqualTo(RidePartySubscriberState.DEGRADED);
+        bus.recoverIfNecessary();
+        verify(container, org.mockito.Mockito.times(2)).addMessageListener(
+                org.mockito.ArgumentMatchers.any(org.springframework.data.redis.connection.MessageListener.class),
+                anyTopics());
+    }
+
+    @Test
+    @DisplayName("in-flight old generation callback은 ping failure와 restart를 교차 처리하지 않는다")
+    void fencesInFlightOldGenerationCallbackAcrossRestart() throws Exception {
+        StringRedisTemplate redis = mock(StringRedisTemplate.class);
+        RedisMessageListenerContainer container = mock(RedisMessageListenerContainer.class);
+        List<String> failures = new ArrayList<>();
+        CountDownLatch inboundStarted = new CountDownLatch(1);
+        CountDownLatch releaseInbound = new CountDownLatch(1);
+        RidePartyRedisPubSubEventBus bus = new RidePartyRedisPubSubEventBus(
+                redis, container, objectMapper, raw -> {
+                    inboundStarted.countDown();
+                    try {
+                        releaseInbound.await(2, TimeUnit.SECONDS);
+                    } catch (InterruptedException exception) {
+                        Thread.currentThread().interrupt();
+                    }
+                    throw new IllegalStateException("old callback failure");
+                }, failures::add, () -> { }, () -> { }, () -> { });
+
+        bus.start();
+        org.mockito.ArgumentCaptor<org.springframework.data.redis.connection.MessageListener> listener =
+                org.mockito.ArgumentCaptor.forClass(org.springframework.data.redis.connection.MessageListener.class);
+        verify(container).addMessageListener(listener.capture(), anyTopics());
+        org.springframework.data.redis.connection.Message data = mock(org.springframework.data.redis.connection.Message.class);
+        when(data.getChannel()).thenReturn(RidePartyRedisPubSubEventBus.TOPIC.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+        when(data.getBody()).thenReturn("location".getBytes(java.nio.charset.StandardCharsets.UTF_8));
+        Thread oldCallback = new Thread(() -> listener.getValue().onMessage(data, null));
+        oldCallback.start();
+        assertThat(inboundStarted.await(2, TimeUnit.SECONDS)).isTrue();
+
+        Thread ping = new Thread(bus::confirmSubscriptionOrFail);
+        ping.start();
+        releaseInbound.countDown();
+        oldCallback.join(2_000);
+        ping.join(2_000);
+        bus.recoverIfNecessary();
+        listener.getValue().onMessage(data, null);
+
+        assertThat(failures).containsExactly("listener");
+        assertThat(bus.isRunning()).isTrue();
+        verify(container, org.mockito.Mockito.times(2)).addMessageListener(
+                org.mockito.ArgumentMatchers.any(org.springframework.data.redis.connection.MessageListener.class),
+                anyTopics());
+    }
+    private java.util.Collection<? extends Topic> anyTopics() {
+        return org.mockito.ArgumentMatchers.any();
+    }
+    private void echoHealth(org.springframework.data.redis.connection.MessageListener listener, String nonce) {
+        org.springframework.data.redis.connection.Message healthMessage = mock(org.springframework.data.redis.connection.Message.class);
+        when(healthMessage.getChannel()).thenReturn(RidePartyRedisPubSubEventBus.HEALTH_TOPIC.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+        when(healthMessage.getBody()).thenReturn(nonce.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+        listener.onMessage(healthMessage, null);
     }
     private Node node(String nodeId, FakeBus bus) {
         RidePartySocketSessionRegistry registry = new RidePartySocketSessionRegistry();

--- a/src/test/java/com/bikeprojectminji/bikeback/party/websocket/RidePartyDistributedWebSocketTest.java
+++ b/src/test/java/com/bikeprojectminji/bikeback/party/websocket/RidePartyDistributedWebSocketTest.java
@@ -458,6 +458,7 @@ class RidePartyDistributedWebSocketTest {
         List<String> failures = new ArrayList<>();
         CountDownLatch inboundStarted = new CountDownLatch(1);
         CountDownLatch releaseInbound = new CountDownLatch(1);
+        CountDownLatch restartAttempted = new CountDownLatch(1);
         RidePartyRedisPubSubEventBus bus = new RidePartyRedisPubSubEventBus(
                 redis, container, objectMapper, raw -> {
                     inboundStarted.countDown();
@@ -480,11 +481,19 @@ class RidePartyDistributedWebSocketTest {
         oldCallback.start();
         assertThat(inboundStarted.await(2, TimeUnit.SECONDS)).isTrue();
 
-        Thread ping = new Thread(bus::confirmSubscriptionOrFail);
+        Thread ping = new Thread(() -> {
+            restartAttempted.countDown();
+            bus.confirmSubscriptionOrFail();
+        });
         ping.start();
+        assertThat(restartAttempted.await(2, TimeUnit.SECONDS)).isTrue();
+        assertThat(ping.isAlive()).isTrue();
         releaseInbound.countDown();
         oldCallback.join(2_000);
         ping.join(2_000);
+        assertThat(oldCallback.isAlive()).isFalse();
+        assertThat(ping.isAlive()).isFalse();
+        assertThat(bus.isRunning()).isFalse();
         bus.recoverIfNecessary();
         listener.getValue().onMessage(data, null);
 
@@ -493,6 +502,96 @@ class RidePartyDistributedWebSocketTest {
         verify(container, org.mockito.Mockito.times(2)).addMessageListener(
                 org.mockito.ArgumentMatchers.any(org.springframework.data.redis.connection.MessageListener.class),
                 anyTopics());
+    }
+    @Test
+    @DisplayName("cold-start synchronous subscribe callback은 active generation으로 확인된다")
+    void acceptsSynchronousSubscriptionCallbackDuringRegistration() {
+        StringRedisTemplate redis = mock(StringRedisTemplate.class);
+        RedisMessageListenerContainer container = mock(RedisMessageListenerContainer.class);
+        AtomicInteger ready = new AtomicInteger();
+        when(redis.execute(org.mockito.ArgumentMatchers.<org.springframework.data.redis.core.RedisCallback<String>>any())).thenReturn("PONG");
+        when(redis.convertAndSend(org.mockito.ArgumentMatchers.eq(RidePartyRedisPubSubEventBus.HEALTH_TOPIC),
+                org.mockito.ArgumentMatchers.anyString())).thenReturn(1L);
+        org.mockito.Mockito.doAnswer(invocation -> {
+            ((org.springframework.data.redis.connection.SubscriptionListener) invocation.getArgument(0))
+                    .onChannelSubscribed(RidePartyRedisPubSubEventBus.TOPIC.getBytes(java.nio.charset.StandardCharsets.UTF_8), 1);
+            return null;
+        }).when(container).addMessageListener(
+                org.mockito.ArgumentMatchers.any(org.springframework.data.redis.connection.MessageListener.class), anyTopics());
+        RidePartyRedisPubSubEventBus bus = new RidePartyRedisPubSubEventBus(
+                redis, container, objectMapper, raw -> { }, ignored -> { }, () -> { }, ready::incrementAndGet, () -> { });
+
+        bus.start();
+        org.mockito.ArgumentCaptor<org.springframework.data.redis.connection.MessageListener> listener =
+                org.mockito.ArgumentCaptor.forClass(org.springframework.data.redis.connection.MessageListener.class);
+        verify(container).addMessageListener(listener.capture(), anyTopics());
+        bus.confirmSubscriptionOrFail();
+        org.mockito.ArgumentCaptor<String> nonce = org.mockito.ArgumentCaptor.forClass(String.class);
+        verify(redis).convertAndSend(org.mockito.ArgumentMatchers.eq(RidePartyRedisPubSubEventBus.HEALTH_TOPIC), nonce.capture());
+        echoHealth(listener.getValue(), nonce.getValue());
+
+        assertThat(bus.isRunning()).isTrue();
+        assertThat(ready.get()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("cold-start listener registration failure는 preinstalled lifecycle state를 정확히 정리한다")
+    void cleansUpPreinstalledGenerationWhenListenerRegistrationFails() {
+        StringRedisTemplate redis = mock(StringRedisTemplate.class);
+        RedisMessageListenerContainer container = mock(RedisMessageListenerContainer.class);
+        List<String> failures = new ArrayList<>();
+        org.mockito.Mockito.doThrow(new IllegalStateException("subscribe failed")).when(container).addMessageListener(
+                org.mockito.ArgumentMatchers.any(org.springframework.data.redis.connection.MessageListener.class), anyTopics());
+        RidePartyRedisPubSubEventBus bus = new RidePartyRedisPubSubEventBus(
+                redis, container, objectMapper, raw -> { }, failures::add, () -> { }, () -> { }, () -> { });
+
+        org.assertj.core.api.Assertions.assertThatThrownBy(bus::start)
+                .isInstanceOf(RidePartyDistributedSubscriptionException.class);
+
+        assertThat(bus.isRunning()).isFalse();
+        assertThat(failures).containsExactly("subscribe");
+        verify(container).removeMessageListener(
+                org.mockito.ArgumentMatchers.any(org.springframework.data.redis.connection.MessageListener.class), anyTopics());
+    }
+
+    @Test
+    @DisplayName("소비된 heartbeat nonce replay는 readiness timestamp를 갱신하지 못한다")
+    void rejectsConsumedHeartbeatNonceReplay() {
+        AtomicLong now = new AtomicLong(1);
+        StringRedisTemplate redis = mock(StringRedisTemplate.class);
+        RedisMessageListenerContainer container = mock(RedisMessageListenerContainer.class);
+        AtomicInteger ready = new AtomicInteger();
+        List<String> failures = new ArrayList<>();
+        when(redis.execute(org.mockito.ArgumentMatchers.<org.springframework.data.redis.core.RedisCallback<String>>any())).thenReturn("PONG");
+        when(redis.convertAndSend(org.mockito.ArgumentMatchers.eq(RidePartyRedisPubSubEventBus.HEALTH_TOPIC),
+                org.mockito.ArgumentMatchers.anyString())).thenReturn(1L);
+        RidePartyRedisPubSubEventBus bus = new RidePartyRedisPubSubEventBus(
+                redis, container, objectMapper, raw -> { }, failures::add, () -> { }, ready::incrementAndGet, () -> { },
+                now::get, TimeUnit.SECONDS.toNanos(30));
+
+        bus.start();
+        org.mockito.ArgumentCaptor<org.springframework.data.redis.connection.MessageListener> listener =
+                org.mockito.ArgumentCaptor.forClass(org.springframework.data.redis.connection.MessageListener.class);
+        verify(container).addMessageListener(listener.capture(), anyTopics());
+        ((org.springframework.data.redis.connection.SubscriptionListener) listener.getValue())
+                .onChannelSubscribed(RidePartyRedisPubSubEventBus.TOPIC.getBytes(java.nio.charset.StandardCharsets.UTF_8), 1);
+        bus.confirmSubscriptionOrFail();
+        org.mockito.ArgumentCaptor<String> nonce = org.mockito.ArgumentCaptor.forClass(String.class);
+        verify(redis).convertAndSend(org.mockito.ArgumentMatchers.eq(RidePartyRedisPubSubEventBus.HEALTH_TOPIC), nonce.capture());
+        echoHealth(listener.getValue(), nonce.getValue());
+        now.set(10);
+        echoHealth(listener.getValue(), nonce.getValue());
+        bus.confirmSubscriptionOrFail();
+        org.mockito.ArgumentCaptor<String> challenges = org.mockito.ArgumentCaptor.forClass(String.class);
+        verify(redis, org.mockito.Mockito.times(2)).convertAndSend(
+                org.mockito.ArgumentMatchers.eq(RidePartyRedisPubSubEventBus.HEALTH_TOPIC), challenges.capture());
+        assertThat(challenges.getAllValues().get(1)).isNotEqualTo(nonce.getValue());
+
+        now.set(TimeUnit.SECONDS.toNanos(31));
+        bus.confirmSubscriptionOrFail();
+
+        assertThat(ready.get()).isEqualTo(1);
+        assertThat(failures).containsExactly("heartbeat");
     }
     private java.util.Collection<? extends Topic> anyTopics() {
         return org.mockito.ArgumentMatchers.any();

--- a/src/test/java/com/bikeprojectminji/bikeback/party/websocket/RidePartyLocationWebSocketHandlerTest.java
+++ b/src/test/java/com/bikeprojectminji/bikeback/party/websocket/RidePartyLocationWebSocketHandlerTest.java
@@ -57,8 +57,7 @@ class RidePartyLocationWebSocketHandlerTest {
                 {
                   "latitude": 37.5001,
                   "longitude": 127.0002,
-                  "accuracyM": 8.5,
-                  "capturedAt": "2026-06-26T00:00:00Z"
+                  "accuracyM": 8.5
                 }
                 """));
 

--- a/src/test/java/com/bikeprojectminji/bikeback/party/websocket/RidePartyRedisPubSubWebSocketConfigurationTest.java
+++ b/src/test/java/com/bikeprojectminji/bikeback/party/websocket/RidePartyRedisPubSubWebSocketConfigurationTest.java
@@ -1,0 +1,66 @@
+package com.bikeprojectminji.bikeback.party.websocket;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.LifecycleProcessor;
+import org.springframework.context.support.AbstractApplicationContext;
+
+class RidePartyRedisPubSubWebSocketConfigurationTest {
+
+    @Test
+    void productionConfigurationBuildsListenerContainerFromRedisConnectionFactory() {
+        RedisConnectionFactory connectionFactory = mock(RedisConnectionFactory.class);
+
+        RedisMessageListenerContainer container = new RidePartyRedisPubSubConfiguration()
+                .ridePartyRedisMessageListenerContainer(connectionFactory);
+
+        assertThat(container).isNotNull();
+        assertThat(container.getConnectionFactory()).isSameAs(connectionFactory);
+    }
+
+    @Test
+    void lifecycleOwnedSweepInvokesAuthoritativeMembershipRevalidation() {
+        RidePartyDistributedStateService stateService = mock(RidePartyDistributedStateService.class);
+
+        new RidePartySocketAccessSweep(stateService).sweep();
+
+        verify(stateService).revalidateAllSessionsOrDrain();
+    }
+
+    @Test
+    void springContextOwnsNamedPartyContainerAlongsideAnUnrelatedSharedContainer() {
+        try (AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext(ContextConfig.class)) {
+            RedisMessageListenerContainer party = context.getBean("ridePartyRedisMessageListenerContainer", RedisMessageListenerContainer.class);
+            RedisMessageListenerContainer shared = context.getBean("sharedRedisMessageListenerContainer", RedisMessageListenerContainer.class);
+
+            assertThat(party).isNotSameAs(shared);
+            assertThat(party.getConnectionFactory()).isSameAs(context.getBean(RedisConnectionFactory.class));
+        }
+    }
+
+    @Configuration
+    @Import(RidePartyRedisPubSubConfiguration.class)
+    static class ContextConfig {
+        @Bean RedisConnectionFactory connectionFactory() { return mock(RedisConnectionFactory.class); }
+        @Bean(name = "sharedRedisMessageListenerContainer") RedisMessageListenerContainer sharedContainer() { return mock(RedisMessageListenerContainer.class); }
+        @Bean(name = AbstractApplicationContext.LIFECYCLE_PROCESSOR_BEAN_NAME)
+        LifecycleProcessor noOpLifecycleProcessor() {
+            return new LifecycleProcessor() {
+                public void onRefresh() { }
+                public void onClose() { }
+                public void start() { }
+                public void stop() { }
+                public boolean isRunning() { return false; }
+            };
+        }
+    }
+}

--- a/src/test/java/com/bikeprojectminji/bikeback/party/websocket/RidePartyRedisPubSubWebSocketConfigurationTest.java
+++ b/src/test/java/com/bikeprojectminji/bikeback/party/websocket/RidePartyRedisPubSubWebSocketConfigurationTest.java
@@ -4,6 +4,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
+import com.bikeprojectminji.bikeback.party.service.RidePartyLocationAccessService;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.listener.RedisMessageListenerContainer;
@@ -46,6 +48,16 @@ class RidePartyRedisPubSubWebSocketConfigurationTest {
             assertThat(party.getConnectionFactory()).isSameAs(context.getBean(RedisConnectionFactory.class));
         }
     }
+    @Test
+    void springProductionGraphResolvesDedicatedBusStateAndSweep() {
+        try (AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext(ProductionGraphConfig.class)) {
+            assertThat(context.getBean(RidePartyRedisPubSubEventBus.class)).isNotNull();
+            assertThat(context.getBean(RidePartyDistributedStateService.class)).isNotNull();
+            assertThat(context.getBean(RidePartySocketAccessSweep.class)).isNotNull();
+            assertThat(context.getBean("ridePartyRedisMessageListenerContainer", RedisMessageListenerContainer.class))
+                    .isNotSameAs(context.getBean("sharedRedisMessageListenerContainer", RedisMessageListenerContainer.class));
+        }
+    }
 
     @Configuration
     @Import(RidePartyRedisPubSubConfiguration.class)
@@ -61,6 +73,23 @@ class RidePartyRedisPubSubWebSocketConfigurationTest {
                 public void stop() { }
                 public boolean isRunning() { return false; }
             };
+        }
+    }
+    @Configuration
+    @Import({
+            ContextConfig.class,
+            RidePartyRedisPubSubEventBus.class,
+            RidePartyDistributedStateService.class,
+            RidePartySocketAccessSweep.class,
+            RidePartySocketSessionRegistry.class
+    })
+    static class ProductionGraphConfig {
+        @Bean ObjectMapper objectMapper() { return new ObjectMapper().findAndRegisterModules(); }
+        @Bean org.springframework.data.redis.core.StringRedisTemplate stringRedisTemplate() {
+            return mock(org.springframework.data.redis.core.StringRedisTemplate.class);
+        }
+        @Bean RidePartyLocationAccessService ridePartyLocationAccessService() {
+            return mock(RidePartyLocationAccessService.class);
         }
     }
 }

--- a/src/test/java/com/bikeprojectminji/bikeback/party/websocket/RidePartySocketSessionRegistryTest.java
+++ b/src/test/java/com/bikeprojectminji/bikeback/party/websocket/RidePartySocketSessionRegistryTest.java
@@ -4,6 +4,8 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.web.socket.CloseStatus;
@@ -33,6 +35,55 @@ class RidePartySocketSessionRegistryTest {
         registry.closeParty(20L);
 
         verify(session).close(CloseStatus.POLICY_VIOLATION.withReason("party-canceled"));
+    }
+
+    @Test
+    @DisplayName("동일 session의 send와 close는 registry 안정 lock으로 직렬화한다")
+    void serializesConcurrentSendAndClose() throws Exception {
+        WebSocketSession session = openSession();
+        registry.register(20L, 2L, session);
+        CountDownLatch sent = new CountDownLatch(1);
+        org.mockito.Mockito.doAnswer(invocation -> { sent.countDown(); return null; }).when(session).sendMessage(org.mockito.ArgumentMatchers.any());
+
+        Thread sender = new Thread(() -> registry.send(session, new org.springframework.web.socket.TextMessage("location")));
+        Thread closer = new Thread(() -> { try { sent.await(2, TimeUnit.SECONDS); registry.close(session, CloseStatus.POLICY_VIOLATION); } catch (InterruptedException exception) { Thread.currentThread().interrupt(); } });
+        sender.start(); closer.start(); sender.join(); closer.join();
+
+        verify(session).sendMessage(org.mockito.ArgumentMatchers.any());
+        verify(session).close(CloseStatus.POLICY_VIOLATION);
+        org.assertj.core.api.Assertions.assertThat(registry.sessionsForParty(20L)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("send failure는 같은 lock에서 한 번만 close하고 후속 close를 격리한다")
+    void closesFailedSendOnce() throws Exception {
+        WebSocketSession session = openSession();
+        registry.register(20L, 2L, session);
+        org.mockito.Mockito.doThrow(new java.io.IOException("broken write"))
+                .when(session).sendMessage(org.mockito.ArgumentMatchers.any());
+
+        org.assertj.core.api.Assertions.assertThat(
+                registry.send(session, new org.springframework.web.socket.TextMessage("location"))).isFalse();
+        registry.close(session, CloseStatus.POLICY_VIOLATION);
+
+        verify(session, org.mockito.Mockito.times(1)).close(CloseStatus.SERVER_ERROR);
+        org.assertj.core.api.Assertions.assertThat(registry.sessionsForParty(20L)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("transport close 예외는 다른 registry session의 drain을 막지 않는다")
+    void isolatesTransportCloseExceptions() throws Exception {
+        WebSocketSession broken = openSession();
+        WebSocketSession healthy = openSession();
+        registry.register(20L, 2L, broken);
+        registry.register(20L, 3L, healthy);
+        org.mockito.Mockito.doThrow(new IllegalStateException("broken close"))
+                .when(broken).close(org.mockito.ArgumentMatchers.any());
+
+        registry.closeAll();
+
+        verify(healthy).close(CloseStatus.POLICY_VIOLATION.withReason("distributed-bus-unavailable"));
+        org.assertj.core.api.Assertions.assertThat(registry.sessionsForParty(20L)).isEmpty();
     }
 
     private WebSocketSession openSession() {


### PR DESCRIPTION
## Summary
- add fail-closed Redis Pub/Sub lifecycle handling for party WebSockets
- serialize per-session send and close operations
- validate distributed event envelopes and payloads

Closes #83