### PR TITLE
fix: prevent Spring context constructor regressions

### DIFF
--- a/reports/T-BE-05.md
+++ b/reports/T-BE-05.md
@@ -1,0 +1,13 @@
+# T-BE-05 결과
+- A-T-BE-05-01: 두 Party WebSocket 컴포넌트의 public 런타임 생성자에 `@Autowired`를 추가했다.
+- Handler 컨텍스트 회귀 테스트는 Handler와 RevocationListener를 모두 생성한다.
+- A-T-BE-05-02: Redis Pub/Sub lifecycle auto-start를 `bike.party.redis.auto-start` 설정으로 주입했다.
+- 운영 기본값은 `true`이며 test profile은 명시적으로 `false`여서 외부 Redis 없이 컨텍스트가 기동한다.
+- 회귀 테스트는 기본값 true와 test 설정 false가 `isAutoStartup()`에 반영됨을 확인한다.
+- 직접 `start()`하는 Pub/Sub 단위 계약은 기존 Party WebSocket 집중 시험으로 보존·검증했다.
+- 집중 검증: 관련 5개 테스트 클래스를 실행해 BUILD SUCCESSFUL (2m 37s)을 확인했다.
+- 전체 검증: `./gradlew --rerun-tasks --no-daemon test --console=plain` BUILD SUCCESSFUL (12m 26s).
+- 최종 XML: `build/test-results/test/` 132개, tests 652 / failures 0 / errors 0 / skipped 0.
+- `git diff --check`: 통과.
+- 후보 SHA/PR: initial pushed candidate `4bf91f001c9779ca4464c2375aa8c1ed76e64b1d`; Draft PR https://github.com/BIKE-PROJECT-MINJI/bike-back/pull/88.
+- 남은 위험: test profile에서만 auto-start를 비활성화하며 운영 fail-closed 기본값은 유지한다.

--- a/reports/T-BE-05.md
+++ b/reports/T-BE-05.md
@@ -1,13 +1,9 @@
 # T-BE-05 결과
-- A-T-BE-05-01: 두 Party WebSocket 컴포넌트의 public 런타임 생성자에 `@Autowired`를 추가했다.
-- Handler 컨텍스트 회귀 테스트는 Handler와 RevocationListener를 모두 생성한다.
-- A-T-BE-05-02: Redis Pub/Sub lifecycle auto-start를 `bike.party.redis.auto-start` 설정으로 주입했다.
-- 운영 기본값은 `true`이며 test profile은 명시적으로 `false`여서 외부 Redis 없이 컨텍스트가 기동한다.
-- 회귀 테스트는 기본값 true와 test 설정 false가 `isAutoStartup()`에 반영됨을 확인한다.
-- 직접 `start()`하는 Pub/Sub 단위 계약은 기존 Party WebSocket 집중 시험으로 보존·검증했다.
-- 집중 검증: 관련 5개 테스트 클래스를 실행해 BUILD SUCCESSFUL (2m 37s)을 확인했다.
-- 전체 검증: `./gradlew --rerun-tasks --no-daemon test --console=plain` BUILD SUCCESSFUL (12m 26s).
-- 최종 XML: `build/test-results/test/` 132개, tests 652 / failures 0 / errors 0 / skipped 0.
+
+- A-T-BE-05-03: `recoveryAllowed`의 초기값을 `autoStartup` 설정에서 가져오도록 변경했다. 따라서 `bike.party.redis.auto-start=false`인 컨텍스트에서는 scheduled recovery가 명시적 `start()` 전까지 Redis container를 시작하거나 listener를 등록하지 않는다.
+- 명시적 `start()`는 recovery를 활성화하고 구독을 등록한다. 구독 실패 뒤 `recoverIfNecessary()`는 다시 구독하며, `stop()` 뒤에는 recovery가 비활성화되어 재구독하지 않는다.
+- 회귀 테스트는 auto-start false의 inert recovery와 explicit start/recovery/stop lifecycle을 직접 검증한다.
+- 집중 검증: `./gradlew --no-daemon test --tests 'com.bikeprojectminji.bikeback.party.websocket.*' --console=plain` 성공, XML 7개에서 tests 46 / failures 0 / errors 0 / skipped 0.
+- 전체 검증: `./gradlew --rerun-tasks --no-daemon test --console=plain` 성공. 최종 `build/test-results/test/` XML 132개에서 tests 654 / failures 0 / errors 0 / skipped 0 (652 이상).
+- 최종 XML 및 HTML system output에서 `scheduler.*RedisConnectionFailureException`, `RedisConnectionFailureException.*scheduler`, `subscription unavailable`를 검색한 결과는 0건이다. 별도 Redis failure 계약 및 integration fixture의 의도된 RedisConnectionFailureException 출력은 이 scheduler/subscription 조건에 해당하지 않는다.
 - `git diff --check`: 통과.
-- 후보 SHA/PR: initial pushed candidate `4bf91f001c9779ca4464c2375aa8c1ed76e64b1d`; Draft PR https://github.com/BIKE-PROJECT-MINJI/bike-back/pull/88.
-- 남은 위험: test profile에서만 auto-start를 비활성화하며 운영 fail-closed 기본값은 유지한다.

--- a/src/main/java/com/bikeprojectminji/bikeback/party/websocket/RidePartyLocationWebSocketHandler.java
+++ b/src/main/java/com/bikeprojectminji/bikeback/party/websocket/RidePartyLocationWebSocketHandler.java
@@ -13,6 +13,7 @@ import java.time.OffsetDateTime;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.web.socket.CloseStatus;
 import org.springframework.web.socket.TextMessage;
@@ -32,6 +33,7 @@ public class RidePartyLocationWebSocketHandler extends TextWebSocketHandler {
     private final RidePartySocketSessionRegistry sessionRegistry;
     private final RidePartyDistributedStateService distributedStateService;
 
+    @Autowired
     public RidePartyLocationWebSocketHandler(
             ObjectMapper objectMapper,
             RidePartySocketTokenService socketTokenService,

--- a/src/main/java/com/bikeprojectminji/bikeback/party/websocket/RidePartyRedisPubSubEventBus.java
+++ b/src/main/java/com/bikeprojectminji/bikeback/party/websocket/RidePartyRedisPubSubEventBus.java
@@ -53,7 +53,7 @@ public class RidePartyRedisPubSubEventBus implements RidePartyDistributedEventPu
     private volatile long pendingHeartbeatSentAtNanos;
     private volatile MessageListener activeListener;
     private volatile boolean listenerRegistered;
-    private volatile boolean recoveryAllowed = true;
+    private volatile boolean recoveryAllowed;
 
     @Autowired
     public RidePartyRedisPubSubEventBus(
@@ -132,6 +132,7 @@ public class RidePartyRedisPubSubEventBus implements RidePartyDistributedEventPu
         this.nanoTime = nanoTime;
         this.heartbeatTimeoutNanos = heartbeatTimeoutNanos;
         this.autoStartup = autoStartup;
+        this.recoveryAllowed = autoStartup;
         this.listenerContainer.setErrorHandler(error -> fail("listener"));
     }
 

--- a/src/main/java/com/bikeprojectminji/bikeback/party/websocket/RidePartyRedisPubSubEventBus.java
+++ b/src/main/java/com/bikeprojectminji/bikeback/party/websocket/RidePartyRedisPubSubEventBus.java
@@ -11,6 +11,7 @@ import java.util.function.LongSupplier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.SmartLifecycle;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.ObjectProvider;
@@ -41,6 +42,7 @@ public class RidePartyRedisPubSubEventBus implements RidePartyDistributedEventPu
     private final Runnable stoppedConsumer;
     private final LongSupplier nanoTime;
     private final long heartbeatTimeoutNanos;
+    private final boolean autoStartup;
     private volatile boolean running;
     private volatile long generation;
     private volatile long confirmedGeneration = -1;
@@ -58,14 +60,15 @@ public class RidePartyRedisPubSubEventBus implements RidePartyDistributedEventPu
             StringRedisTemplate redisTemplate,
             @Qualifier("ridePartyRedisMessageListenerContainer") RedisMessageListenerContainer listenerContainer,
             ObjectMapper objectMapper,
-            ObjectProvider<RidePartyDistributedStateService> distributedStateService
+            ObjectProvider<RidePartyDistributedStateService> distributedStateService,
+            @Value("${bike.party.redis.auto-start:true}") boolean autoStartup
     ) {
         this(redisTemplate, listenerContainer, objectMapper,
                 rawMessage -> distributedStateService.getObject().receive(rawMessage),
                 operation -> distributedStateService.getObject().onBusFailure(operation),
                 () -> distributedStateService.getObject().onSubscriptionStarting(),
                 () -> distributedStateService.getObject().onSubscriptionConfirmed(),
-                () -> distributedStateService.getObject().onBusStopped());
+                () -> distributedStateService.getObject().onBusStopped(), autoStartup);
     }
 
     RidePartyRedisPubSubEventBus(
@@ -101,8 +104,23 @@ public class RidePartyRedisPubSubEventBus implements RidePartyDistributedEventPu
 
     RidePartyRedisPubSubEventBus(StringRedisTemplate redisTemplate, RedisMessageListenerContainer listenerContainer,
             ObjectMapper objectMapper, Consumer<String> inboundMessageConsumer, Consumer<String> failureConsumer,
+            Runnable recoveringConsumer, Runnable readyConsumer, Runnable stoppedConsumer, boolean autoStartup) {
+        this(redisTemplate, listenerContainer, objectMapper, inboundMessageConsumer, failureConsumer,
+                recoveringConsumer, readyConsumer, stoppedConsumer, System::nanoTime, HEARTBEAT_TIMEOUT_NANOS, autoStartup);
+    }
+
+    RidePartyRedisPubSubEventBus(StringRedisTemplate redisTemplate, RedisMessageListenerContainer listenerContainer,
+            ObjectMapper objectMapper, Consumer<String> inboundMessageConsumer, Consumer<String> failureConsumer,
             Runnable recoveringConsumer, Runnable readyConsumer, Runnable stoppedConsumer,
             LongSupplier nanoTime, long heartbeatTimeoutNanos) {
+        this(redisTemplate, listenerContainer, objectMapper, inboundMessageConsumer, failureConsumer,
+                recoveringConsumer, readyConsumer, stoppedConsumer, nanoTime, heartbeatTimeoutNanos, true);
+    }
+
+    RidePartyRedisPubSubEventBus(StringRedisTemplate redisTemplate, RedisMessageListenerContainer listenerContainer,
+            ObjectMapper objectMapper, Consumer<String> inboundMessageConsumer, Consumer<String> failureConsumer,
+            Runnable recoveringConsumer, Runnable readyConsumer, Runnable stoppedConsumer,
+            LongSupplier nanoTime, long heartbeatTimeoutNanos, boolean autoStartup) {
         this.redisTemplate = redisTemplate;
         this.listenerContainer = listenerContainer;
         this.objectMapper = objectMapper;
@@ -113,6 +131,7 @@ public class RidePartyRedisPubSubEventBus implements RidePartyDistributedEventPu
         this.stoppedConsumer = stoppedConsumer;
         this.nanoTime = nanoTime;
         this.heartbeatTimeoutNanos = heartbeatTimeoutNanos;
+        this.autoStartup = autoStartup;
         this.listenerContainer.setErrorHandler(error -> fail("listener"));
     }
 
@@ -191,7 +210,7 @@ public class RidePartyRedisPubSubEventBus implements RidePartyDistributedEventPu
 
     @Override
     public boolean isAutoStartup() {
-        return true;
+        return autoStartup;
     }
 
     @Override

--- a/src/main/java/com/bikeprojectminji/bikeback/party/websocket/RidePartySocketRevocationListener.java
+++ b/src/main/java/com/bikeprojectminji/bikeback/party/websocket/RidePartySocketRevocationListener.java
@@ -2,6 +2,7 @@ package com.bikeprojectminji.bikeback.party.websocket;
 
 import com.bikeprojectminji.bikeback.party.event.RidePartyCanceledEvent;
 import com.bikeprojectminji.bikeback.party.event.RidePartyMemberLeftEvent;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
@@ -12,6 +13,7 @@ public class RidePartySocketRevocationListener {
     private final RidePartySocketSessionRegistry sessionRegistry;
     private final RidePartyDistributedStateService distributedStateService;
 
+    @Autowired
     public RidePartySocketRevocationListener(
             RidePartySocketSessionRegistry sessionRegistry,
             RidePartyDistributedStateService distributedStateService

--- a/src/test/java/com/bikeprojectminji/bikeback/party/websocket/RidePartyLocationWebSocketHandlerContextTest.java
+++ b/src/test/java/com/bikeprojectminji/bikeback/party/websocket/RidePartyLocationWebSocketHandlerContextTest.java
@@ -1,0 +1,32 @@
+package com.bikeprojectminji.bikeback.party.websocket;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import com.bikeprojectminji.bikeback.party.service.RidePartyLocationAccessService;
+import com.bikeprojectminji.bikeback.party.service.RidePartyLocationService;
+import com.bikeprojectminji.bikeback.party.service.RidePartySocketTokenService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+
+class RidePartyLocationWebSocketHandlerContextTest {
+
+    @Test
+    void createsHandlerThroughSpringApplicationContext() {
+        try (AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext()) {
+            context.registerBean(ObjectMapper.class, () -> new ObjectMapper());
+            context.registerBean(RidePartySocketTokenService.class, () -> mock(RidePartySocketTokenService.class));
+            context.registerBean(RidePartyLocationService.class, () -> mock(RidePartyLocationService.class));
+            context.registerBean(RidePartyLocationAccessService.class, () -> mock(RidePartyLocationAccessService.class));
+            context.registerBean(RidePartySocketSessionRegistry.class, RidePartySocketSessionRegistry::new);
+            context.registerBean(RidePartyDistributedStateService.class, () -> mock(RidePartyDistributedStateService.class));
+            context.register(RidePartyLocationWebSocketHandler.class);
+            context.register(RidePartySocketRevocationListener.class);
+            context.refresh();
+
+            assertThat(context.getBean(RidePartyLocationWebSocketHandler.class)).isNotNull();
+            assertThat(context.getBean(RidePartySocketRevocationListener.class)).isNotNull();
+        }
+    }
+}

--- a/src/test/java/com/bikeprojectminji/bikeback/party/websocket/RidePartyRedisPubSubEventBusTest.java
+++ b/src/test/java/com/bikeprojectminji/bikeback/party/websocket/RidePartyRedisPubSubEventBusTest.java
@@ -2,13 +2,18 @@ package com.bikeprojectminji.bikeback.party.websocket;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.listener.RedisMessageListenerContainer;
 import org.springframework.test.context.support.TestPropertySourceUtils;
+import org.springframework.util.ErrorHandler;
 
 class RidePartyRedisPubSubEventBusTest {
 
@@ -24,6 +29,47 @@ class RidePartyRedisPubSubEventBusTest {
         try (AnnotationConfigApplicationContext context = contextWith("bike.party.redis.auto-start=false")) {
             assertThat(context.getBean(RidePartyRedisPubSubEventBus.class).isAutoStartup()).isFalse();
         }
+    }
+
+    @Test
+    void disabledAutoStartupKeepsScheduledRecoveryInertUntilExplicitStart() {
+        RedisMessageListenerContainer container = mock(RedisMessageListenerContainer.class);
+        RidePartyRedisPubSubEventBus bus = busWithAutoStartupDisabled(container);
+
+        bus.recoverIfNecessary();
+
+        verify(container, never()).start();
+        verify(container, never()).addMessageListener(org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.anyCollection());
+        assertThat(bus.isRunning()).isFalse();
+    }
+
+    @Test
+    void explicitStartEnablesRecoveryAndStopDisablesItAgain() {
+        RedisMessageListenerContainer container = mock(RedisMessageListenerContainer.class);
+        RidePartyRedisPubSubEventBus bus = busWithAutoStartupDisabled(container);
+        when(container.isRunning()).thenReturn(true);
+
+        bus.start();
+        verify(container).addMessageListener(org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.anyCollection());
+        assertThat(bus.isRunning()).isTrue();
+
+        ArgumentCaptor<ErrorHandler> errorHandler = ArgumentCaptor.forClass(ErrorHandler.class);
+        verify(container).setErrorHandler(errorHandler.capture());
+        errorHandler.getValue().handleError(new RuntimeException("subscription unavailable"));
+        assertThat(bus.isRunning()).isFalse();
+        bus.recoverIfNecessary();
+        verify(container, org.mockito.Mockito.times(2)).addMessageListener(
+                org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.anyCollection());
+
+        bus.stop();
+        bus.recoverIfNecessary();
+        verify(container, org.mockito.Mockito.times(2)).addMessageListener(
+                org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.anyCollection());
+    }
+
+    private RidePartyRedisPubSubEventBus busWithAutoStartupDisabled(RedisMessageListenerContainer container) {
+        return new RidePartyRedisPubSubEventBus(mock(StringRedisTemplate.class), container, new ObjectMapper(),
+                raw -> { }, operation -> { }, () -> { }, () -> { }, () -> { }, false);
     }
 
     private AnnotationConfigApplicationContext contextWith(String... properties) {

--- a/src/test/java/com/bikeprojectminji/bikeback/party/websocket/RidePartyRedisPubSubEventBusTest.java
+++ b/src/test/java/com/bikeprojectminji/bikeback/party/websocket/RidePartyRedisPubSubEventBusTest.java
@@ -1,0 +1,41 @@
+package com.bikeprojectminji.bikeback.party.websocket;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+import org.springframework.test.context.support.TestPropertySourceUtils;
+
+class RidePartyRedisPubSubEventBusTest {
+
+    @Test
+    void defaultsToAutoStartupForProductionContexts() {
+        try (AnnotationConfigApplicationContext context = contextWith()) {
+            assertThat(context.getBean(RidePartyRedisPubSubEventBus.class).isAutoStartup()).isTrue();
+        }
+    }
+
+    @Test
+    void respectsConfiguredAutoStartupSettingForTestContexts() {
+        try (AnnotationConfigApplicationContext context = contextWith("bike.party.redis.auto-start=false")) {
+            assertThat(context.getBean(RidePartyRedisPubSubEventBus.class).isAutoStartup()).isFalse();
+        }
+    }
+
+    private AnnotationConfigApplicationContext contextWith(String... properties) {
+        AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
+        TestPropertySourceUtils.addInlinedPropertiesToEnvironment(context, properties);
+        context.registerBean(StringRedisTemplate.class, () -> mock(StringRedisTemplate.class));
+        context.registerBean("ridePartyRedisMessageListenerContainer", RedisMessageListenerContainer.class,
+                () -> mock(RedisMessageListenerContainer.class));
+        context.registerBean(ObjectMapper.class, () -> new ObjectMapper());
+        context.registerBean(RidePartyDistributedStateService.class, () -> mock(RidePartyDistributedStateService.class));
+        context.register(RidePartyRedisPubSubEventBus.class);
+        context.refresh();
+        return context;
+    }
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -25,5 +25,8 @@ auth:
 
 bike:
   app-role: api
+  party:
+    redis:
+      auto-start: false
   rate-limit:
     store: memory


### PR DESCRIPTION
Fixes #87

- explicitly selects runtime constructors for Party WebSocket components
- keeps Redis Pub/Sub auto-start enabled by default and disables it only in the test profile
- gates scheduled Redis recovery by lifecycle: auto-start false stays inert until explicit start, and stop disables recovery
- adds Spring context plus inert recovery and explicit start/stop regression coverage
- verifies 46 focused Party Redis/WebSocket tests and 654 full-suite tests with 0 failures/errors